### PR TITLE
perf(db): add compound index on (category, published_at) for listArticles

### DIFF
--- a/migrations/0004_compound_index.sql
+++ b/migrations/0004_compound_index.sql
@@ -1,0 +1,11 @@
+-- category + published_at + id の複合インデックス
+-- listArticles の WHERE category = ? ORDER BY published_at DESC, id DESC クエリで
+-- SQLite が単一インデックスしか使えない問題を解消する。
+-- id を末尾に含めることでカーソルページングの tie-break も index only scan で賄える。
+CREATE INDEX IF NOT EXISTS idx_articles_category_published_at
+  ON articles(category, published_at DESC, id DESC);
+
+-- lang + published_at + id の複合インデックス
+-- WHERE lang = ? ORDER BY published_at DESC, id DESC パターン向け。
+CREATE INDEX IF NOT EXISTS idx_articles_lang_published_at
+  ON articles(lang, published_at DESC, id DESC);


### PR DESCRIPTION
## Summary

- `migrations/0004_compound_index.sql` を追加し、`listArticles` の `WHERE category = ? ORDER BY published_at DESC, id DESC` パターンに最適化した複合インデックスを2本追加
  - `idx_articles_category_published_at` on `(category, published_at DESC, id DESC)`
  - `idx_articles_lang_published_at` on `(lang, published_at DESC, id DESC)`
- 既存の単独インデックス (`idx_articles_category`, `idx_articles_lang`) は即座に DROP しない（rollback 安全のため次回整理）
- `CREATE INDEX IF NOT EXISTS` で冪等性を確保

## Test plan

- [x] `pnpm migrate:local` で 0004 が適用されること（✅ 確認済み）
- [x] `pnpm build` pass
- [x] `pnpm typecheck` pass
- [x] `pnpm test` pass (38 tests)
- [x] `pnpm check` pass (errors: 0, warnings: 既存コードのもの)

Closes #34