### PR TITLE
feat(client): 記事の既読管理 (localStorage ベース)

### DIFF
--- a/apps/web/client/App.tsx
+++ b/apps/web/client/App.tsx
@@ -5,6 +5,7 @@ import { SearchInput } from "./components/SearchInput";
 import { ThemeToggle } from "./components/ThemeToggle";
 import { useArticles } from "./hooks/useArticles";
 import { useFeeds } from "./hooks/useFeeds";
+import { useReadState } from "./hooks/useReadState";
 import { useStats } from "./hooks/useStats";
 import { useTheme } from "./hooks/useTheme";
 import type { FeedCategory, FeedLang } from "./types/api";
@@ -29,6 +30,7 @@ function readFromUrl(): {
   q: string;
   dateFrom: string;
   dateTo: string;
+  unreadOnly: boolean;
 } {
   const params = new URLSearchParams(window.location.search);
   return {
@@ -38,6 +40,7 @@ function readFromUrl(): {
     q: params.get("q") ?? "",
     dateFrom: params.get("date_from") ?? "",
     dateTo: params.get("date_to") ?? "",
+    unreadOnly: params.get("unread") === "1",
   };
 }
 
@@ -48,6 +51,7 @@ function buildSearch(
   q: string,
   dateFrom: string,
   dateTo: string,
+  unreadOnly: boolean,
 ): string {
   const params = new URLSearchParams();
   if (category) params.set("category", category);
@@ -56,6 +60,8 @@ function buildSearch(
   if (q) params.set("q", q);
   if (dateFrom) params.set("date_from", dateFrom);
   if (dateTo) params.set("date_to", dateTo);
+  // true のときだけ付ける
+  if (unreadOnly) params.set("unread", "1");
   const s = params.toString();
   return s ? `?${s}` : window.location.pathname;
 }
@@ -67,10 +73,12 @@ export default function App() {
   const [q, setQ] = useState<string>(() => readFromUrl().q);
   const [dateFrom, setDateFrom] = useState<string>(() => readFromUrl().dateFrom);
   const [dateTo, setDateTo] = useState<string>(() => readFromUrl().dateTo);
+  const [unreadOnly, setUnreadOnly] = useState<boolean>(() => readFromUrl().unreadOnly);
 
   const { theme, toggleTheme } = useTheme();
   const { feeds } = useFeeds();
   const { stats } = useStats();
+  const { isRead } = useReadState();
 
   // popstate でブラウザ戻る/進むに追従する
   useEffect(() => {
@@ -82,6 +90,7 @@ export default function App() {
       setQ(next.q);
       setDateFrom(next.dateFrom);
       setDateTo(next.dateTo);
+      setUnreadOnly(next.unreadOnly);
     };
     window.addEventListener("popstate", onPop);
     return () => window.removeEventListener("popstate", onPop);
@@ -96,9 +105,18 @@ export default function App() {
       nextQ: string,
       nextDateFrom: string,
       nextDateTo: string,
+      nextUnreadOnly: boolean,
     ) => {
-      const next = buildSearch(nextCategory, nextLang, nextFeedId, nextQ, nextDateFrom, nextDateTo);
-      const current = buildSearch(category, lang, feedId, q, dateFrom, dateTo);
+      const next = buildSearch(
+        nextCategory,
+        nextLang,
+        nextFeedId,
+        nextQ,
+        nextDateFrom,
+        nextDateTo,
+        nextUnreadOnly,
+      );
+      const current = buildSearch(category, lang, feedId, q, dateFrom, dateTo, unreadOnly);
       // 同じ URL なら重複履歴を作らない
       if (next !== current) {
         window.history.pushState(null, "", next);
@@ -109,51 +127,57 @@ export default function App() {
       setQ(nextQ);
       setDateFrom(nextDateFrom);
       setDateTo(nextDateTo);
+      setUnreadOnly(nextUnreadOnly);
     },
-    [category, lang, feedId, q, dateFrom, dateTo],
+    [category, lang, feedId, q, dateFrom, dateTo, unreadOnly],
   );
 
   const handleCategoryChange = useCallback(
-    (v: FeedCategory | "") => pushFilter(v, lang, v ? feedId : "", q, dateFrom, dateTo),
-    [pushFilter, lang, feedId, q, dateFrom, dateTo],
+    (v: FeedCategory | "") => pushFilter(v, lang, v ? feedId : "", q, dateFrom, dateTo, unreadOnly),
+    [pushFilter, lang, feedId, q, dateFrom, dateTo, unreadOnly],
   );
 
   const handleLangChange = useCallback(
-    (v: FeedLang | "") => pushFilter(category, v, v ? feedId : "", q, dateFrom, dateTo),
-    [pushFilter, category, feedId, q, dateFrom, dateTo],
+    (v: FeedLang | "") => pushFilter(category, v, v ? feedId : "", q, dateFrom, dateTo, unreadOnly),
+    [pushFilter, category, feedId, q, dateFrom, dateTo, unreadOnly],
   );
 
   const handleFeedChange = useCallback(
-    (id: string) => pushFilter(category, lang, id, q, dateFrom, dateTo),
-    [pushFilter, category, lang, q, dateFrom, dateTo],
+    (id: string) => pushFilter(category, lang, id, q, dateFrom, dateTo, unreadOnly),
+    [pushFilter, category, lang, q, dateFrom, dateTo, unreadOnly],
   );
 
   const handleQChange = useCallback(
-    (v: string) => pushFilter(category, lang, feedId, v, dateFrom, dateTo),
-    [pushFilter, category, lang, feedId, dateFrom, dateTo],
+    (v: string) => pushFilter(category, lang, feedId, v, dateFrom, dateTo, unreadOnly),
+    [pushFilter, category, lang, feedId, dateFrom, dateTo, unreadOnly],
   );
 
   const handleDateFromChange = useCallback(
-    (v: string) => pushFilter(category, lang, feedId, q, v, dateTo),
-    [pushFilter, category, lang, feedId, q, dateTo],
+    (v: string) => pushFilter(category, lang, feedId, q, v, dateTo, unreadOnly),
+    [pushFilter, category, lang, feedId, q, dateTo, unreadOnly],
   );
 
   const handleDateToChange = useCallback(
-    (v: string) => pushFilter(category, lang, feedId, q, dateFrom, v),
-    [pushFilter, category, lang, feedId, q, dateFrom],
+    (v: string) => pushFilter(category, lang, feedId, q, dateFrom, v, unreadOnly),
+    [pushFilter, category, lang, feedId, q, dateFrom, unreadOnly],
   );
 
-  const handleClear = useCallback(() => pushFilter("", "", "", q, "", ""), [pushFilter, q]);
+  const handleUnreadOnlyChange = useCallback(
+    (v: boolean) => pushFilter(category, lang, feedId, q, dateFrom, dateTo, v),
+    [pushFilter, category, lang, feedId, q, dateFrom, dateTo],
+  );
+
+  const handleClear = useCallback(() => pushFilter("", "", "", q, "", "", false), [pushFilter, q]);
 
   // カード上のバッジ/取得元クリックでフィルタを適用する
   const handleFilterByCategory = useCallback(
-    (c: FeedCategory) => pushFilter(c, lang, "", q, dateFrom, dateTo),
-    [pushFilter, lang, q, dateFrom, dateTo],
+    (c: FeedCategory) => pushFilter(c, lang, "", q, dateFrom, dateTo, unreadOnly),
+    [pushFilter, lang, q, dateFrom, dateTo, unreadOnly],
   );
 
   const handleFilterByFeedId = useCallback(
-    (id: string) => pushFilter(category, lang, id, q, dateFrom, dateTo),
-    [pushFilter, category, lang, q, dateFrom, dateTo],
+    (id: string) => pushFilter(category, lang, id, q, dateFrom, dateTo, unreadOnly),
+    [pushFilter, category, lang, q, dateFrom, dateTo, unreadOnly],
   );
 
   const query = useMemo(
@@ -168,7 +192,20 @@ export default function App() {
     [category, lang, feedId, q, dateFrom, dateTo],
   );
 
-  const { articles, loading, loadingMore, error, nextCursor, loadMore } = useArticles(query);
+  const {
+    articles: allArticles,
+    loading,
+    loadingMore,
+    error,
+    nextCursor,
+    loadMore,
+  } = useArticles(query);
+
+  // 未読フィルタはクライアントサイドで適用 (サーバー API は既読を知らないため)
+  const articles = useMemo(
+    () => (unreadOnly ? allArticles.filter((a) => !isRead(a.id)) : allArticles),
+    [allArticles, unreadOnly, isRead],
+  );
 
   return (
     <div className="app">
@@ -206,11 +243,13 @@ export default function App() {
           feeds={feeds}
           dateFrom={dateFrom}
           dateTo={dateTo}
+          unreadOnly={unreadOnly}
           onCategoryChange={handleCategoryChange}
           onLangChange={handleLangChange}
           onFeedChange={handleFeedChange}
           onDateFromChange={handleDateFromChange}
           onDateToChange={handleDateToChange}
+          onUnreadOnlyChange={handleUnreadOnlyChange}
           onClear={handleClear}
         />
       </div>

--- a/apps/web/client/components/ArticleCard.tsx
+++ b/apps/web/client/components/ArticleCard.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+import { useReadState } from "../hooks/useReadState";
 import type { Article, FeedCategory } from "../types/api";
 
 interface Props {
@@ -35,11 +37,37 @@ function safeHref(url: string): string {
 }
 
 export function ArticleCard({ article, onFilterByCategory, onFilterByFeedId }: Props) {
+  const { isRead, markRead, markUnread } = useReadState();
+  const [hovered, setHovered] = useState(false);
+  const read = isRead(article.id);
+
   return (
-    <article className="article-card">
-      <a href={safeHref(article.url)} target="_blank" rel="noopener noreferrer" className="title">
-        {article.title}
-      </a>
+    <article
+      className={`article-card${read ? " read" : ""}`}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      <div className="article-card-title-row">
+        <a
+          href={safeHref(article.url)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="title"
+          onClick={() => markRead(article.id)}
+        >
+          {article.title}
+        </a>
+        {/* hover 時に既読 / 未読切り替えボタンを薄く表示 */}
+        {hovered && (
+          <button
+            type="button"
+            className="read-toggle"
+            onClick={() => (read ? markUnread(article.id) : markRead(article.id))}
+          >
+            {read ? "未読に戻す" : "既読にする"}
+          </button>
+        )}
+      </div>
       <div className="meta">
         <button
           type="button"

--- a/apps/web/client/components/FilterBar.tsx
+++ b/apps/web/client/components/FilterBar.tsx
@@ -7,11 +7,13 @@ interface Props {
   feeds: FeedSummary[];
   dateFrom: string;
   dateTo: string;
+  unreadOnly: boolean;
   onCategoryChange: (c: FeedCategory | "") => void;
   onLangChange: (l: FeedLang | "") => void;
   onFeedChange: (id: string) => void;
   onDateFromChange: (v: string) => void;
   onDateToChange: (v: string) => void;
+  onUnreadOnlyChange: (v: boolean) => void;
   onClear: () => void;
 }
 
@@ -22,11 +24,13 @@ export function FilterBar({
   feeds,
   dateFrom,
   dateTo,
+  unreadOnly,
   onCategoryChange,
   onLangChange,
   onFeedChange,
   onDateFromChange,
   onDateToChange,
+  onUnreadOnlyChange,
   onClear,
 }: Props) {
   const visibleFeeds = feeds
@@ -34,7 +38,12 @@ export function FilterBar({
     .filter((f) => (lang ? f.lang === lang : true));
 
   const hasFilter =
-    category !== "" || lang !== "" || feedId !== "" || dateFrom !== "" || dateTo !== "";
+    category !== "" ||
+    lang !== "" ||
+    feedId !== "" ||
+    dateFrom !== "" ||
+    dateTo !== "" ||
+    unreadOnly;
 
   return (
     <>
@@ -84,6 +93,15 @@ export function FilterBar({
         onChange={(e) => onDateToChange(e.target.value)}
         aria-label="期間 終了日"
       />
+
+      <label className="unread-only-label">
+        <input
+          type="checkbox"
+          checked={unreadOnly}
+          onChange={(e) => onUnreadOnlyChange(e.target.checked)}
+        />
+        未読のみ
+      </label>
 
       {hasFilter && (
         <button type="button" className="clear-filter" onClick={onClear}>

--- a/apps/web/client/hooks/useReadState.ts
+++ b/apps/web/client/hooks/useReadState.ts
@@ -1,0 +1,92 @@
+import { useCallback, useSyncExternalStore } from "react";
+
+const STORAGE_KEY = "tnb-read-articles";
+const MAX_IDS = 1000;
+
+// localStorage から既読 id 配列を読む (新しい順に保存)
+function readStorage(): number[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((v): v is number => typeof v === "number");
+  } catch {
+    return [];
+  }
+}
+
+function writeStorage(ids: number[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(ids));
+  } catch {
+    // localStorage が使えない環境では無視
+  }
+}
+
+// useSyncExternalStore 用サブスクライバー管理
+type Listener = () => void;
+const listeners = new Set<Listener>();
+
+function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+
+  // 他タブからの storage event を受けてタブ間同期
+  const onStorage = (e: StorageEvent) => {
+    if (e.key === STORAGE_KEY) listener();
+  };
+  window.addEventListener("storage", onStorage);
+
+  return () => {
+    listeners.delete(listener);
+    window.removeEventListener("storage", onStorage);
+  };
+}
+
+function notify(): void {
+  for (const l of listeners) l();
+}
+
+function getSnapshot(): number[] {
+  return readStorage();
+}
+
+export interface ReadStateAPI {
+  /** 指定 id が既読かどうか */
+  isRead: (id: number) => boolean;
+  /** 既読にする (LRU 1000件超過分は古い順に破棄) */
+  markRead: (id: number) => void;
+  /** 未読に戻す */
+  markUnread: (id: number) => void;
+  /** 全件クリア */
+  clearAll: () => void;
+}
+
+export function useReadState(): ReadStateAPI {
+  const readIds = useSyncExternalStore(subscribe, getSnapshot, () => []);
+
+  const isRead = useCallback((id: number) => readIds.includes(id), [readIds]);
+
+  const markRead = useCallback((id: number) => {
+    const current = readStorage();
+    // すでに既読なら先頭に移動して更新 (LRU の定義通り)
+    const without = current.filter((v) => v !== id);
+    const next = [id, ...without].slice(0, MAX_IDS);
+    writeStorage(next);
+    notify();
+  }, []);
+
+  const markUnread = useCallback((id: number) => {
+    const current = readStorage();
+    const next = current.filter((v) => v !== id);
+    writeStorage(next);
+    notify();
+  }, []);
+
+  const clearAll = useCallback(() => {
+    writeStorage([]);
+    notify();
+  }, []);
+
+  return { isRead, markRead, markUnread, clearAll };
+}

--- a/apps/web/client/index.css
+++ b/apps/web/client/index.css
@@ -202,11 +202,44 @@ a:hover {
   border-color: var(--accent);
 }
 
+/* 既読カードは全体を薄く表示する */
+.article-card.read {
+  opacity: 0.6;
+}
+
+.article-card-title-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
 .article-card .title {
+  flex: 1;
   font-size: 1.05rem;
   font-weight: 600;
   line-height: 1.35;
   color: var(--fg);
+}
+
+/* hover 時にだけ表示する既読切り替えボタン */
+.read-toggle {
+  flex-shrink: 0;
+  padding: 2px 8px;
+  background: var(--bg-elev-2);
+  color: var(--fg-muted);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-family: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+  opacity: 0.7;
+}
+
+.read-toggle:hover {
+  opacity: 1;
+  color: var(--fg);
+  border-color: var(--accent);
 }
 
 .article-card .meta {
@@ -302,6 +335,24 @@ a:hover {
 .feed-name-clickable:hover {
   color: var(--accent);
   text-decoration: underline;
+}
+
+.unread-only-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--fg-muted);
+  font-size: 0.9rem;
+  cursor: pointer;
+  white-space: nowrap;
+  user-select: none;
+}
+
+.unread-only-label input[type="checkbox"] {
+  cursor: pointer;
+  accent-color: var(--accent);
+  width: 14px;
+  height: 14px;
 }
 
 .clear-filter {


### PR DESCRIPTION
## Summary

- `useReadState` hook を新規作成 (`apps/web/client/hooks/useReadState.ts`)
  - localStorage キー `tnb-read-articles` に既読 article id (number[]) を保存
  - `useSyncExternalStore` で同期し、`storage` イベントでタブ間同期も対応
  - LRU 1000 件: 新しい id を先頭に追加し、超過分は配列末尾から破棄
  - API: `{ isRead, markRead, markUnread, clearAll }`
- `ArticleCard` を更新
  - タイトルリンクのクリックで `markRead(article.id)` を自動発火
  - hover 時に「既読にする / 未読に戻す」ボタンを薄く表示
  - 既読カードは `.read` クラスで `opacity: 0.6` の視覚的差別化
- `FilterBar` を更新
  - 「未読のみ」チェックボックスを追加
  - `?unread=1` で URL 同期 (true のときだけパラメータを付与)
  - 既存フィルタ (category / lang / feed_id / date range / q) と AND 結合
- `App` を更新
  - `unreadOnly` state を管理し `pushState` で URL 同期
  - `popstate` 時に `unreadOnly` も復元
  - 未読フィルタはクライアントサイドで適用 (サーバー API は既読状態を知らないため)

## Test plan

- [x] `pnpm build` pass
- [x] `pnpm typecheck` pass
- [x] `pnpm test` pass (67 tests)
- [x] `pnpm check` pass (format + lint)

Closes #39