### PR TITLE
feat(client): keyboard shortcuts for article navigation

### DIFF
--- a/apps/web/client/App.tsx
+++ b/apps/web/client/App.tsx
@@ -1,10 +1,12 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ArticleList } from "./components/ArticleList";
 import { FilterBar } from "./components/FilterBar";
+import { HelpModal } from "./components/HelpModal";
 import { SearchInput } from "./components/SearchInput";
 import { ThemeToggle } from "./components/ThemeToggle";
 import { useArticles } from "./hooks/useArticles";
 import { useFeeds } from "./hooks/useFeeds";
+import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { useReadState } from "./hooks/useReadState";
 import { useStats } from "./hooks/useStats";
 import { useTheme } from "./hooks/useTheme";
@@ -74,11 +76,14 @@ export default function App() {
   const [dateFrom, setDateFrom] = useState<string>(() => readFromUrl().dateFrom);
   const [dateTo, setDateTo] = useState<string>(() => readFromUrl().dateTo);
   const [unreadOnly, setUnreadOnly] = useState<boolean>(() => readFromUrl().unreadOnly);
+  const [helpOpen, setHelpOpen] = useState(false);
+
+  const searchRef = useRef<HTMLInputElement>(null);
 
   const { theme, toggleTheme } = useTheme();
   const { feeds } = useFeeds();
   const { stats } = useStats();
-  const { isRead } = useReadState();
+  const { isRead, markRead, markUnread } = useReadState();
 
   // popstate でブラウザ戻る/進むに追従する
   useEffect(() => {
@@ -207,8 +212,42 @@ export default function App() {
     [allArticles, unreadOnly, isRead],
   );
 
+  const handleActivate = useCallback(
+    (id: number, url: string) => {
+      markRead(id);
+      window.open(url, "_blank", "noopener,noreferrer");
+    },
+    [markRead],
+  );
+
+  const handleToggleRead = useCallback(
+    (id: number) => {
+      if (isRead(id)) markUnread(id);
+      else markRead(id);
+    },
+    [isRead, markRead, markUnread],
+  );
+
+  const handleSearchFocus = useCallback(() => {
+    searchRef.current?.focus();
+  }, []);
+
+  const handleClearAll = useCallback(() => pushFilter("", "", "", "", "", "", false), [pushFilter]);
+
+  const handleToggleHelp = useCallback(() => setHelpOpen((prev) => !prev), []);
+
+  const { focusedId } = useKeyboardShortcuts({
+    items: articles,
+    onActivate: handleActivate,
+    onToggleRead: handleToggleRead,
+    onSearchFocus: handleSearchFocus,
+    onClearAll: handleClearAll,
+    onShowHelp: handleToggleHelp,
+  });
+
   return (
     <div className="app">
+      <HelpModal open={helpOpen} onClose={() => setHelpOpen(false)} />
       <header className="header">
         <h1>Tech News Bot</h1>
         <ThemeToggle theme={theme} onToggle={toggleTheme} />
@@ -235,7 +274,7 @@ export default function App() {
       </header>
 
       <div className="toolbar">
-        <SearchInput value={q} onChange={handleQChange} />
+        <SearchInput ref={searchRef} value={q} onChange={handleQChange} />
         <FilterBar
           category={category}
           lang={lang}
@@ -263,6 +302,7 @@ export default function App() {
       {articles.length > 0 && (
         <ArticleList
           articles={articles}
+          focusedId={focusedId}
           onFilterByCategory={handleFilterByCategory}
           onFilterByFeedId={handleFilterByFeedId}
         />

--- a/apps/web/client/components/ArticleCard.tsx
+++ b/apps/web/client/components/ArticleCard.tsx
@@ -4,6 +4,7 @@ import type { Article, FeedCategory } from "../types/api";
 
 interface Props {
   article: Article;
+  focused?: boolean;
   onFilterByCategory: (c: FeedCategory) => void;
   onFilterByFeedId: (id: string) => void;
 }
@@ -36,14 +37,16 @@ function safeHref(url: string): string {
   }
 }
 
-export function ArticleCard({ article, onFilterByCategory, onFilterByFeedId }: Props) {
+export function ArticleCard({ article, focused, onFilterByCategory, onFilterByFeedId }: Props) {
   const { isRead, markRead, markUnread } = useReadState();
   const [hovered, setHovered] = useState(false);
   const read = isRead(article.id);
 
   return (
     <article
-      className={`article-card${read ? " read" : ""}`}
+      className={`article-card${read ? " read" : ""}${focused ? " focused" : ""}`}
+      data-article-id={article.id}
+      tabIndex={-1}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >

--- a/apps/web/client/components/ArticleList.tsx
+++ b/apps/web/client/components/ArticleList.tsx
@@ -3,17 +3,19 @@ import { ArticleCard } from "./ArticleCard";
 
 interface Props {
   articles: Article[];
+  focusedId?: number | null;
   onFilterByCategory: (c: FeedCategory) => void;
   onFilterByFeedId: (id: string) => void;
 }
 
-export function ArticleList({ articles, onFilterByCategory, onFilterByFeedId }: Props) {
+export function ArticleList({ articles, focusedId, onFilterByCategory, onFilterByFeedId }: Props) {
   return (
     <div className="article-list">
       {articles.map((a) => (
         <ArticleCard
           key={a.id}
           article={a}
+          focused={focusedId === a.id}
           onFilterByCategory={onFilterByCategory}
           onFilterByFeedId={onFilterByFeedId}
         />

--- a/apps/web/client/components/HelpModal.tsx
+++ b/apps/web/client/components/HelpModal.tsx
@@ -1,0 +1,50 @@
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+const SHORTCUTS: { key: string; label: string }[] = [
+  { key: "j / ↓", label: "次の記事に移動" },
+  { key: "k / ↑", label: "前の記事に移動" },
+  { key: "o / Enter", label: "フォーカス中の記事を別タブで開く" },
+  { key: "m", label: "既読 / 未読をトグル" },
+  { key: "/", label: "検索ボックスにフォーカス" },
+  { key: "r", label: "フィルタをすべてクリア" },
+  { key: "?", label: "このヘルプを開く / 閉じる" },
+  { key: "Esc", label: "ヘルプを閉じる / 検索ボックスから離れる" },
+];
+
+export function HelpModal({ open, onClose }: Props) {
+  if (!open) return null;
+
+  return (
+    <div
+      className="help-overlay"
+      onClick={onClose}
+      role="dialog"
+      aria-modal
+      aria-label="キーボードショートカット"
+    >
+      <div className="help-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="help-modal-header">
+          <h2>キーボードショートカット</h2>
+          <button type="button" className="help-close" onClick={onClose} aria-label="閉じる">
+            ✕
+          </button>
+        </div>
+        <table className="help-table">
+          <tbody>
+            {SHORTCUTS.map(({ key, label }) => (
+              <tr key={key}>
+                <td>
+                  <kbd>{key}</kbd>
+                </td>
+                <td>{label}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/client/components/SearchInput.tsx
+++ b/apps/web/client/components/SearchInput.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { forwardRef, useEffect, useState } from "react";
 
 interface Props {
   value: string;
@@ -6,7 +6,10 @@ interface Props {
   delayMs?: number;
 }
 
-export function SearchInput({ value, onChange, delayMs = 300 }: Props) {
+export const SearchInput = forwardRef<HTMLInputElement, Props>(function SearchInput(
+  { value, onChange, delayMs = 300 },
+  ref,
+) {
   const [local, setLocal] = useState(value);
 
   useEffect(() => {
@@ -23,6 +26,7 @@ export function SearchInput({ value, onChange, delayMs = 300 }: Props) {
 
   return (
     <input
+      ref={ref}
       type="search"
       className="search-input"
       placeholder="記事を検索 (タイトル / 概要)"
@@ -30,4 +34,4 @@ export function SearchInput({ value, onChange, delayMs = 300 }: Props) {
       onChange={(e) => setLocal(e.target.value)}
     />
   );
-}
+});

--- a/apps/web/client/hooks/useKeyboardShortcuts.ts
+++ b/apps/web/client/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,127 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Article } from "../types/api";
+
+interface Options {
+  items: Article[];
+  onActivate: (id: number, url: string) => void;
+  onToggleRead: (id: number) => void;
+  onSearchFocus: () => void;
+  onClearAll: () => void;
+  onShowHelp: () => void;
+}
+
+function isInputFocused(): boolean {
+  const t = document.activeElement;
+  if (!t) return false;
+  return (
+    t instanceof HTMLInputElement ||
+    t instanceof HTMLTextAreaElement ||
+    t instanceof HTMLSelectElement ||
+    (t as HTMLElement).isContentEditable
+  );
+}
+
+export function useKeyboardShortcuts({
+  items,
+  onActivate,
+  onToggleRead,
+  onSearchFocus,
+  onClearAll,
+  onShowHelp,
+}: Options): { focusedId: number | null } {
+  const [focusedId, setFocusedId] = useState<number | null>(null);
+  // ref で items を追跡して keydown handler の closure staleness を避ける
+  const itemsRef = useRef(items);
+  useEffect(() => {
+    itemsRef.current = items;
+  }, [items]);
+
+  const focusedIdRef = useRef(focusedId);
+  useEffect(() => {
+    focusedIdRef.current = focusedId;
+  }, [focusedId]);
+
+  const moveFocus = useCallback((dir: 1 | -1) => {
+    const list = itemsRef.current;
+    if (list.length === 0) return;
+    const current = focusedIdRef.current;
+    const idx = list.findIndex((a) => a.id === current);
+    let next: number;
+    if (idx === -1) {
+      next = dir === 1 ? 0 : list.length - 1;
+    } else {
+      next = Math.max(0, Math.min(list.length - 1, idx + dir));
+    }
+    const nextId = list[next].id;
+    setFocusedId(nextId);
+    // DOM element を scroll into view
+    const el = document.querySelector<HTMLElement>(`[data-article-id="${nextId}"]`);
+    el?.scrollIntoView({ block: "nearest" });
+  }, []);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const inInput = isInputFocused();
+
+      // Esc は入力欄でも常に処理 (blur / close help)
+      if (e.key === "Escape") {
+        if (inInput) {
+          (document.activeElement as HTMLElement).blur();
+        } else {
+          onShowHelp(); // HelpModal が open なら close する (toggle)
+        }
+        return;
+      }
+
+      if (inInput) return;
+
+      switch (e.key) {
+        case "j":
+        case "ArrowDown":
+          e.preventDefault();
+          moveFocus(1);
+          break;
+        case "k":
+        case "ArrowUp":
+          e.preventDefault();
+          moveFocus(-1);
+          break;
+        case "o":
+        case "Enter": {
+          const id = focusedIdRef.current;
+          if (id === null) break;
+          const article = itemsRef.current.find((a) => a.id === id);
+          if (article) onActivate(id, article.url);
+          break;
+        }
+        case "m": {
+          const id = focusedIdRef.current;
+          if (id !== null) onToggleRead(id);
+          break;
+        }
+        case "/":
+          e.preventDefault();
+          onSearchFocus();
+          break;
+        case "r":
+          onClearAll();
+          break;
+        case "?":
+          onShowHelp();
+          break;
+      }
+    };
+
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [moveFocus, onActivate, onToggleRead, onSearchFocus, onClearAll, onShowHelp]);
+
+  // items が変わったとき、focusedId が存在しなくなっていたらリセット
+  useEffect(() => {
+    if (focusedId !== null && !items.some((a) => a.id === focusedId)) {
+      setFocusedId(null);
+    }
+  }, [items, focusedId]);
+
+  return { focusedId };
+}

--- a/apps/web/client/index.css
+++ b/apps/web/client/index.css
@@ -207,6 +207,12 @@ a:hover {
   opacity: 0.6;
 }
 
+/* キーボードショートカットで選択中のカード */
+.article-card.focused {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 .article-card-title-row {
   display: flex;
   align-items: flex-start;
@@ -406,4 +412,79 @@ a:hover {
 .load-more:disabled {
   opacity: 0.5;
   cursor: progress;
+}
+
+/* キーボードショートカット ヘルプモーダル */
+.help-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.help-modal {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 20px 24px;
+  min-width: 320px;
+  max-width: 480px;
+  width: 90%;
+}
+
+.help-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.help-modal-header h2 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.help-close {
+  background: none;
+  border: none;
+  color: var(--fg-muted);
+  font-size: 1rem;
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.help-close:hover {
+  color: var(--fg);
+  background: var(--bg-elev-2);
+}
+
+.help-table {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 0.9rem;
+}
+
+.help-table td {
+  padding: 5px 8px;
+  vertical-align: middle;
+}
+
+.help-table td:first-child {
+  width: 40%;
+  white-space: nowrap;
+}
+
+kbd {
+  display: inline-block;
+  padding: 1px 6px;
+  background: var(--bg-elev-2);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  font-size: 0.8rem;
 }


### PR DESCRIPTION
## Summary

- Adds `useKeyboardShortcuts` hook that listens to `document.keydown` and manages `focusedId` state
- Adds `HelpModal` component (div-based overlay) listing all shortcuts
- `j`/`k` (or arrow keys): move focus between article cards with `scrollIntoView`
- `o`/`Enter`: open focused article in new tab, fires `markRead`
- `m`: toggle read/unread for focused article
- `/`: focus the search box
- `r`: clear all filters (category, lang, feedId, q, dates, unreadOnly)
- `?`: toggle help modal
- `Esc`: close help modal or blur search input
- Shortcuts disabled while `<input>`, `<textarea>`, `<select>`, or `contentEditable` is focused (`Esc` always works)
- `ArticleCard` gains `data-article-id`, `tabIndex={-1}`, and `.focused` CSS class (`outline: 2px solid var(--accent)`)
- `SearchInput` converted to `forwardRef` to allow programmatic focus

## Test plan

- [ ] `pnpm build` passes (build confirms no TS errors)
- [ ] `pnpm check` passes (0 lint errors, warnings are pre-existing)
- [ ] `pnpm test` passes (71/71 tests green)
- [ ] Manual: press `j`/`k` to navigate cards, `o`/`Enter` to open, `m` to toggle read, `/` to focus search, `r` to clear filters, `?` to open help modal

Closes #29