### PR TITLE
fix: D1 migration SQLITE_LOCKED に対してリトライを追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,18 @@ jobs:
         run: vp run build
       - name: Apply D1 migrations
         working-directory: apps/web
-        run: pnpm exec wrangler d1 migrations apply tech-news-bot-db --remote
+        # D1 が一時的に SQLITE_LOCKED を返すことがあるため、最大 3 回リトライする
+        run: |
+          for i in 1 2 3; do
+            pnpm exec wrangler d1 migrations apply tech-news-bot-db --remote && break
+            if [ $i -lt 3 ]; then
+              echo "Migration attempt $i failed, retrying in 10s..."
+              sleep 10
+            else
+              echo "Migration failed after 3 attempts"
+              exit 1
+            fi
+          done
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## 根本原因

commit 75cf8c54 の deploy (run [25003517711](https://github.com/rikeda71/tech-news-bot/actions/runs/25003517711)) で、`Apply D1 migrations` ステップが `SQLITE_LOCKED (code: 7500)` で失敗した。

Cron Worker (`0 */3 * * *`) が同タイミングで D1 に書き込んでおり、テーブルロックが競合したと考えられる。一時的な状態のためリトライ (run [25003913498](https://github.com/rikeda71/tech-news-bot/actions/runs/25003913498)) では成功している。

## 変更内容

`.github/workflows/deploy.yml` の `Apply D1 migrations` ステップに、最大 3 回・10 秒間隔のリトライを追加した。

## 対応しないもの

今回の失敗は secrets 起因ではない（`CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` はマスクされつつ正常に渡されている）。

## 完了条件
- [ ] CI (deploy workflow) が通過すること