### PR TITLE
feat: RSS conditional GET (ETag/If-Modified-Since) でキャッシュ対応

### DIFF
--- a/apps/web/tests/worker/collector/conditionalGet.test.ts
+++ b/apps/web/tests/worker/collector/conditionalGet.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { env } from "cloudflare:test";
+import { fetchFeed } from "../../../worker/collector/index";
+import { loadFeedHeaders, syncFeeds, updateFeedHeaders } from "../../../worker/db/feeds";
+import type { FeedConfig } from "../../../worker/types";
+
+const DUMMY_URL = "https://example.com/feed.xml";
+const VALID_XML = `<?xml version="1.0"?><rss version="2.0"><channel><title>T</title></channel></rss>`;
+
+const TEST_FEED: FeedConfig = {
+  id: "test-feed",
+  name: "Test Feed",
+  url: DUMMY_URL,
+  category: "bigtech",
+  lang: "en",
+  enabled: true,
+};
+
+beforeEach(async () => {
+  await syncFeeds(env.DB, [TEST_FEED]);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("fetchFeed conditional GET", () => {
+  it("returns xml with notModified=false on 200 OK (no conditional headers)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(VALID_XML, { status: 200 }));
+
+    const result = await fetchFeed(DUMMY_URL, 10000, 0);
+    expect(result.notModified).toBe(false);
+    expect(result.xml).toBe(VALID_XML);
+  });
+
+  it("returns notModified=true on 304 and xml is null", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(null, { status: 304 }));
+
+    const result = await fetchFeed(DUMMY_URL, 10000, 0);
+    expect(result.notModified).toBe(true);
+    expect(result.xml).toBeNull();
+  });
+
+  it("sends If-None-Match header when etag is provided", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(VALID_XML, { status: 200 }));
+
+    await fetchFeed(DUMMY_URL, 10000, 0, { etag: '"abc123"', lastModified: null });
+
+    const callArgs = spy.mock.calls[0];
+    const headers = callArgs[1]?.headers as Record<string, string>;
+    expect(headers["if-none-match"]).toBe('"abc123"');
+  });
+
+  it("sends If-Modified-Since header when lastModified is provided", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(VALID_XML, { status: 200 }));
+
+    const lastMod = "Mon, 01 Jan 2024 00:00:00 GMT";
+    await fetchFeed(DUMMY_URL, 10000, 0, { etag: null, lastModified: lastMod });
+
+    const callArgs = spy.mock.calls[0];
+    const headers = callArgs[1]?.headers as Record<string, string>;
+    expect(headers["if-modified-since"]).toBe(lastMod);
+  });
+
+  it("does not send conditional headers when both are null", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(VALID_XML, { status: 200 }));
+
+    await fetchFeed(DUMMY_URL, 10000, 0, { etag: null, lastModified: null });
+
+    const callArgs = spy.mock.calls[0];
+    const headers = callArgs[1]?.headers as Record<string, string>;
+    expect(headers["if-none-match"]).toBeUndefined();
+    expect(headers["if-modified-since"]).toBeUndefined();
+  });
+
+  it("saves etag from 200 response", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(VALID_XML, {
+        status: 200,
+        headers: { etag: '"newetag"', "last-modified": "Tue, 02 Jan 2024 00:00:00 GMT" },
+      }),
+    );
+
+    const result = await fetchFeed(DUMMY_URL, 10000, 0);
+    expect(result.etag).toBe('"newetag"');
+    expect(result.lastModified).toBe("Tue, 02 Jan 2024 00:00:00 GMT");
+  });
+});
+
+describe("loadFeedHeaders / updateFeedHeaders", () => {
+  it("returns null headers for a feed with no saved headers", async () => {
+    const headers = await loadFeedHeaders(env.DB, "test-feed");
+    expect(headers.last_etag).toBeNull();
+    expect(headers.last_modified).toBeNull();
+  });
+
+  it("saves and retrieves etag and last_modified", async () => {
+    await updateFeedHeaders(env.DB, "test-feed", '"v1"', "Wed, 03 Jan 2024 00:00:00 GMT");
+
+    const headers = await loadFeedHeaders(env.DB, "test-feed");
+    expect(headers.last_etag).toBe('"v1"');
+    expect(headers.last_modified).toBe("Wed, 03 Jan 2024 00:00:00 GMT");
+  });
+
+  it("overwrites existing headers on subsequent update", async () => {
+    await updateFeedHeaders(env.DB, "test-feed", '"v1"', "Wed, 03 Jan 2024 00:00:00 GMT");
+    await updateFeedHeaders(env.DB, "test-feed", '"v2"', null);
+
+    const headers = await loadFeedHeaders(env.DB, "test-feed");
+    expect(headers.last_etag).toBe('"v2"');
+    expect(headers.last_modified).toBeNull();
+  });
+
+  it("returns null for unknown feed id", async () => {
+    const headers = await loadFeedHeaders(env.DB, "non-existent-feed");
+    expect(headers.last_etag).toBeNull();
+    expect(headers.last_modified).toBeNull();
+  });
+});

--- a/apps/web/tests/worker/collector/retry.test.ts
+++ b/apps/web/tests/worker/collector/retry.test.ts
@@ -68,7 +68,8 @@ describe("fetchFeed retry behavior", () => {
       .mockResolvedValueOnce(new Response(VALID_XML, { status: 200 }));
 
     const result = await fetchFeed(DUMMY_URL, 10000, 2);
-    expect(result).toBe(VALID_XML);
+    expect(result.xml).toBe(VALID_XML);
+    expect(result.notModified).toBe(false);
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
@@ -83,7 +84,7 @@ describe("fetchFeed retry behavior", () => {
     await vi.runAllTimersAsync();
     const result = await promise;
 
-    expect(result).toBe(VALID_XML);
+    expect(result.xml).toBe(VALID_XML);
     expect(spy).toHaveBeenCalledTimes(2);
   });
 
@@ -98,7 +99,7 @@ describe("fetchFeed retry behavior", () => {
     await vi.runAllTimersAsync();
     const result = await promise;
 
-    expect(result).toBe(VALID_XML);
+    expect(result.xml).toBe(VALID_XML);
     expect(spy).toHaveBeenCalledTimes(2);
   });
 
@@ -145,7 +146,7 @@ describe("fetchFeed retry behavior", () => {
     await vi.runAllTimersAsync();
     const result = await promise;
 
-    expect(result).toBe(VALID_XML);
+    expect(result.xml).toBe(VALID_XML);
     expect(spy).toHaveBeenCalledTimes(2);
   });
 

--- a/apps/web/worker/collector/index.ts
+++ b/apps/web/worker/collector/index.ts
@@ -3,7 +3,13 @@ import { loadEnabledFeeds } from "../feed-config";
 import { parseFeed } from "./rssParser";
 import { buildGuids } from "./deduplicator";
 import { deleteOlderThan, insertArticles, type InsertableArticle } from "../db/articles";
-import { recordFetchError, recordFetchSuccess, syncFeeds } from "../db/feeds";
+import {
+  loadFeedHeaders,
+  recordFetchError,
+  recordFetchSuccess,
+  syncFeeds,
+  updateFeedHeaders,
+} from "../db/feeds";
 
 const MAX_FEED_BYTES = 4 * 1024 * 1024; // 4MB
 const MAX_ITEMS_PER_FEED = 50;
@@ -13,7 +19,7 @@ const BACKOFF_BASE_MS = 500;
 
 export interface CollectResult {
   feedId: string;
-  status: "ok" | "error";
+  status: "ok" | "error" | "not_modified";
   inserted: number;
   parsed: number;
   error?: string;
@@ -52,26 +58,54 @@ export function isRetryableError(err: unknown): boolean {
   return false;
 }
 
+/** fetchFeedOnce の戻り値。304 の場合は xml が null になる。 */
+interface FetchFeedResult {
+  xml: string | null;
+  etag: string | null;
+  lastModified: string | null;
+  notModified: boolean;
+}
+
 /**
  * 1 回の HTTP fetch を試みる。失敗時は呼び出し元でリトライを判断する。
  * - 4xx (429 除く) は恒久エラーなので Error をそのまま throw
  * - 5xx / 429 / AbortError / ネットワークエラーは throw して呼び出し元がリトライ
+ * - 304 Not Modified は notModified=true で返す (リトライしない)
  */
-async function fetchFeedOnce(url: string, timeoutMs: number): Promise<string> {
+async function fetchFeedOnce(
+  url: string,
+  timeoutMs: number,
+  conditionalHeaders: { etag: string | null; lastModified: string | null },
+): Promise<FetchFeedResult> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
+    const reqHeaders: Record<string, string> = {
+      "User-Agent": USER_AGENT,
+      Accept: "application/atom+xml, application/rss+xml, application/xml;q=0.9, */*;q=0.5",
+    };
+    if (conditionalHeaders.etag) {
+      reqHeaders["if-none-match"] = conditionalHeaders.etag;
+    }
+    if (conditionalHeaders.lastModified) {
+      reqHeaders["if-modified-since"] = conditionalHeaders.lastModified;
+    }
+
     const res = await fetch(url, {
-      headers: {
-        "User-Agent": USER_AGENT,
-        Accept: "application/atom+xml, application/rss+xml, application/xml;q=0.9, */*;q=0.5",
-      },
+      headers: reqHeaders,
       signal: controller.signal,
       redirect: "follow",
     });
+
+    // 304: サーバが変更なしと判断。parse/insert をスキップする。
+    if (res.status === 304) {
+      return { xml: null, etag: null, lastModified: null, notModified: true };
+    }
+
     if (!res.ok) {
       throw new Error(`HTTP ${res.status} ${res.statusText}`);
     }
+
     const contentLength = Number(res.headers.get("content-length") ?? 0);
     if (contentLength > MAX_FEED_BYTES) {
       throw new Error(`Feed too large: ${contentLength} bytes`);
@@ -80,7 +114,13 @@ async function fetchFeedOnce(url: string, timeoutMs: number): Promise<string> {
     if (text.length > MAX_FEED_BYTES) {
       throw new Error(`Feed body too large: ${text.length} bytes`);
     }
-    return text;
+
+    return {
+      xml: text,
+      etag: res.headers.get("etag"),
+      lastModified: res.headers.get("last-modified"),
+      notModified: false,
+    };
   } finally {
     clearTimeout(timer);
   }
@@ -88,7 +128,7 @@ async function fetchFeedOnce(url: string, timeoutMs: number): Promise<string> {
 
 /**
  * 一時障害 (5xx / 429 / AbortError / ネットワークエラー) に対して
- * 指数バックオフ + jitter でリトライする。4xx は即 fail。
+ * 指数バックオフ + jitter でリトライする。4xx / 304 は即 return。
  * sleep は wallclock のみ消費するため Worker の CPU 制限に影響しない。
  * テスト用に export する
  */
@@ -96,11 +136,15 @@ export async function fetchFeed(
   url: string,
   timeoutMs: number,
   maxRetries: number,
-): Promise<string> {
+  conditionalHeaders: { etag: string | null; lastModified: string | null } = {
+    etag: null,
+    lastModified: null,
+  },
+): Promise<FetchFeedResult> {
   let lastError: unknown;
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
-      return await fetchFeedOnce(url, timeoutMs);
+      return await fetchFeedOnce(url, timeoutMs, conditionalHeaders);
     } catch (err) {
       lastError = err;
 
@@ -132,8 +176,23 @@ async function collectFeed(
 ): Promise<CollectResult> {
   const fetchedAt = new Date().toISOString();
   try {
-    const xml = await fetchFeed(feed.url, timeoutMs, maxRetries);
-    const allItems = parseFeed(xml, {
+    // 前回の conditional GET ヘッダを読み込んでリクエストに付与する
+    const savedHeaders = await loadFeedHeaders(env.DB, feed.id);
+    const result = await fetchFeed(feed.url, timeoutMs, maxRetries, {
+      etag: savedHeaders.last_etag,
+      lastModified: savedHeaders.last_modified,
+    });
+
+    // 304 Not Modified: parse/insert をスキップし last_fetched_at だけ更新する
+    if (result.notModified) {
+      await recordFetchSuccess(env.DB, feed.id, fetchedAt, 0, "not_modified");
+      return { feedId: feed.id, status: "not_modified", inserted: 0, parsed: 0 };
+    }
+
+    // 200 OK: レスポンスの ETag / Last-Modified を保存する
+    await updateFeedHeaders(env.DB, feed.id, result.etag, result.lastModified);
+
+    const allItems = parseFeed(result.xml!, {
       summaryMaxLength: summaryMax,
       fallbackPublishedAt: fetchedAt,
     });
@@ -209,6 +268,7 @@ export async function collectAll(env: Env): Promise<CollectAllResult> {
   );
 
   const inserted = results.reduce((acc, r) => acc + r.inserted, 0);
+  const skipped304 = results.filter((r) => r.status === "not_modified").length;
 
   const retentionDays = Number(env.RETENTION_DAYS ?? "90") || 90;
   let pruned = 0;
@@ -222,7 +282,7 @@ export async function collectAll(env: Env): Promise<CollectAllResult> {
 
   const durationMs = Date.now() - start;
   console.log(
-    `[collector] feeds=${feeds.length} inserted=${inserted} pruned=${pruned} retentionDays=${retentionDays} duration=${durationMs}ms`,
+    `[collector] feeds=${feeds.length} skipped304=${skipped304} inserted=${inserted} pruned=${pruned} retentionDays=${retentionDays} duration=${durationMs}ms`,
   );
   for (const r of results) {
     if (r.status === "error") {

--- a/apps/web/worker/db/feeds.ts
+++ b/apps/web/worker/db/feeds.ts
@@ -1,5 +1,41 @@
 import type { FeedConfig } from "../types";
 
+export interface FeedHeaders {
+  last_etag: string | null;
+  last_modified: string | null;
+}
+
+/** 前回保存した conditional GET ヘッダを返す。未取得 feed は null ペアを返す。*/
+export async function loadFeedHeaders(db: D1Database, feedId: string): Promise<FeedHeaders> {
+  const row = await db
+    .prepare(`SELECT last_etag, last_modified FROM feeds WHERE id = ?1`)
+    .bind(feedId)
+    .first<FeedHeaders>();
+  return row ?? { last_etag: null, last_modified: null };
+}
+
+/**
+ * 200 応答時のレスポンスヘッダを保存する。
+ * null を渡すと既存値を NULL 上書きする (サーバが ETag を返さなくなった場合)。
+ */
+export async function updateFeedHeaders(
+  db: D1Database,
+  feedId: string,
+  etag: string | null,
+  lastModified: string | null,
+): Promise<void> {
+  await db
+    .prepare(
+      `UPDATE feeds
+       SET last_etag = ?1,
+           last_modified = ?2,
+           updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+       WHERE id = ?3`,
+    )
+    .bind(etag, lastModified, feedId)
+    .run();
+}
+
 export async function syncFeeds(db: D1Database, feeds: FeedConfig[]): Promise<void> {
   if (feeds.length === 0) return;
   const stmts = feeds.map((f) =>
@@ -28,7 +64,10 @@ export async function recordFetchSuccess(
   feedId: string,
   fetchedAt: string,
   insertedCount: number,
+  // 304 の場合は "not_modified"、それ以外は挿入件数を含む "ok:N" 形式
+  statusOverride?: "not_modified",
 ): Promise<void> {
+  const status = statusOverride ?? `ok:${insertedCount}`;
   await db
     .prepare(
       `UPDATE feeds
@@ -38,7 +77,7 @@ export async function recordFetchSuccess(
            updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
        WHERE id = ?3`,
     )
-    .bind(fetchedAt, `ok:${insertedCount}`, feedId)
+    .bind(fetchedAt, status, feedId)
     .run();
 }
 

--- a/migrations/0005_feed_conditional_headers.sql
+++ b/migrations/0005_feed_conditional_headers.sql
@@ -1,0 +1,4 @@
+-- conditional GET に使う ETag / Last-Modified を保持するカラムを追加する。
+-- 既存レコードは NULL (次回 200 応答時に埋まる)。
+ALTER TABLE feeds ADD COLUMN last_etag TEXT;
+ALTER TABLE feeds ADD COLUMN last_modified TEXT;


### PR DESCRIPTION
## Summary

- `migrations/0005_feed_conditional_headers.sql`: `feeds` テーブルに `last_etag TEXT` / `last_modified TEXT` カラムを `ALTER TABLE` で追加
- `apps/web/worker/db/feeds.ts`: `loadFeedHeaders` / `updateFeedHeaders` / `recordFetchSuccess` の `not_modified` オーバーロードを追加
- `apps/web/worker/collector/index.ts`: `fetchFeed` に conditional GET ヘッダを付与し 304 をスキップ、`collectAll` のログに `skipped304` 件数を追加
- `apps/web/tests/worker/collector/conditionalGet.test.ts`: 304 スキップ・ETag 保存・ヘッダ送信・DB 関数の新規テスト追加

## Test plan

- [ ] `pnpm migrate:local` で 0005 が正常 apply される
- [ ] `pnpm build` pass
- [ ] `pnpm typecheck` pass
- [ ] `pnpm test` 全 77 tests pass (新規 conditionalGet.test.ts 含む)
- [ ] `pnpm check` 0 errors

Closes #18