### PR TITLE
feat(search): FTS5 tokenizer を trigram に変更して日本語検索を改善する

### DIFF
--- a/apps/web/tests/worker/db/articles.test.ts
+++ b/apps/web/tests/worker/db/articles.test.ts
@@ -177,4 +177,84 @@ describe("articles db", () => {
     expect(onlyZenn.articles[0].category).toBe("zenn");
     expect(onlyZenn.articles[0].lang).toBe("ja");
   });
+
+  describe("FTS5 trigram Japanese full-text search", () => {
+    beforeEach(async () => {
+      // trigram は 3 文字以上の部分文字列に一致するため、日本語キーワードで検索できる
+      await insertArticles(env.DB, [
+        {
+          guid: "fts-jp-1",
+          feed_id: "feed-z",
+          title: "東京で開催されるAIカンファレンス",
+          url: "https://example.com/1",
+          summary: "最新の機械学習と型安全なTypeScriptの活用事例を紹介",
+          author: null,
+          published_at: "2024-05-01T00:00:00.000Z",
+          category: "ai",
+          lang: "ja",
+        },
+        {
+          guid: "fts-jp-2",
+          feed_id: "feed-z",
+          title: "メルカリのマイクロサービス設計",
+          url: "https://example.com/2",
+          summary: "Go言語とKubernetesを活用したスケーラブルなアーキテクチャ",
+          author: null,
+          published_at: "2024-05-02T00:00:00.000Z",
+          category: "jp",
+          lang: "ja",
+        },
+        {
+          guid: "fts-en-1",
+          feed_id: "feed-a",
+          title: "TypeScript 5.5 release notes",
+          url: "https://example.com/3",
+          summary: "New features in TypeScript",
+          author: null,
+          published_at: "2024-05-03T00:00:00.000Z",
+          category: "bigtech",
+          lang: "en",
+        },
+      ]);
+    });
+
+    it("matches Japanese title with trigram query (東京で)", async () => {
+      // trigram は 3 文字 N-gram なので、3 文字以上の部分文字列にのみ一致する
+      // 「東京で」はタイトル「東京で開催されるAIカンファレンス」に含まれる
+      const result = await listArticles(env.DB, { limit: 10, q: "東京で" });
+      expect(result.articles.map((a) => a.guid)).toContain("fts-jp-1");
+      expect(result.articles.map((a) => a.guid)).not.toContain("fts-jp-2");
+    });
+
+    it("matches Japanese title with trigram query (メルカリ)", async () => {
+      const result = await listArticles(env.DB, { limit: 10, q: "メルカリ" });
+      expect(result.articles.map((a) => a.guid)).toContain("fts-jp-2");
+      expect(result.articles.map((a) => a.guid)).not.toContain("fts-jp-1");
+    });
+
+    it("matches Japanese summary with trigram query (型安全)", async () => {
+      // summary に含まれる日本語の部分文字列でも検索できる
+      const result = await listArticles(env.DB, { limit: 10, q: "型安全" });
+      expect(result.articles.map((a) => a.guid)).toContain("fts-jp-1");
+    });
+
+    it("matches katakana keyword in Japanese title (AIカン)", async () => {
+      // "AI" は 2 文字なので trigram では検索不可。3 文字以上の "AIカン" で検索する
+      const result = await listArticles(env.DB, { limit: 10, q: "AIカン" });
+      expect(result.articles.map((a) => a.guid)).toContain("fts-jp-1");
+    });
+
+    it("matches English keyword with trigram (TypeScript)", async () => {
+      const result = await listArticles(env.DB, { limit: 10, q: "TypeScript" });
+      // 英語記事と日本語 summary 両方にマッチする
+      const guids = result.articles.map((a) => a.guid);
+      expect(guids).toContain("fts-en-1");
+      expect(guids).toContain("fts-jp-1");
+    });
+
+    it("returns empty when no article matches the query", async () => {
+      const result = await listArticles(env.DB, { limit: 10, q: "該当なしのキーワード" });
+      expect(result.articles).toHaveLength(0);
+    });
+  });
 });

--- a/migrations/0003_fts5_trigram.sql
+++ b/migrations/0003_fts5_trigram.sql
@@ -1,0 +1,41 @@
+-- FTS5 tokenizer を unicode61 から trigram に変更する。
+-- trigram は 3 文字 N-gram で分割するため、日本語・記号を含む任意の部分文字列を検索できる。
+-- SQLite 3.43+ (Cloudflare D1 でサポート済み) が必要。
+
+-- Step 1: 既存の FTS トリガを削除
+DROP TRIGGER IF EXISTS articles_ai;
+DROP TRIGGER IF EXISTS articles_ad;
+DROP TRIGGER IF EXISTS articles_au;
+
+-- Step 2: 既存の FTS テーブルを削除
+DROP TABLE IF EXISTS articles_fts;
+
+-- Step 3: trigram tokenizer で FTS テーブルを再作成
+CREATE VIRTUAL TABLE IF NOT EXISTS articles_fts USING fts5(
+  title,
+  summary,
+  content='articles',
+  content_rowid='id',
+  tokenize='trigram'
+);
+
+-- Step 4: 既存記事を trigram で再 index
+INSERT INTO articles_fts(articles_fts) VALUES ('rebuild');
+
+-- Step 5: トリガを再作成
+CREATE TRIGGER IF NOT EXISTS articles_ai AFTER INSERT ON articles BEGIN
+  INSERT INTO articles_fts(rowid, title, summary)
+  VALUES (new.id, new.title, COALESCE(new.summary, ''));
+END;
+
+CREATE TRIGGER IF NOT EXISTS articles_ad AFTER DELETE ON articles BEGIN
+  INSERT INTO articles_fts(articles_fts, rowid, title, summary)
+  VALUES ('delete', old.id, old.title, COALESCE(old.summary, ''));
+END;
+
+CREATE TRIGGER IF NOT EXISTS articles_au AFTER UPDATE ON articles BEGIN
+  INSERT INTO articles_fts(articles_fts, rowid, title, summary)
+  VALUES ('delete', old.id, old.title, COALESCE(old.summary, ''));
+  INSERT INTO articles_fts(rowid, title, summary)
+  VALUES (new.id, new.title, COALESCE(new.summary, ''));
+END;


### PR DESCRIPTION
Closes #43

## 概要

FTS5 の tokenizer を unicode61 から trigram に変更し、日本語・CJK 文字列の部分一致検索を改善する。

## 変更内容

- migrations/0003_fts5_trigram.sql: articles_fts を trigram tokenizer で再作成、既存記事の rebuild、triggers 再作成
- apps/web/tests/worker/db/articles.test.ts: 日本語 FTS trigram のテストスイートを追加

## 検証

- pnpm migrate:local → 0003 が正常に apply
- pnpm test → 44 tests passed (全 pass)