### PR TITLE
fix(wrangler): set real D1 database_id to unblock deploy

### DIFF
--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -14,7 +14,7 @@ not_found_handling = "single-page-application"
 [[d1_databases]]
 binding = "DB"
 database_name = "tech-news-bot-db"
-database_id = "REPLACE_WITH_REAL_ID_FROM_wrangler_d1_create"
+database_id = "a6cd7dbc-9f26-46d9-83c8-4a7b89405b7b"
 migrations_dir = "../../migrations"
 
 [triggers]


### PR DESCRIPTION
## Summary

main にマージ後トリガーされた Deploy workflow が \`apps/web/wrangler.toml\` の \`database_id = \"REPLACE_WITH_REAL_ID_FROM_wrangler_d1_create\"\` のままで失敗していたため、\`wrangler d1 create tech-news-bot-db\` で発行された UUID に差し替える。

参考: https://github.com/rikeda71/tech-news-bot/actions/runs/24999754915/job/73206292879

## Test plan

- [x] \`wrangler d1 list\` で \`tech-news-bot-db\` が UUID \`a6cd7dbc-9f26-46d9-83c8-4a7b89405b7b\` で存在することを確認
- [ ] マージ後の Deploy workflow が \`Apply D1 migrations\` / \`Deploy worker\` で成功することを確認