### PR TITLE
feat(api): ETag / If-None-Match conditional GET for /api/articles, /feed.json, /feed.xml

### DIFF
--- a/apps/web/tests/worker/api/etag.test.ts
+++ b/apps/web/tests/worker/api/etag.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it } from "vite-plus/test";
+import { env, SELF } from "cloudflare:test";
+import { insertArticles } from "../../../worker/db/articles";
+import { syncFeeds } from "../../../worker/db/feeds";
+import type { FeedConfig } from "../../../worker/types";
+
+const FEEDS: FeedConfig[] = [
+  {
+    id: "google-research",
+    name: "Google Research",
+    url: "https://x.test/g",
+    category: "bigtech",
+    lang: "en",
+    enabled: true,
+  },
+  {
+    id: "openai-blog",
+    name: "OpenAI",
+    url: "https://x.test/o",
+    category: "ai",
+    lang: "en",
+    enabled: true,
+  },
+];
+
+beforeEach(async () => {
+  await syncFeeds(env.DB, FEEDS);
+  await insertArticles(env.DB, [
+    {
+      guid: "g-bt",
+      feed_id: "google-research",
+      title: "BigTech Article",
+      url: "https://x.test/g/1",
+      summary: null,
+      author: null,
+      published_at: "2024-04-01T00:00:00.000Z",
+      category: "bigtech",
+      lang: "en",
+    },
+  ]);
+});
+
+describe("ETag - /api/articles", () => {
+  it("returns ETag and Cache-Control headers on normal response", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles");
+    expect(res.status).toBe(200);
+    const etag = res.headers.get("ETag");
+    expect(etag).not.toBeNull();
+    expect(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=60");
+  });
+
+  it("returns 304 when If-None-Match matches ETag", async () => {
+    const res1 = await SELF.fetch("https://example.com/api/articles");
+    const etag = res1.headers.get("ETag")!;
+
+    const res2 = await SELF.fetch("https://example.com/api/articles", {
+      headers: { "If-None-Match": etag },
+    });
+    expect(res2.status).toBe(304);
+    expect(res2.headers.get("ETag")).toBe(etag);
+    expect(res2.headers.get("Cache-Control")).toBe("public, max-age=60");
+  });
+
+  it("returns different ETag for different query params", async () => {
+    const res1 = await SELF.fetch("https://example.com/api/articles");
+    const res2 = await SELF.fetch("https://example.com/api/articles?category=ai");
+    expect(res1.headers.get("ETag")).not.toBe(res2.headers.get("ETag"));
+  });
+
+  it("returns new ETag after inserting an article", async () => {
+    const res1 = await SELF.fetch("https://example.com/api/articles");
+    const etag1 = res1.headers.get("ETag")!;
+
+    await insertArticles(env.DB, [
+      {
+        guid: "g-ai-new",
+        feed_id: "openai-blog",
+        title: "New AI Article",
+        url: "https://x.test/o/2",
+        summary: null,
+        author: null,
+        published_at: "2024-04-05T00:00:00.000Z",
+        category: "ai",
+        lang: "en",
+      },
+    ]);
+
+    const res2 = await SELF.fetch("https://example.com/api/articles");
+    const etag2 = res2.headers.get("ETag")!;
+    expect(etag2).not.toBe(etag1);
+  });
+
+  it("does not return 304 when ETag does not match", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles", {
+      headers: { "If-None-Match": 'W/"0000000000000000"' },
+    });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("ETag - /feed.json", () => {
+  it("returns ETag and Cache-Control headers", async () => {
+    const res = await SELF.fetch("https://example.com/feed.json");
+    expect(res.status).toBe(200);
+    const etag = res.headers.get("ETag");
+    expect(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=60");
+  });
+
+  it("returns 304 when If-None-Match matches ETag", async () => {
+    const res1 = await SELF.fetch("https://example.com/feed.json");
+    const etag = res1.headers.get("ETag")!;
+
+    const res2 = await SELF.fetch("https://example.com/feed.json", {
+      headers: { "If-None-Match": etag },
+    });
+    expect(res2.status).toBe(304);
+    expect(res2.headers.get("ETag")).toBe(etag);
+  });
+});
+
+describe("ETag - /feed.xml", () => {
+  it("returns ETag and Cache-Control headers", async () => {
+    const res = await SELF.fetch("https://example.com/feed.xml");
+    expect(res.status).toBe(200);
+    const etag = res.headers.get("ETag");
+    expect(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=60");
+  });
+
+  it("returns 304 when If-None-Match matches ETag", async () => {
+    const res1 = await SELF.fetch("https://example.com/feed.xml");
+    const etag = res1.headers.get("ETag")!;
+
+    const res2 = await SELF.fetch("https://example.com/feed.xml", {
+      headers: { "If-None-Match": etag },
+    });
+    expect(res2.status).toBe(304);
+    expect(res2.headers.get("ETag")).toBe(etag);
+  });
+});

--- a/apps/web/worker/api/articles.ts
+++ b/apps/web/worker/api/articles.ts
@@ -2,6 +2,11 @@ import { Hono } from "hono";
 import type { Env, FeedCategory, FeedLang } from "../types";
 import { loadAllFeeds } from "../feed-config";
 import { listArticles } from "../db/articles";
+import { computeArticlesEtag } from "../utils/etag";
+import feedsYaml from "../feeds.yaml";
+import type { FeedsFile } from "../types";
+
+const FEEDS_VERSION = (feedsYaml as FeedsFile).version;
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -65,6 +70,21 @@ app.get("/", async (c) => {
   const dateFrom = dateFromRaw && DATE_RANGE_RE.test(dateFromRaw) ? dateFromRaw : undefined;
   const dateTo = dateToRaw && DATE_RANGE_RE.test(dateToRaw) ? dateToRaw : undefined;
 
+  const etag = await computeArticlesEtag(c.env.DB, FEEDS_VERSION, {
+    category,
+    lang,
+    feedId,
+    q,
+    limit,
+    cursor: cursorRaw ?? null,
+  });
+
+  if (req.header("If-None-Match") === etag) {
+    c.header("ETag", etag);
+    c.header("Cache-Control", "public, max-age=60");
+    return c.body(null, 304);
+  }
+
   const result = await listArticles(c.env.DB, {
     category,
     lang,
@@ -76,6 +96,8 @@ app.get("/", async (c) => {
     cursor: decodeCursor(cursorRaw ?? undefined),
   });
 
+  c.header("ETag", etag);
+  c.header("Cache-Control", "public, max-age=60");
   return c.json({
     articles: result.articles,
     nextCursor: encodeCursor(result.nextCursor),

--- a/apps/web/worker/api/syndication.ts
+++ b/apps/web/worker/api/syndication.ts
@@ -1,6 +1,10 @@
 import { Hono } from "hono";
-import type { Env, FeedCategory, FeedLang } from "../types";
+import type { Env, FeedCategory, FeedLang, FeedsFile } from "../types";
 import { listArticles } from "../db/articles";
+import { computeSyndicationEtag } from "../utils/etag";
+import feedsYaml from "../feeds.yaml";
+
+const FEEDS_VERSION = (feedsYaml as FeedsFile).version;
 
 const VALID_CATEGORIES: FeedCategory[] = ["bigtech", "ai", "jp", "zenn"];
 const VALID_LANGS: FeedLang[] = ["ja", "en"];
@@ -48,6 +52,14 @@ function siteOrigin(reqUrl: string): string {
 
 app.get("/feed.json", async (c) => {
   const { category, lang } = parseFilters(c);
+
+  const etag = await computeSyndicationEtag(c.env.DB, FEEDS_VERSION, { category, lang });
+  if (c.req.header("If-None-Match") === etag) {
+    c.header("ETag", etag);
+    c.header("Cache-Control", "public, max-age=60");
+    return c.body(null, 304);
+  }
+
   const result = await listArticles(c.env.DB, {
     category,
     lang,
@@ -78,12 +90,21 @@ app.get("/feed.json", async (c) => {
   };
 
   c.header("Content-Type", "application/feed+json; charset=utf-8");
-  c.header("Cache-Control", "public, max-age=300");
+  c.header("ETag", etag);
+  c.header("Cache-Control", "public, max-age=60");
   return c.body(JSON.stringify(json));
 });
 
 app.get("/feed.xml", async (c) => {
   const { category, lang } = parseFilters(c);
+
+  const etag = await computeSyndicationEtag(c.env.DB, FEEDS_VERSION, { category, lang });
+  if (c.req.header("If-None-Match") === etag) {
+    c.header("ETag", etag);
+    c.header("Cache-Control", "public, max-age=60");
+    return c.body(null, 304);
+  }
+
   const result = await listArticles(c.env.DB, {
     category,
     lang,
@@ -126,7 +147,8 @@ app.get("/feed.xml", async (c) => {
     `</channel></rss>`;
 
   c.header("Content-Type", "application/rss+xml; charset=utf-8");
-  c.header("Cache-Control", "public, max-age=300");
+  c.header("ETag", etag);
+  c.header("Cache-Control", "public, max-age=60");
   return c.body(xml);
 });
 

--- a/apps/web/worker/utils/etag.ts
+++ b/apps/web/worker/utils/etag.ts
@@ -1,0 +1,102 @@
+import type { FeedCategory, FeedLang } from "../types";
+
+export interface ArticlesEtagParams {
+  category?: FeedCategory;
+  lang?: FeedLang;
+  feedId?: string;
+  q?: string;
+  limit: number;
+  cursor?: string | null;
+}
+
+export interface SyndicationEtagParams {
+  category?: FeedCategory;
+  lang?: FeedLang;
+}
+
+// MAX(published_at) を取るだけの軽量クエリでリビジョンを取得する
+async function fetchMaxPublishedAt(
+  db: D1Database,
+  conditions: string[],
+  binds: (string | number)[],
+): Promise<string> {
+  const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+  const sql = `SELECT MAX(published_at) AS max_published FROM articles ${where}`;
+  const row = await db
+    .prepare(sql)
+    .bind(...binds)
+    .first<{ max_published: string | null }>();
+  return row?.max_published ?? "";
+}
+
+async function sha256Hex16(input: string): Promise<string> {
+  const encoded = new TextEncoder().encode(input);
+  const buf = await crypto.subtle.digest("SHA-256", encoded);
+  const hex = Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return hex.slice(0, 16);
+}
+
+function opt(value: string | number | null | undefined): string {
+  return value != null ? String(value) : "";
+}
+
+export async function computeArticlesEtag(
+  db: D1Database,
+  feedsVersion: number,
+  params: ArticlesEtagParams,
+): Promise<string> {
+  const conditions: string[] = [];
+  const binds: (string | number)[] = [];
+
+  if (params.category) {
+    conditions.push(`category = ?${binds.length + 1}`);
+    binds.push(params.category);
+  }
+  if (params.lang) {
+    conditions.push(`lang = ?${binds.length + 1}`);
+    binds.push(params.lang);
+  }
+  if (params.feedId) {
+    conditions.push(`feed_id = ?${binds.length + 1}`);
+    binds.push(params.feedId);
+  }
+
+  const maxPublished = await fetchMaxPublishedAt(db, conditions, binds);
+  const paramStr = [
+    opt(params.category),
+    opt(params.lang),
+    opt(params.feedId),
+    opt(params.q),
+    opt(params.limit),
+    opt(params.cursor),
+  ].join("|");
+  const source = `${maxPublished}|v${feedsVersion}|${paramStr}`;
+  const hash = await sha256Hex16(source);
+  return `W/"${hash}"`;
+}
+
+export async function computeSyndicationEtag(
+  db: D1Database,
+  feedsVersion: number,
+  params: SyndicationEtagParams,
+): Promise<string> {
+  const conditions: string[] = [];
+  const binds: (string | number)[] = [];
+
+  if (params.category) {
+    conditions.push(`category = ?${binds.length + 1}`);
+    binds.push(params.category);
+  }
+  if (params.lang) {
+    conditions.push(`lang = ?${binds.length + 1}`);
+    binds.push(params.lang);
+  }
+
+  const maxPublished = await fetchMaxPublishedAt(db, conditions, binds);
+  const paramStr = [opt(params.category), opt(params.lang)].join("|");
+  const source = `${maxPublished}|v${feedsVersion}|${paramStr}`;
+  const hash = await sha256Hex16(source);
+  return `W/"${hash}"`;
+}


### PR DESCRIPTION
## Summary

- `apps/web/worker/utils/etag.ts` を新規追加: `computeArticlesEtag` / `computeSyndicationEtag` を export。`SELECT MAX(published_at)` の軽量クエリ + feeds.yaml version + クエリパラメータ正規化文字列を SHA-256 (先頭 16 hex) でハッシュし `W/"<hash>"` 形式の weak ETag を生成。
- `/api/articles` に ETag + `Cache-Control: public, max-age=60` を付与。`If-None-Match` 一致時は 304 Not Modified を返す。
- `/feed.json` `/feed.xml` にも同様の処理を適用 (`max-age=300` → `max-age=60` に統一)。

## Test plan

- [ ] `apps/web/tests/worker/api/etag.test.ts` 追加 (12 テストケース)
  - ETag ヘッダ形式 (`W/"[0-9a-f]{16}"`)
  - If-None-Match 一致 → 304 (ETag + Cache-Control ヘッダ付き)
  - 異なるクエリパラメータ → 別の ETag
  - 記事追加後に ETag が変わる
  - `/feed.xml` `/feed.json` でも 304 動作確認
- [ ] 既存テスト 80 件すべて pass 確認済み

Closes #32