### PR TITLE
feat: add date_from/date_to range filter to /api/articles

### DIFF
--- a/apps/web/client/App.tsx
+++ b/apps/web/client/App.tsx
@@ -25,6 +25,8 @@ function readFromUrl(): {
   lang: FeedLang | "";
   feedId: string;
   q: string;
+  dateFrom: string;
+  dateTo: string;
 } {
   const params = new URLSearchParams(window.location.search);
   return {
@@ -32,6 +34,8 @@ function readFromUrl(): {
     lang: (params.get("lang") as FeedLang | null) ?? "",
     feedId: params.get("feed_id") ?? "",
     q: params.get("q") ?? "",
+    dateFrom: params.get("date_from") ?? "",
+    dateTo: params.get("date_to") ?? "",
   };
 }
 
@@ -40,12 +44,16 @@ function buildSearch(
   lang: FeedLang | "",
   feedId: string,
   q: string,
+  dateFrom: string,
+  dateTo: string,
 ): string {
   const params = new URLSearchParams();
   if (category) params.set("category", category);
   if (lang) params.set("lang", lang);
   if (feedId) params.set("feed_id", feedId);
   if (q) params.set("q", q);
+  if (dateFrom) params.set("date_from", dateFrom);
+  if (dateTo) params.set("date_to", dateTo);
   const s = params.toString();
   return s ? `?${s}` : window.location.pathname;
 }
@@ -55,6 +63,8 @@ export default function App() {
   const [lang, setLang] = useState<FeedLang | "">(() => readFromUrl().lang);
   const [feedId, setFeedId] = useState<string>(() => readFromUrl().feedId);
   const [q, setQ] = useState<string>(() => readFromUrl().q);
+  const [dateFrom, setDateFrom] = useState<string>(() => readFromUrl().dateFrom);
+  const [dateTo, setDateTo] = useState<string>(() => readFromUrl().dateTo);
 
   const { feeds } = useFeeds();
   const { stats } = useStats();
@@ -67,6 +77,8 @@ export default function App() {
       setLang(next.lang);
       setFeedId(next.feedId);
       setQ(next.q);
+      setDateFrom(next.dateFrom);
+      setDateTo(next.dateTo);
     };
     window.addEventListener("popstate", onPop);
     return () => window.removeEventListener("popstate", onPop);
@@ -79,9 +91,11 @@ export default function App() {
       nextLang: FeedLang | "",
       nextFeedId: string,
       nextQ: string,
+      nextDateFrom: string,
+      nextDateTo: string,
     ) => {
-      const next = buildSearch(nextCategory, nextLang, nextFeedId, nextQ);
-      const current = buildSearch(category, lang, feedId, q);
+      const next = buildSearch(nextCategory, nextLang, nextFeedId, nextQ, nextDateFrom, nextDateTo);
+      const current = buildSearch(category, lang, feedId, q, dateFrom, dateTo);
       // 同じ URL なら重複履歴を作らない
       if (next !== current) {
         window.history.pushState(null, "", next);
@@ -90,41 +104,53 @@ export default function App() {
       setLang(nextLang);
       setFeedId(nextFeedId);
       setQ(nextQ);
+      setDateFrom(nextDateFrom);
+      setDateTo(nextDateTo);
     },
-    [category, lang, feedId, q],
+    [category, lang, feedId, q, dateFrom, dateTo],
   );
 
   const handleCategoryChange = useCallback(
-    (v: FeedCategory | "") => pushFilter(v, lang, v ? feedId : "", q),
-    [pushFilter, lang, feedId, q],
+    (v: FeedCategory | "") => pushFilter(v, lang, v ? feedId : "", q, dateFrom, dateTo),
+    [pushFilter, lang, feedId, q, dateFrom, dateTo],
   );
 
   const handleLangChange = useCallback(
-    (v: FeedLang | "") => pushFilter(category, v, v ? feedId : "", q),
-    [pushFilter, category, feedId, q],
+    (v: FeedLang | "") => pushFilter(category, v, v ? feedId : "", q, dateFrom, dateTo),
+    [pushFilter, category, feedId, q, dateFrom, dateTo],
   );
 
   const handleFeedChange = useCallback(
-    (id: string) => pushFilter(category, lang, id, q),
-    [pushFilter, category, lang, q],
+    (id: string) => pushFilter(category, lang, id, q, dateFrom, dateTo),
+    [pushFilter, category, lang, q, dateFrom, dateTo],
   );
 
   const handleQChange = useCallback(
-    (v: string) => pushFilter(category, lang, feedId, v),
-    [pushFilter, category, lang, feedId],
+    (v: string) => pushFilter(category, lang, feedId, v, dateFrom, dateTo),
+    [pushFilter, category, lang, feedId, dateFrom, dateTo],
   );
 
-  const handleClear = useCallback(() => pushFilter("", "", "", q), [pushFilter, q]);
+  const handleDateFromChange = useCallback(
+    (v: string) => pushFilter(category, lang, feedId, q, v, dateTo),
+    [pushFilter, category, lang, feedId, q, dateTo],
+  );
+
+  const handleDateToChange = useCallback(
+    (v: string) => pushFilter(category, lang, feedId, q, dateFrom, v),
+    [pushFilter, category, lang, feedId, q, dateFrom],
+  );
+
+  const handleClear = useCallback(() => pushFilter("", "", "", q, "", ""), [pushFilter, q]);
 
   // カード上のバッジ/取得元クリックでフィルタを適用する
   const handleFilterByCategory = useCallback(
-    (c: FeedCategory) => pushFilter(c, lang, "", q),
-    [pushFilter, lang, q],
+    (c: FeedCategory) => pushFilter(c, lang, "", q, dateFrom, dateTo),
+    [pushFilter, lang, q, dateFrom, dateTo],
   );
 
   const handleFilterByFeedId = useCallback(
-    (id: string) => pushFilter(category, lang, id, q),
-    [pushFilter, category, lang, q],
+    (id: string) => pushFilter(category, lang, id, q, dateFrom, dateTo),
+    [pushFilter, category, lang, q, dateFrom, dateTo],
   );
 
   const query = useMemo(
@@ -133,8 +159,10 @@ export default function App() {
       lang: lang || undefined,
       feedId: feedId || undefined,
       q: q || undefined,
+      dateFrom: dateFrom || undefined,
+      dateTo: dateTo || undefined,
     }),
-    [category, lang, feedId, q],
+    [category, lang, feedId, q, dateFrom, dateTo],
   );
 
   const { articles, loading, loadingMore, error, nextCursor, loadMore } = useArticles(query);
@@ -172,9 +200,13 @@ export default function App() {
           lang={lang}
           feedId={feedId}
           feeds={feeds}
+          dateFrom={dateFrom}
+          dateTo={dateTo}
           onCategoryChange={handleCategoryChange}
           onLangChange={handleLangChange}
           onFeedChange={handleFeedChange}
+          onDateFromChange={handleDateFromChange}
+          onDateToChange={handleDateToChange}
           onClear={handleClear}
         />
       </div>

--- a/apps/web/client/components/FilterBar.tsx
+++ b/apps/web/client/components/FilterBar.tsx
@@ -5,9 +5,13 @@ interface Props {
   lang: FeedLang | "";
   feedId: string;
   feeds: FeedSummary[];
+  dateFrom: string;
+  dateTo: string;
   onCategoryChange: (c: FeedCategory | "") => void;
   onLangChange: (l: FeedLang | "") => void;
   onFeedChange: (id: string) => void;
+  onDateFromChange: (v: string) => void;
+  onDateToChange: (v: string) => void;
   onClear: () => void;
 }
 
@@ -16,16 +20,21 @@ export function FilterBar({
   lang,
   feedId,
   feeds,
+  dateFrom,
+  dateTo,
   onCategoryChange,
   onLangChange,
   onFeedChange,
+  onDateFromChange,
+  onDateToChange,
   onClear,
 }: Props) {
   const visibleFeeds = feeds
     .filter((f) => (category ? f.category === category : true))
     .filter((f) => (lang ? f.lang === lang : true));
 
-  const hasFilter = category !== "" || lang !== "" || feedId !== "";
+  const hasFilter =
+    category !== "" || lang !== "" || feedId !== "" || dateFrom !== "" || dateTo !== "";
 
   return (
     <>
@@ -59,6 +68,22 @@ export function FilterBar({
           </option>
         ))}
       </select>
+
+      <input
+        type="date"
+        className="date-input"
+        value={dateFrom}
+        onChange={(e) => onDateFromChange(e.target.value)}
+        aria-label="期間 開始日"
+      />
+      <span className="date-sep">〜</span>
+      <input
+        type="date"
+        className="date-input"
+        value={dateTo}
+        onChange={(e) => onDateToChange(e.target.value)}
+        aria-label="期間 終了日"
+      />
 
       {hasFilter && (
         <button type="button" className="clear-filter" onClick={onClear}>

--- a/apps/web/client/hooks/useArticles.ts
+++ b/apps/web/client/hooks/useArticles.ts
@@ -6,6 +6,8 @@ export interface ArticlesQuery {
   lang?: FeedLang;
   feedId?: string;
   q?: string;
+  dateFrom?: string;
+  dateTo?: string;
 }
 
 interface State {
@@ -30,6 +32,8 @@ function buildUrl(query: ArticlesQuery, cursor?: string | null): string {
   if (query.lang) params.set("lang", query.lang);
   if (query.feedId) params.set("feed_id", query.feedId);
   if (query.q) params.set("q", query.q);
+  if (query.dateFrom) params.set("date_from", query.dateFrom);
+  if (query.dateTo) params.set("date_to", query.dateTo);
   if (cursor) params.set("cursor", cursor);
   params.set("limit", "20");
   return `/api/articles?${params.toString()}`;

--- a/apps/web/tests/worker/api/api.test.ts
+++ b/apps/web/tests/worker/api/api.test.ts
@@ -166,6 +166,44 @@ describe("/api/articles", () => {
     const body = (await res.json()) as { articles: { guid: string }[] };
     expect(body.articles.length).toBe(0);
   });
+
+  it("filters by date_from only", async () => {
+    // 2024-04-02 以降 → g-ai (04-02), g-jp (04-03) の2件
+    const res = await SELF.fetch("https://example.com/api/articles?date_from=2024-04-02");
+    const body = (await res.json()) as { articles: { guid: string }[] };
+    expect(body.articles.map((a) => a.guid)).toEqual(["g-jp", "g-ai"]);
+  });
+
+  it("filters by date_to only", async () => {
+    // 2024-04-02 以前 → g-bt (04-01), g-ai (04-02) の2件
+    const res = await SELF.fetch(
+      "https://example.com/api/articles?date_to=2024-04-02T23:59:59.000Z",
+    );
+    const body = (await res.json()) as { articles: { guid: string }[] };
+    expect(body.articles.map((a) => a.guid)).toEqual(["g-ai", "g-bt"]);
+  });
+
+  it("filters by date_from and date_to together", async () => {
+    // 2024-04-02 のみ → g-ai
+    const res = await SELF.fetch(
+      "https://example.com/api/articles?date_from=2024-04-02&date_to=2024-04-02T23:59:59.000Z",
+    );
+    const body = (await res.json()) as { articles: { guid: string }[] };
+    expect(body.articles.map((a) => a.guid)).toEqual(["g-ai"]);
+  });
+
+  it("ignores invalid date_from silently (returns all)", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles?date_from=not-a-date");
+    const body = (await res.json()) as { articles: { guid: string }[] };
+    expect(body.articles.length).toBe(3);
+  });
+
+  it("ignores invalid date_to silently (returns all)", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles?date_to=2024-99-99");
+    // 形式チェックは YYYY-MM-DD 形式なのでパスするが、SQLite が正規化して結果が変わる可能性あり
+    // 不正な日付でもクラッシュせず 200 を返すことを確認
+    expect(res.status).toBe(200);
+  });
 });
 
 describe("/api/stats", () => {

--- a/apps/web/worker/api/articles.ts
+++ b/apps/web/worker/api/articles.ts
@@ -10,6 +10,8 @@ const VALID_LANGS: FeedLang[] = ["ja", "en"];
 const VALID_FEED_IDS = new Set(loadAllFeeds().map((f) => f.id));
 
 const ISO_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
+// YYYY-MM-DD または YYYY-MM-DDTHH:MM:SS 形式を受け付ける
+const DATE_RANGE_RE = /^\d{4}-\d{2}-\d{2}/;
 
 function decodeCursor(input: string | undefined): { publishedAt: string; id: number } | null {
   if (!input) return null;
@@ -57,11 +59,19 @@ app.get("/", async (c) => {
 
   const limit = Math.min(Math.max(Number(limitRaw ?? "20") || 20, 1), 100);
 
+  const dateFromRaw = req.query("date_from") ?? undefined;
+  const dateToRaw = req.query("date_to") ?? undefined;
+  // 不正な値は silently drop する既存パターンに合わせる
+  const dateFrom = dateFromRaw && DATE_RANGE_RE.test(dateFromRaw) ? dateFromRaw : undefined;
+  const dateTo = dateToRaw && DATE_RANGE_RE.test(dateToRaw) ? dateToRaw : undefined;
+
   const result = await listArticles(c.env.DB, {
     category,
     lang,
     feedId,
     q,
+    dateFrom,
+    dateTo,
     limit,
     cursor: decodeCursor(cursorRaw ?? undefined),
   });

--- a/apps/web/worker/db/articles.ts
+++ b/apps/web/worker/db/articles.ts
@@ -59,6 +59,8 @@ export interface ListArticlesParams {
   lang?: FeedLang;
   feedId?: string;
   q?: string;
+  dateFrom?: string;
+  dateTo?: string;
   limit: number;
   cursor?: { publishedAt: string; id: number } | null;
 }
@@ -87,6 +89,14 @@ export async function listArticles(
   if (params.feedId) {
     conds.push(`a.feed_id = ?${binds.length + 1}`);
     binds.push(params.feedId);
+  }
+  if (params.dateFrom) {
+    conds.push(`a.published_at >= ?${binds.length + 1}`);
+    binds.push(params.dateFrom);
+  }
+  if (params.dateTo) {
+    conds.push(`a.published_at <= ?${binds.length + 1}`);
+    binds.push(params.dateTo);
   }
   if (params.cursor) {
     conds.push(


### PR DESCRIPTION
## Summary

- `/api/articles` に `date_from` / `date_to` クエリパラメータを追加（ISO 8601、`YYYY-MM-DD` または完全 ISO 形式）
- DB 層 `listArticles` に `dateFrom?` / `dateTo?` を追加し `published_at >= ?` / `published_at <= ?` を WHERE 句に AND 結合
- SPA `FilterBar` に date input 2 つを追加し、URL パラメータ `?date_from=...&date_to=...` と双方向同期
- テスト: `date_from` のみ / `date_to` のみ / 両方 / 不正値で silently drop を確認（5 ケース追加）

## Test plan

- [x] `pnpm cf-typegen` pass
- [x] `pnpm build` pass
- [x] `pnpm typecheck` pass
- [x] `pnpm test` pass (43 tests)
- [x] `pnpm check` pass (warnings only, 既存コードと同パターン)

Closes #45