### PR TITLE
feat(collector): emit events to Analytics Engine per feed collection

### DIFF
--- a/apps/web/tests/worker/collector/metrics.test.ts
+++ b/apps/web/tests/worker/collector/metrics.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import { writeCollectorEvent } from "../../../worker/collector/metrics";
+import type { Env } from "../../../worker/types";
+
+function makeEnv(writeDataPoint?: ReturnType<typeof vi.fn>): Env {
+  const ae = writeDataPoint ? { writeDataPoint } : undefined;
+  return {
+    DB: {} as unknown as D1Database,
+    ASSETS: {} as unknown as Fetcher,
+    COLLECTOR_CONCURRENCY: "4",
+    COLLECTOR_TIMEOUT_MS: "10000",
+    COLLECTOR_RETRIES: "2",
+    SUMMARY_MAX_LENGTH: "500",
+    RETENTION_DAYS: "90",
+    CORS_ALLOWED_ORIGINS: "*",
+    COLLECTOR_AE: ae as unknown as AnalyticsEngineDataset | undefined,
+  };
+}
+
+describe("writeCollectorEvent", () => {
+  it("calls writeDataPoint with correct blobs/doubles/indexes on ok status", () => {
+    const writeDataPoint = vi.fn<() => void>();
+    const env = makeEnv(writeDataPoint);
+
+    writeCollectorEvent(env, { feedId: "feed-a", status: "ok", ms: 123, statusCode: 200 });
+
+    expect(writeDataPoint).toHaveBeenCalledTimes(1);
+    expect(writeDataPoint).toHaveBeenCalledWith({
+      blobs: ["feed-a", "ok"],
+      doubles: [123, 200],
+      indexes: ["feed-a"],
+    });
+  });
+
+  it("calls writeDataPoint with correct blobs/doubles/indexes on error status", () => {
+    const writeDataPoint = vi.fn<() => void>();
+    const env = makeEnv(writeDataPoint);
+
+    writeCollectorEvent(env, { feedId: "feed-b", status: "error", ms: 456, statusCode: 503 });
+
+    expect(writeDataPoint).toHaveBeenCalledTimes(1);
+    expect(writeDataPoint).toHaveBeenCalledWith({
+      blobs: ["feed-b", "error"],
+      doubles: [456, 503],
+      indexes: ["feed-b"],
+    });
+  });
+
+  it("calls writeDataPoint with correct blobs/doubles/indexes on not_modified status", () => {
+    const writeDataPoint = vi.fn<() => void>();
+    const env = makeEnv(writeDataPoint);
+
+    writeCollectorEvent(env, {
+      feedId: "feed-c",
+      status: "not_modified",
+      ms: 50,
+      statusCode: 304,
+    });
+
+    expect(writeDataPoint).toHaveBeenCalledTimes(1);
+    expect(writeDataPoint).toHaveBeenCalledWith({
+      blobs: ["feed-c", "not_modified"],
+      doubles: [50, 304],
+      indexes: ["feed-c"],
+    });
+  });
+
+  it("does not throw when COLLECTOR_AE binding is undefined", () => {
+    const env = makeEnv(undefined);
+
+    expect(() => {
+      writeCollectorEvent(env, { feedId: "feed-d", status: "ok", ms: 10, statusCode: 200 });
+    }).not.toThrow();
+  });
+
+  it("does not throw when writeDataPoint throws internally", () => {
+    const writeDataPoint = vi.fn<() => void>().mockImplementation(() => {
+      throw new Error("AE unavailable");
+    });
+    const env = makeEnv(writeDataPoint);
+
+    expect(() => {
+      writeCollectorEvent(env, { feedId: "feed-e", status: "error", ms: 99, statusCode: 0 });
+    }).not.toThrow();
+  });
+});

--- a/apps/web/worker/collector/index.ts
+++ b/apps/web/worker/collector/index.ts
@@ -2,6 +2,7 @@ import type { Env, FeedConfig } from "../types";
 import { loadEnabledFeeds } from "../feed-config";
 import { parseFeed } from "./rssParser";
 import { buildGuids } from "./deduplicator";
+import { writeCollectorEvent } from "./metrics";
 import { deleteOlderThan, insertArticles, type InsertableArticle } from "../db/articles";
 import {
   loadFeedHeaders,
@@ -175,6 +176,7 @@ async function collectFeed(
   maxRetries: number,
 ): Promise<CollectResult> {
   const fetchedAt = new Date().toISOString();
+  const t0 = performance.now();
   try {
     // 前回の conditional GET ヘッダを読み込んでリクエストに付与する
     const savedHeaders = await loadFeedHeaders(env.DB, feed.id);
@@ -186,6 +188,12 @@ async function collectFeed(
     // 304 Not Modified: parse/insert をスキップし last_fetched_at だけ更新する
     if (result.notModified) {
       await recordFetchSuccess(env.DB, feed.id, fetchedAt, 0, "not_modified");
+      writeCollectorEvent(env, {
+        feedId: feed.id,
+        status: "not_modified",
+        ms: Math.round(performance.now() - t0),
+        statusCode: 304,
+      });
       return { feedId: feed.id, status: "not_modified", inserted: 0, parsed: 0 };
     }
 
@@ -223,6 +231,12 @@ async function collectFeed(
 
     const inserted = await insertArticles(env.DB, rows);
     await recordFetchSuccess(env.DB, feed.id, fetchedAt, inserted);
+    writeCollectorEvent(env, {
+      feedId: feed.id,
+      status: "ok",
+      ms: Math.round(performance.now() - t0),
+      statusCode: 200,
+    });
     return { feedId: feed.id, status: "ok", inserted, parsed: allItems.length };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -231,6 +245,15 @@ async function collectFeed(
     } catch (logErr) {
       console.error(`Failed to record error for ${feed.id}`, logErr);
     }
+    // HTTP エラーコードをメッセージから抽出する (例: "HTTP 503 ...")
+    const statusMatch = /^HTTP (\d+)/.exec(message);
+    const statusCode = statusMatch ? Number(statusMatch[1]) : 0;
+    writeCollectorEvent(env, {
+      feedId: feed.id,
+      status: "error",
+      ms: Math.round(performance.now() - t0),
+      statusCode,
+    });
     return { feedId: feed.id, status: "error", inserted: 0, parsed: 0, error: message };
   }
 }

--- a/apps/web/worker/collector/metrics.ts
+++ b/apps/web/worker/collector/metrics.ts
@@ -1,0 +1,21 @@
+import type { Env } from "../types";
+
+export interface CollectorEvent {
+  feedId: string;
+  status: "ok" | "error" | "not_modified";
+  ms: number;
+  statusCode: number;
+}
+
+export function writeCollectorEvent(env: Env, ev: CollectorEvent): void {
+  if (!env.COLLECTOR_AE) return;
+  try {
+    env.COLLECTOR_AE.writeDataPoint({
+      blobs: [ev.feedId, ev.status],
+      doubles: [ev.ms, ev.statusCode],
+      indexes: [ev.feedId],
+    });
+  } catch (e) {
+    console.warn("[collector] AE writeDataPoint failed", e);
+  }
+}

--- a/apps/web/worker/types.ts
+++ b/apps/web/worker/types.ts
@@ -12,6 +12,8 @@ export interface Env {
   ADMIN_TOKEN_NEXT?: string;
   // preview 環境では "1" をセット。admin/collector を no-op にする。
   READONLY?: string;
+  // preview 環境では binding が存在しない場合があるため optional
+  COLLECTOR_AE?: AnalyticsEngineDataset;
 }
 
 export type FeedCategory = "bigtech" | "ai" | "jp" | "zenn";

--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -29,6 +29,10 @@ RETENTION_DAYS = "90"
 # カンマ区切りで許可する Origin を列挙。* は非推奨 (明示的 origin で制限する)
 CORS_ALLOWED_ORIGINS = "https://tech-news-bot.rikeda71.workers.dev"
 
+[[analytics_engine_datasets]]
+binding = "COLLECTOR_AE"
+dataset = "tnb_collector_events"
+
 # preview 環境: PR ごとに動的な Worker 名は wrangler CLI の --name で指定する。
 # D1 は本番と同じ DB を使い、READONLY=1 で admin/collector を無効化する。
 [env.preview]


### PR DESCRIPTION
## Summary

- `wrangler.toml` に `[[analytics_engine_datasets]]` binding (`COLLECTOR_AE` / `tnb_collector_events`) を追加
- `worker/types.ts` の `Env` に `COLLECTOR_AE?: AnalyticsEngineDataset` を追加 (preview 環境では省略可)
- `worker/collector/metrics.ts` を新規作成し `writeCollectorEvent` を実装
- `worker/collector/index.ts` の各ブランチ (ok / error / not_modified) で `writeCollectorEvent` を呼ぶよう修正
- `tests/worker/collector/metrics.test.ts` を追加し全パスをカバー

## Test plan

- [ ] `pnpm build` pass
- [ ] `pnpm check` pass (0 errors)
- [ ] `pnpm test` pass (95 tests)
- [ ] CI green

Closes #26