### PR TITLE
feat: CORS explicit config for /api/* and ADMIN_TOKEN rotation support

### DIFF
--- a/apps/web/tests/worker/api/api.test.ts
+++ b/apps/web/tests/worker/api/api.test.ts
@@ -406,7 +406,7 @@ describe("CORS headers on public /api/* endpoints", () => {
       },
     });
     expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
-  });
+  }, 60000);
 });
 
 describe("security headers", () => {

--- a/apps/web/tests/worker/api/api.test.ts
+++ b/apps/web/tests/worker/api/api.test.ts
@@ -322,8 +322,90 @@ describe("/api/health", () => {
 describe("/api/admin/collect", () => {
   it("rejects unauthenticated requests", async () => {
     const res = await SELF.fetch("https://example.com/api/admin/collect", { method: "POST" });
-    // ADMIN_TOKEN is not set in test env -> 503
+    // ADMIN_TOKEN はテスト環境では設定済みのため 401 を期待する
     expect([401, 503]).toContain(res.status);
+  });
+
+  it("accepts requests with current ADMIN_TOKEN", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/collect", {
+      method: "POST",
+      headers: { authorization: "Bearer test-admin-token" },
+    });
+    // 認証は通るが collect は実際のフィード fetch を試みる (タイムアウト後エラーになるが 200 で返る)
+    expect(res.status).toBe(200);
+  }, 60000);
+
+  it("accepts requests with ADMIN_TOKEN_NEXT (rotation support)", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/collect", {
+      method: "POST",
+      headers: { authorization: "Bearer test-admin-token-next" },
+    });
+    expect(res.status).toBe(200);
+  }, 60000);
+
+  it("rejects requests with invalid token", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/collect", {
+      method: "POST",
+      headers: { authorization: "Bearer invalid-token" },
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("CORS headers on public /api/* endpoints", () => {
+  const allowedOrigin = "https://tech-news-bot.rikeda71.workers.dev";
+
+  it("returns Access-Control-Allow-Origin for /api/articles GET", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles", {
+      headers: { origin: allowedOrigin },
+    });
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe(allowedOrigin);
+  });
+
+  it("handles OPTIONS preflight for /api/articles", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles", {
+      method: "OPTIONS",
+      headers: {
+        origin: allowedOrigin,
+        "Access-Control-Request-Method": "GET",
+        "Access-Control-Request-Headers": "content-type",
+      },
+    });
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe(allowedOrigin);
+    expect(res.headers.get("Access-Control-Allow-Methods")).toMatch(/GET/);
+  });
+
+  it("returns Access-Control-Allow-Origin for /api/health GET", async () => {
+    const res = await SELF.fetch("https://example.com/api/health", {
+      headers: { origin: allowedOrigin },
+    });
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe(allowedOrigin);
+  });
+
+  it("returns Access-Control-Allow-Origin for /api/stats GET", async () => {
+    const res = await SELF.fetch("https://example.com/api/stats", {
+      headers: { origin: allowedOrigin },
+    });
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe(allowedOrigin);
+  });
+
+  it("returns Access-Control-Allow-Origin for /api/feeds GET", async () => {
+    const res = await SELF.fetch("https://example.com/api/feeds", {
+      headers: { origin: allowedOrigin },
+    });
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe(allowedOrigin);
+  });
+
+  it("does NOT return Access-Control-Allow-Origin for /api/admin (server-to-server only)", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/collect", {
+      method: "POST",
+      headers: {
+        origin: allowedOrigin,
+        authorization: "Bearer test-admin-token",
+      },
+    });
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
   });
 });
 

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -13,6 +13,11 @@ export default defineConfig(async () => {
         miniflare: {
           bindings: {
             TEST_MIGRATIONS: migrations,
+            // テスト用トークン (本番では wrangler secret put で登録)
+            ADMIN_TOKEN: "test-admin-token",
+            ADMIN_TOKEN_NEXT: "test-admin-token-next",
+            // フィード収集テストで外部 fetch が失敗するため短くしてタイムアウトを速める
+            COLLECTOR_TIMEOUT_MS: "500",
           },
         },
       }),

--- a/apps/web/worker/api/admin.ts
+++ b/apps/web/worker/api/admin.ts
@@ -13,18 +13,31 @@ function timingSafeEqual(a: string, b: string): boolean {
   return diff === 0;
 }
 
+// 現行 token または次世代 token のいずれかに一致すれば認証 OK。
+// ローテーション期間中は両方を受け入れ、完了後に ADMIN_TOKEN_NEXT を削除する。
+function isValidAdminToken(
+  provided: string,
+  current: string | undefined,
+  next: string | undefined,
+): boolean {
+  if (current && timingSafeEqual(provided, current)) return true;
+  if (next && timingSafeEqual(provided, next)) return true;
+  return false;
+}
+
 app.post("/collect", async (c) => {
   // READONLY=1 の preview 環境では書き込みを行わない
   if (c.env.READONLY === "1") {
     return c.json({ error: "read-only mode" }, 403);
   }
-  const expected = (c.env as unknown as { ADMIN_TOKEN?: string }).ADMIN_TOKEN;
-  if (!expected) {
+  const current = c.env.ADMIN_TOKEN;
+  const next = c.env.ADMIN_TOKEN_NEXT;
+  if (!current) {
     return c.json({ error: "ADMIN_TOKEN is not configured" }, 503);
   }
   const auth = c.req.header("authorization") ?? "";
   const token = auth.replace(/^Bearer\s+/i, "");
-  if (!token || !timingSafeEqual(token, expected)) {
+  if (!token || !isValidAdminToken(token, current, next)) {
     return c.json({ error: "unauthorized" }, 401);
   }
   const result = await collectAll(c.env);

--- a/apps/web/worker/api/router.ts
+++ b/apps/web/worker/api/router.ts
@@ -1,4 +1,6 @@
 import { Hono } from "hono";
+import { cors } from "hono/cors";
+import type { Context, Next } from "hono";
 import type { Env } from "../types";
 import articles from "./articles";
 import feeds from "./feeds";
@@ -12,6 +14,18 @@ api.use("*", async (c, next) => {
   c.header("Cache-Control", "no-store");
   await next();
 });
+
+// /api/admin/* は server-to-server 専用のため CORS を付けない。
+// それ以外の公開エンドポイントは wrangler.toml の CORS_ALLOWED_ORIGINS で制御する。
+function allowedOriginsCors(c: Context<{ Bindings: Env }>, next: Next) {
+  const origins = (c.env.CORS_ALLOWED_ORIGINS ?? "*").split(",").map((o) => o.trim());
+  return cors({ origin: origins })(c, next);
+}
+
+const PUBLIC_PATHS = ["/articles/*", "/feeds/*", "/stats/*", "/health/*"] as const;
+for (const path of PUBLIC_PATHS) {
+  api.use(path, allowedOriginsCors);
+}
 
 api.route("/articles", articles);
 api.route("/feeds", feeds);

--- a/apps/web/worker/types.ts
+++ b/apps/web/worker/types.ts
@@ -6,7 +6,10 @@ export interface Env {
   COLLECTOR_RETRIES: string;
   SUMMARY_MAX_LENGTH: string;
   RETENTION_DAYS: string;
+  CORS_ALLOWED_ORIGINS: string;
   ADMIN_TOKEN?: string;
+  // ローテーション中に新旧両方のトークンを受け入れるための次世代 secret
+  ADMIN_TOKEN_NEXT?: string;
   // preview 環境では "1" をセット。admin/collector を no-op にする。
   READONLY?: string;
 }

--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -26,6 +26,8 @@ COLLECTOR_TIMEOUT_MS = "10000"
 COLLECTOR_RETRIES = "2"
 SUMMARY_MAX_LENGTH = "500"
 RETENTION_DAYS = "90"
+# カンマ区切りで許可する Origin を列挙。* は非推奨 (明示的 origin で制限する)
+CORS_ALLOWED_ORIGINS = "https://tech-news-bot.rikeda71.workers.dev"
 
 # preview 環境: PR ごとに動的な Worker 名は wrangler CLI の --name で指定する。
 # D1 は本番と同じ DB を使い、READONLY=1 で admin/collector を無効化する。
@@ -49,6 +51,8 @@ database_id = "a6cd7dbc-9f26-46d9-83c8-4a7b89405b7b"
 [env.preview.vars]
 COLLECTOR_CONCURRENCY = "4"
 COLLECTOR_TIMEOUT_MS = "10000"
+COLLECTOR_RETRIES = "2"
 SUMMARY_MAX_LENGTH = "500"
 RETENTION_DAYS = "90"
 READONLY = "1"
+CORS_ALLOWED_ORIGINS = "https://tech-news-bot.rikeda71.workers.dev"

--- a/docs/operations/admin-token-rotation.md
+++ b/docs/operations/admin-token-rotation.md
@@ -1,0 +1,67 @@
+# ADMIN_TOKEN ローテーション手順
+
+`/api/admin/collect` エンドポイントを保護する `ADMIN_TOKEN` のローテーション手順を示す。
+
+Worker は `ADMIN_TOKEN`（現行）と `ADMIN_TOKEN_NEXT`（次世代）の両方を timing-safe で検証し、
+どちらかに一致した場合に認証を通す。これによりダウンタイムなしでトークンを切り替えられる。
+
+---
+
+## ローテーション手順
+
+### 1. 次世代トークンを生成して登録する
+
+```bash
+# 安全なランダム文字列を生成 (例: 32 バイト hex)
+openssl rand -hex 32
+
+# 生成した文字列を ADMIN_TOKEN_NEXT として登録
+wrangler secret put ADMIN_TOKEN_NEXT
+# 対話プロンプトに生成したトークンを貼り付ける
+```
+
+Worker は自動的に再デプロイされ、旧トークン (ADMIN_TOKEN) と新トークン (ADMIN_TOKEN_NEXT) の
+両方を受け入れるようになる。
+
+### 2. クライアント側を新トークンに切り替える
+
+`/api/admin/collect` を呼び出しているすべてのクライアント（GitHub Actions の secrets、
+外部スクリプト等）を新トークン (`ADMIN_TOKEN_NEXT` に設定した値) に切り替える。
+
+### 3. 稼働確認
+
+新トークンで `/api/admin/collect` が正常に動作することを確認する（例: 200 レスポンスを受信）。
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" \
+  -X POST https://tech-news-bot.rikeda71.workers.dev/api/admin/collect \
+  -H "Authorization: Bearer <new-token>"
+# → 200 であれば OK
+```
+
+旧トークンがもう使われていないことも確認する。
+
+### 4. 旧トークンを新トークンで上書きする
+
+```bash
+wrangler secret put ADMIN_TOKEN
+# 対話プロンプトに新トークン (= ADMIN_TOKEN_NEXT の値) を貼り付ける
+```
+
+### 5. 次世代 secret を削除する
+
+```bash
+wrangler secret delete ADMIN_TOKEN_NEXT
+```
+
+これでローテーション完了。`ADMIN_TOKEN` のみが有効なトークンとなる。
+
+---
+
+## 注意事項
+
+- `ADMIN_TOKEN` と `ADMIN_TOKEN_NEXT` の値が同じになると意図した区別がなくなるため、
+  必ず別の値を使うこと。
+- ローテーション完了後は `ADMIN_TOKEN_NEXT` を速やかに削除すること（不要な secret を残さない）。
+- トークンの最小推奨長: 32 バイト以上 (hex 64 文字以上)。
+- 本番ではトークンをソースコードや logs に出力しないこと。


### PR DESCRIPTION
## Summary

- `hono/cors` middleware を `/api/articles`, `/api/feeds`, `/api/stats`, `/api/health` に適用。`/api/admin/*` は server-to-server 専用なので意図的に除外。
- `CORS_ALLOWED_ORIGINS` を `wrangler.toml [vars]` に追加 (カンマ区切り)。デフォルト値は `https://tech-news-bot.rikeda71.workers.dev` (本番 workers.dev URL)
- `ADMIN_TOKEN_NEXT` secret を導入し、現行トークンと次世代トークンの両方を timing-safe equal で検証。ローテーション期間中のダウンタイムをゼロにする。
- ローテーション手順を `docs/operations/admin-token-rotation.md` に記載。

## Test plan

- [x] CORS preflight (OPTIONS) が `/api/articles` で 204 を返し、`Access-Control-Allow-Origin` が設定されること
- [x] `/api/admin/collect` には CORS ヘッダが付かないこと
- [x] `ADMIN_TOKEN` で認証が通ること
- [x] `ADMIN_TOKEN_NEXT` で認証が通ること (rotation support)
- [x] 無効トークンで 401 が返ること
- [x] `vp check` (lint + format) pass
- [x] `vp test run` 47 tests all pass

Closes #47