### PR TITLE
feat: PR preview deploy workflow + Worker READONLY mode

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,95 @@
+name: PR Preview Deploy
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+jobs:
+  deploy-preview:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: preview-pr-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "pnpm"
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: "24"
+          cache: true
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm cf-typegen
+      - name: vp build
+        run: vp run build
+      - name: Deploy preview worker
+        id: deploy
+        working-directory: apps/web
+        # --name で PR 番号を含む一意な Worker 名を指定し、preview env の設定を使う
+        run: |
+          WORKER_NAME="tech-news-bot-pr-${{ github.event.pull_request.number }}"
+          pnpm exec wrangler deploy -e preview --name "$WORKER_NAME" 2>&1 | tee /tmp/deploy-output.txt
+          PREVIEW_URL="https://${WORKER_NAME}.${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.workers.dev"
+          echo "preview_url=$PREVIEW_URL" >> "$GITHUB_OUTPUT"
+          echo "worker_name=$WORKER_NAME" >> "$GITHUB_OUTPUT"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      - name: Comment preview URL on PR
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ## Preview Deploy
+
+            | Item | Value |
+            |------|-------|
+            | Worker | `${{ steps.deploy.outputs.worker_name }}` |
+            | URL | ${{ steps.deploy.outputs.preview_url }} |
+            | Commit | ${{ github.sha }} |
+
+            > [!NOTE]
+            > READONLY mode が有効なため、admin エンドポイントと cron collector は無効化されています。本番 D1 を参照します。
+          edit-mode: replace
+
+  cleanup-preview:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
+      - name: Delete preview worker
+        working-directory: apps/web
+        run: |
+          WORKER_NAME="tech-news-bot-pr-${{ github.event.pull_request.number }}"
+          pnpm exec wrangler delete --name "$WORKER_NAME" --force || true
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      - name: Comment cleanup on PR
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ## Preview Deploy
+
+            | Item | Value |
+            |------|-------|
+            | Worker | `tech-news-bot-pr-${{ github.event.pull_request.number }}` |
+            | Status | Deleted (PR closed) |
+
+            > Preview Worker を削除しました。
+          edit-mode: replace

--- a/apps/web/worker/api/admin.ts
+++ b/apps/web/worker/api/admin.ts
@@ -14,6 +14,10 @@ function timingSafeEqual(a: string, b: string): boolean {
 }
 
 app.post("/collect", async (c) => {
+  // READONLY=1 の preview 環境では書き込みを行わない
+  if (c.env.READONLY === "1") {
+    return c.json({ error: "read-only mode" }, 403);
+  }
   const expected = (c.env as unknown as { ADMIN_TOKEN?: string }).ADMIN_TOKEN;
   if (!expected) {
     return c.json({ error: "ADMIN_TOKEN is not configured" }, 503);

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -48,6 +48,11 @@ app.all("*", async (c) => {
 const handler: ExportedHandler<Env> = {
   fetch: app.fetch,
   async scheduled(_controller, env, ctx) {
+    // READONLY=1 の preview 環境ではコレクターを起動しない
+    if (env.READONLY === "1") {
+      console.log("[scheduled] READONLY mode – skipping collectAll");
+      return;
+    }
     ctx.waitUntil(
       collectAll(env).catch((err) => {
         console.error("[scheduled] collectAll failed", err);

--- a/apps/web/worker/types.ts
+++ b/apps/web/worker/types.ts
@@ -6,6 +6,8 @@ export interface Env {
   SUMMARY_MAX_LENGTH: string;
   RETENTION_DAYS: string;
   ADMIN_TOKEN?: string;
+  // preview 環境では "1" をセット。admin/collector を no-op にする。
+  READONLY?: string;
 }
 
 export type FeedCategory = "bigtech" | "ai" | "jp" | "zenn";

--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -25,3 +25,29 @@ COLLECTOR_CONCURRENCY = "4"
 COLLECTOR_TIMEOUT_MS = "10000"
 SUMMARY_MAX_LENGTH = "500"
 RETENTION_DAYS = "90"
+
+# preview 環境: PR ごとに動的な Worker 名は wrangler CLI の --name で指定する。
+# D1 は本番と同じ DB を使い、READONLY=1 で admin/collector を無効化する。
+[env.preview]
+compatibility_date = "2025-04-01"
+compatibility_flags = ["nodejs_compat"]
+
+[env.preview.observability]
+enabled = true
+
+[env.preview.assets]
+directory = "./dist/client"
+binding = "ASSETS"
+not_found_handling = "single-page-application"
+
+[[env.preview.d1_databases]]
+binding = "DB"
+database_name = "tech-news-bot-db"
+database_id = "a6cd7dbc-9f26-46d9-83c8-4a7b89405b7b"
+
+[env.preview.vars]
+COLLECTOR_CONCURRENCY = "4"
+COLLECTOR_TIMEOUT_MS = "10000"
+SUMMARY_MAX_LENGTH = "500"
+RETENTION_DAYS = "90"
+READONLY = "1"


### PR DESCRIPTION
## Summary

- `.github/workflows/preview.yml` を新規追加: `pull_request` (opened/synchronize/reopened) で `tech-news-bot-pr-<N>` という一意な Worker 名でプレビューデプロイし、PR にコメント投稿。PR close 時は cleanup job で Worker 削除。
- `apps/web/wrangler.toml` に `[env.preview]` セクションを追加: 本番 D1 を参照しつつ `READONLY=1` で書き込み操作を無効化。
- Worker 側 READONLY mode 実装: `READONLY=1` のとき `POST /api/admin/collect` は 403、`scheduled()` は no-op でスキップ。

## Test plan

- [ ] `pnpm cf-typegen && pnpm build && pnpm typecheck && pnpm test && pnpm check` がローカルで pass することを確認済み
- [ ] CI (vp check/build/test) が green になることを確認
- [ ] PR が open されたとき preview URL コメントが投稿されることを確認 (実際の動作確認は CI 通過後)

Closes #36