### PR TITLE
feat(api): cursor pagination for /api/feeds + /api/stats no-pagination doc

### DIFF
--- a/apps/web/client/types/api.ts
+++ b/apps/web/client/types/api.ts
@@ -35,4 +35,5 @@ export interface FeedSummary {
 
 export interface FeedsResponse {
   feeds: FeedSummary[];
+  nextCursor: string | null;
 }

--- a/apps/web/tests/worker/api/api.test.ts
+++ b/apps/web/tests/worker/api/api.test.ts
@@ -168,6 +168,63 @@ describe("/api/articles", () => {
   });
 });
 
+describe("/api/feeds", () => {
+  it("returns all feeds with nextCursor null when within limit", async () => {
+    // FEEDS には 3 件あるが、default limit=50 なので全件 + nextCursor=null
+    const res = await SELF.fetch("https://example.com/api/feeds");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      feeds: { id: string }[];
+      nextCursor: string | null;
+    };
+    // feeds.yaml 由来の全フィードが返る (3 件以上)
+    expect(body.feeds.length).toBeGreaterThanOrEqual(3);
+    expect(body.nextCursor).toBeNull();
+  });
+
+  it("paginates via cursor when limit is smaller than total", async () => {
+    // limit=2 で最初のページを取得
+    const page1 = await SELF.fetch("https://example.com/api/feeds?limit=2");
+    expect(page1.status).toBe(200);
+    const body1 = (await page1.json()) as {
+      feeds: { id: string }[];
+      nextCursor: string | null;
+    };
+    expect(body1.feeds.length).toBe(2);
+    // フィードが 3 件以上あるので nextCursor は非 null
+    expect(body1.nextCursor).not.toBeNull();
+
+    // cursor を使って次のページを取得
+    const page2 = await SELF.fetch(
+      `https://example.com/api/feeds?limit=2&cursor=${encodeURIComponent(body1.nextCursor!)}`,
+    );
+    expect(page2.status).toBe(200);
+    const body2 = (await page2.json()) as {
+      feeds: { id: string }[];
+      nextCursor: string | null;
+    };
+    // page1 と page2 で重複がないことを確認
+    const ids1 = body1.feeds.map((f) => f.id);
+    const ids2 = body2.feeds.map((f) => f.id);
+    expect(ids2.some((id) => ids1.includes(id))).toBe(false);
+  });
+
+  it("clamps limit to MAX_LIMIT (100)", async () => {
+    const res = await SELF.fetch("https://example.com/api/feeds?limit=9999");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { feeds: unknown[]; nextCursor: string | null };
+    // フィードの合計は 100 未満なので nextCursor=null かつ全件返る
+    expect(body.nextCursor).toBeNull();
+  });
+
+  it("ignores malformed cursor and returns from start", async () => {
+    const res = await SELF.fetch("https://example.com/api/feeds?cursor=not-base64!!!");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { feeds: { id: string }[] };
+    expect(body.feeds.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
 describe("/api/stats", () => {
   it("returns aggregated counts", async () => {
     const res = await SELF.fetch("https://example.com/api/stats");

--- a/apps/web/worker/api/feeds.ts
+++ b/apps/web/worker/api/feeds.ts
@@ -4,7 +4,19 @@ import { loadAllFeeds } from "../feed-config";
 
 const app = new Hono<{ Bindings: Env }>();
 
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+
 app.get("/", async (c) => {
+  const { req } = c;
+  const limitRaw = req.query("limit");
+  const cursorRaw = req.query("cursor");
+
+  const limit = Math.min(
+    Math.max(Number(limitRaw ?? DEFAULT_LIMIT) || DEFAULT_LIMIT, 1),
+    MAX_LIMIT,
+  );
+
   const configFeeds = loadAllFeeds();
   const result = await c.env.DB.prepare(
     `SELECT f.id, f.name, f.url, f.category, f.lang, f.enabled,
@@ -24,7 +36,7 @@ app.get("/", async (c) => {
   }>();
 
   const dbMap = new Map((result.results ?? []).map((r) => [r.id, r]));
-  const merged = configFeeds.map((f) => {
+  const allMerged = configFeeds.map((f) => {
     const db = dbMap.get(f.id);
     return {
       id: f.id,
@@ -39,7 +51,24 @@ app.get("/", async (c) => {
     };
   });
 
-  return c.json({ feeds: merged });
+  // cursor は id の base64 エンコード。cursor が指す id の次から返す。
+  let startIdx = 0;
+  if (cursorRaw) {
+    try {
+      const cursorId = atob(cursorRaw);
+      const idx = allMerged.findIndex((f) => f.id === cursorId);
+      // cursor の id が見つかった場合、その次の要素から返す
+      if (idx !== -1) startIdx = idx + 1;
+    } catch {
+      // 不正な cursor は無視して先頭から返す
+    }
+  }
+
+  const page = allMerged.slice(startIdx, startIdx + limit);
+  const hasMore = startIdx + limit < allMerged.length;
+  const nextCursor = hasMore ? btoa(page[page.length - 1].id) : null;
+
+  return c.json({ feeds: page, nextCursor });
 });
 
 export default app;

--- a/apps/web/worker/api/stats.ts
+++ b/apps/web/worker/api/stats.ts
@@ -16,6 +16,10 @@ const STALE_FEEDS_SQL = `
   ORDER BY last_fetched_at IS NULL DESC, last_fetched_at ASC
 `;
 
+// no pagination needed (aggregate-only):
+// total / by_category / by_lang は GROUP BY 1 クエリで完結し行数が増えない。
+// stale_feeds はフィード数 (最大数百) に依存するが、全件表示が運用上必要なため除外しない。
+
 app.get("/", async (c) => {
   const totalRow = await c.env.DB.prepare(
     "SELECT COUNT(*) AS n, MAX(published_at) AS last_published, MAX(fetched_at) AS last_fetched FROM articles",


### PR DESCRIPTION
## Summary

- `/api/feeds` に `limit` (default 50, max 100) / `cursor` (id の base64 エンコード) パラメータを追加し、レスポンスを `{ feeds: [...], nextCursor: string | null }` 形式に統一
- `/api/stats` は全クエリが集約系 (GROUP BY / COUNT) のためページング不要と判断し、`// no pagination needed (aggregate-only)` コメントを追加
- `apps/web/client/types/api.ts` の `FeedsResponse` に `nextCursor: string | null` フィールドを追加
- 既存テストを壊さず、新規ケース (cursor 動作 / limit clamp / nextCursor null 終端 / malformed cursor) を追加 (42 tests pass)

## /api/feeds cursor 設計

- cursor = `btoa(lastItemId)` — feeds.yaml 由来のリストを配列インデックスで操作する関係で、D1 クエリ側ではなくアプリ側でスライス
- 不正な cursor は無視して先頭から返す (silent fallback)
- `limit=9999` は MAX_LIMIT=100 に clamp

## /api/stats 判定

ページング対象なし。理由:
- `total / by_category / by_lang` — GROUP BY 1 クエリで行数固定
- `stale_feeds` — フィード数上限 (数百) まで全件必要

## Test plan

- [ ] `pnpm build` pass
- [ ] `pnpm typecheck` pass
- [ ] `pnpm test` 42 tests pass
- [ ] `pnpm check` exit code 0

Closes #46