### PR TITLE
feat(ui): ダークモード / ライトモード切り替えボタンを追加する

### DIFF
--- a/apps/web/client/App.tsx
+++ b/apps/web/client/App.tsx
@@ -2,9 +2,11 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { ArticleList } from "./components/ArticleList";
 import { FilterBar } from "./components/FilterBar";
 import { SearchInput } from "./components/SearchInput";
+import { ThemeToggle } from "./components/ThemeToggle";
 import { useArticles } from "./hooks/useArticles";
 import { useFeeds } from "./hooks/useFeeds";
 import { useStats } from "./hooks/useStats";
+import { useTheme } from "./hooks/useTheme";
 import type { FeedCategory, FeedLang } from "./types/api";
 
 function formatRelative(iso: string): string {
@@ -56,6 +58,7 @@ export default function App() {
   const [feedId, setFeedId] = useState<string>(() => readFromUrl().feedId);
   const [q, setQ] = useState<string>(() => readFromUrl().q);
 
+  const { theme, toggleTheme } = useTheme();
   const { feeds } = useFeeds();
   const { stats } = useStats();
 
@@ -143,6 +146,7 @@ export default function App() {
     <div className="app">
       <header className="header">
         <h1>Tech News Bot</h1>
+        <ThemeToggle theme={theme} onToggle={toggleTheme} />
         <span className="subtitle">
           {stats ? `${stats.total.toLocaleString()} 記事 · 直近 24h: ${stats.last24h}` : ""}
           {feeds.length > 0 ? ` · ${feeds.length} sources` : ""}

--- a/apps/web/client/components/ThemeToggle.tsx
+++ b/apps/web/client/components/ThemeToggle.tsx
@@ -1,0 +1,67 @@
+interface Props {
+  theme: "light" | "dark";
+  onToggle: () => void;
+}
+
+// SVG アイコンをインラインで定義し、フォントへの依存を排除する
+function SunIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="5" />
+      <line x1="12" y1="1" x2="12" y2="3" />
+      <line x1="12" y1="21" x2="12" y2="23" />
+      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+      <line x1="1" y1="12" x2="3" y2="12" />
+      <line x1="21" y1="12" x2="23" y2="12" />
+      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+    </svg>
+  );
+}
+
+function MoonIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+    </svg>
+  );
+}
+
+export function ThemeToggle({ theme, onToggle }: Props) {
+  const label = theme === "dark" ? "ライトモードに切り替え" : "ダークモードに切り替え";
+
+  return (
+    <button
+      type="button"
+      className="theme-toggle"
+      onClick={onToggle}
+      aria-label={label}
+      title={label}
+    >
+      {theme === "dark" ? <SunIcon /> : <MoonIcon />}
+    </button>
+  );
+}

--- a/apps/web/client/hooks/useTheme.ts
+++ b/apps/web/client/hooks/useTheme.ts
@@ -1,0 +1,41 @@
+import { useCallback, useEffect, useState } from "react";
+
+type Theme = "light" | "dark";
+
+const STORAGE_KEY = "tnb-theme";
+
+function resolveInitialTheme(): Theme {
+  // localStorage の保存値を優先し、なければ OS 設定に従う
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored === "light" || stored === "dark") return stored;
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+function applyTheme(theme: Theme): void {
+  const html = document.documentElement;
+  if (theme === "dark") {
+    html.setAttribute("data-theme", "dark");
+  } else {
+    html.removeAttribute("data-theme");
+  }
+}
+
+export function useTheme(): { theme: Theme; toggleTheme: () => void } {
+  const [theme, setTheme] = useState<Theme>(() => {
+    const initial = resolveInitialTheme();
+    // 初期化時点でも HTML 属性に反映する (hydration 前のちらつき対策)
+    applyTheme(initial);
+    return initial;
+  });
+
+  useEffect(() => {
+    applyTheme(theme);
+    localStorage.setItem(STORAGE_KEY, theme);
+  }, [theme]);
+
+  const toggleTheme = useCallback(() => {
+    setTheme((prev) => (prev === "dark" ? "light" : "dark"));
+  }, []);
+
+  return { theme, toggleTheme };
+}

--- a/apps/web/client/index.css
+++ b/apps/web/client/index.css
@@ -1,5 +1,29 @@
+/* デフォルト (= ライトテーマ) の CSS 変数 */
 :root {
   color-scheme: light dark;
+  --bg: #ffffff;
+  --bg-elev: #f6f8fa;
+  --bg-elev-2: #eaeef2;
+  --border: #d0d7de;
+  --fg: #1f2328;
+  --fg-muted: #656d76;
+  --accent: #0969da;
+  --accent-soft: rgba(9, 105, 218, 0.1);
+  /* ライト背景でも十分なコントラストを確保した色 */
+  --badge-bigtech: #0550ae;
+  --badge-ai: #7d4e00;
+  --badge-jp: #1a7f37;
+  --badge-zenn: #0550ae;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", "Hiragino Sans", "Noto Sans JP", Roboto,
+    sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+/* ダークテーマ変数: data-theme="dark" を html に付与したとき有効 */
+[data-theme="dark"] {
+  color-scheme: dark;
   --bg: #0d1117;
   --bg-elev: #161b22;
   --bg-elev-2: #21262d;
@@ -12,12 +36,10 @@
   --badge-ai: #d29922;
   --badge-jp: #3fb950;
   --badge-zenn: #3ea8ff;
-  font-family:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", "Hiragino Sans", "Noto Sans JP", Roboto,
-    sans-serif;
-  font-size: 14px;
-  line-height: 1.5;
 }
+
+/* OS 設定がダークのとき、かつ localStorage で明示指定されていないときは
+   html に data-theme="dark" を付けて対応する (useTheme.ts 側で制御) */
 
 * {
   box-sizing: border-box;
@@ -50,7 +72,7 @@ a:hover {
 .header {
   display: flex;
   justify-content: space-between;
-  align-items: baseline;
+  align-items: center;
   flex-wrap: wrap;
   gap: 8px;
   margin-bottom: 16px;
@@ -59,6 +81,26 @@ a:hover {
 .header h1 {
   font-size: 1.4rem;
   margin: 0;
+}
+
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  background: var(--bg-elev);
+  color: var(--fg-muted);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.theme-toggle:hover {
+  color: var(--fg);
+  border-color: var(--accent);
 }
 
 .header .subtitle {
@@ -205,24 +247,42 @@ a:hover {
   opacity: 0.8;
 }
 
+/* ライトモード: より濃い文字色に対し薄い背景で視認性を確保 */
 .badge.cat-bigtech {
-  background: rgba(68, 147, 248, 0.15);
+  background: rgba(5, 80, 174, 0.1);
   color: var(--badge-bigtech);
 }
 
 .badge.cat-ai {
-  background: rgba(210, 153, 34, 0.15);
+  background: rgba(125, 78, 0, 0.1);
   color: var(--badge-ai);
 }
 
 .badge.cat-jp {
-  background: rgba(63, 185, 80, 0.15);
+  background: rgba(26, 127, 55, 0.1);
   color: var(--badge-jp);
 }
 
 .badge.cat-zenn {
-  background: rgba(62, 168, 255, 0.15);
+  background: rgba(5, 80, 174, 0.1);
   color: var(--badge-zenn);
+}
+
+/* ダークモード: 明るい文字色に対してより濃い不透明度の背景 */
+[data-theme="dark"] .badge.cat-bigtech {
+  background: rgba(68, 147, 248, 0.15);
+}
+
+[data-theme="dark"] .badge.cat-ai {
+  background: rgba(210, 153, 34, 0.15);
+}
+
+[data-theme="dark"] .badge.cat-jp {
+  background: rgba(63, 185, 80, 0.15);
+}
+
+[data-theme="dark"] .badge.cat-zenn {
+  background: rgba(62, 168, 255, 0.15);
 }
 
 .feed-name {


### PR DESCRIPTION
## Summary

- `useTheme` hook で OS の `prefers-color-scheme` を初期値とし、ユーザー選択を `localStorage`(`tnb-theme`)に保存
- `data-theme="dark"` を `<html>` に付与して CSS カスタムプロパティ (`[data-theme="dark"]`) で全色を切り替え
- `ThemeToggle` コンポーネント: インライン SVG (Sun / Moon アイコン)、`aria-label` で支援技術対応
- `:root` をライトテーマ変数に置き換え、既存のダーク変数を `[data-theme="dark"]` セレクタへ移動
- バッジ色 (`bigtech` / `ai` / `jp` / `zenn`) をライト / ダーク両背景で WCAG AA コントラスト比確保

## Accessibility

- トグルボタンには `aria-label="ライトモードに切り替え"` / `"ダークモードに切り替え"` を付与
- アイコンは `aria-hidden="true"` でスクリーンリーダーからは非表示
- ライトモードのバッジ文字色は白背景に対して 4.5:1 以上のコントラスト比 (WCAG AA) を確保

## Test plan

- [x] `pnpm build` pass
- [x] `pnpm typecheck` pass
- [x] `pnpm test` pass (38 tests)
- [x] `pnpm check` pass (errors: 0, warnings: 既存コードのみ)

Closes #28