### PR TITLE
feat(client): add starred articles feature with localStorage

### DIFF
--- a/apps/web/client/App.tsx
+++ b/apps/web/client/App.tsx
@@ -8,6 +8,7 @@ import { useArticles } from "./hooks/useArticles";
 import { useFeeds } from "./hooks/useFeeds";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { useReadState } from "./hooks/useReadState";
+import { useStarredState } from "./hooks/useStarredState";
 import { useStats } from "./hooks/useStats";
 import { useTheme } from "./hooks/useTheme";
 import type { FeedCategory, FeedLang } from "./types/api";
@@ -33,6 +34,7 @@ function readFromUrl(): {
   dateFrom: string;
   dateTo: string;
   unreadOnly: boolean;
+  starredOnly: boolean;
 } {
   const params = new URLSearchParams(window.location.search);
   return {
@@ -43,6 +45,7 @@ function readFromUrl(): {
     dateFrom: params.get("date_from") ?? "",
     dateTo: params.get("date_to") ?? "",
     unreadOnly: params.get("unread") === "1",
+    starredOnly: params.get("starred") === "1",
   };
 }
 
@@ -54,6 +57,7 @@ function buildSearch(
   dateFrom: string,
   dateTo: string,
   unreadOnly: boolean,
+  starredOnly: boolean,
 ): string {
   const params = new URLSearchParams();
   if (category) params.set("category", category);
@@ -64,6 +68,7 @@ function buildSearch(
   if (dateTo) params.set("date_to", dateTo);
   // true のときだけ付ける
   if (unreadOnly) params.set("unread", "1");
+  if (starredOnly) params.set("starred", "1");
   const s = params.toString();
   return s ? `?${s}` : window.location.pathname;
 }
@@ -76,6 +81,7 @@ export default function App() {
   const [dateFrom, setDateFrom] = useState<string>(() => readFromUrl().dateFrom);
   const [dateTo, setDateTo] = useState<string>(() => readFromUrl().dateTo);
   const [unreadOnly, setUnreadOnly] = useState<boolean>(() => readFromUrl().unreadOnly);
+  const [starredOnly, setStarredOnly] = useState<boolean>(() => readFromUrl().starredOnly);
   const [helpOpen, setHelpOpen] = useState(false);
 
   const searchRef = useRef<HTMLInputElement>(null);
@@ -84,6 +90,7 @@ export default function App() {
   const { feeds } = useFeeds();
   const { stats } = useStats();
   const { isRead, markRead, markUnread } = useReadState();
+  const { isStarred } = useStarredState();
 
   // popstate でブラウザ戻る/進むに追従する
   useEffect(() => {
@@ -96,6 +103,7 @@ export default function App() {
       setDateFrom(next.dateFrom);
       setDateTo(next.dateTo);
       setUnreadOnly(next.unreadOnly);
+      setStarredOnly(next.starredOnly);
     };
     window.addEventListener("popstate", onPop);
     return () => window.removeEventListener("popstate", onPop);
@@ -111,6 +119,7 @@ export default function App() {
       nextDateFrom: string,
       nextDateTo: string,
       nextUnreadOnly: boolean,
+      nextStarredOnly: boolean,
     ) => {
       const next = buildSearch(
         nextCategory,
@@ -120,8 +129,18 @@ export default function App() {
         nextDateFrom,
         nextDateTo,
         nextUnreadOnly,
+        nextStarredOnly,
       );
-      const current = buildSearch(category, lang, feedId, q, dateFrom, dateTo, unreadOnly);
+      const current = buildSearch(
+        category,
+        lang,
+        feedId,
+        q,
+        dateFrom,
+        dateTo,
+        unreadOnly,
+        starredOnly,
+      );
       // 同じ URL なら重複履歴を作らない
       if (next !== current) {
         window.history.pushState(null, "", next);
@@ -133,56 +152,67 @@ export default function App() {
       setDateFrom(nextDateFrom);
       setDateTo(nextDateTo);
       setUnreadOnly(nextUnreadOnly);
+      setStarredOnly(nextStarredOnly);
     },
-    [category, lang, feedId, q, dateFrom, dateTo, unreadOnly],
+    [category, lang, feedId, q, dateFrom, dateTo, unreadOnly, starredOnly],
   );
 
   const handleCategoryChange = useCallback(
-    (v: FeedCategory | "") => pushFilter(v, lang, v ? feedId : "", q, dateFrom, dateTo, unreadOnly),
-    [pushFilter, lang, feedId, q, dateFrom, dateTo, unreadOnly],
+    (v: FeedCategory | "") =>
+      pushFilter(v, lang, v ? feedId : "", q, dateFrom, dateTo, unreadOnly, starredOnly),
+    [pushFilter, lang, feedId, q, dateFrom, dateTo, unreadOnly, starredOnly],
   );
 
   const handleLangChange = useCallback(
-    (v: FeedLang | "") => pushFilter(category, v, v ? feedId : "", q, dateFrom, dateTo, unreadOnly),
-    [pushFilter, category, feedId, q, dateFrom, dateTo, unreadOnly],
+    (v: FeedLang | "") =>
+      pushFilter(category, v, v ? feedId : "", q, dateFrom, dateTo, unreadOnly, starredOnly),
+    [pushFilter, category, feedId, q, dateFrom, dateTo, unreadOnly, starredOnly],
   );
 
   const handleFeedChange = useCallback(
-    (id: string) => pushFilter(category, lang, id, q, dateFrom, dateTo, unreadOnly),
-    [pushFilter, category, lang, q, dateFrom, dateTo, unreadOnly],
+    (id: string) => pushFilter(category, lang, id, q, dateFrom, dateTo, unreadOnly, starredOnly),
+    [pushFilter, category, lang, q, dateFrom, dateTo, unreadOnly, starredOnly],
   );
 
   const handleQChange = useCallback(
-    (v: string) => pushFilter(category, lang, feedId, v, dateFrom, dateTo, unreadOnly),
-    [pushFilter, category, lang, feedId, dateFrom, dateTo, unreadOnly],
+    (v: string) => pushFilter(category, lang, feedId, v, dateFrom, dateTo, unreadOnly, starredOnly),
+    [pushFilter, category, lang, feedId, dateFrom, dateTo, unreadOnly, starredOnly],
   );
 
   const handleDateFromChange = useCallback(
-    (v: string) => pushFilter(category, lang, feedId, q, v, dateTo, unreadOnly),
-    [pushFilter, category, lang, feedId, q, dateTo, unreadOnly],
+    (v: string) => pushFilter(category, lang, feedId, q, v, dateTo, unreadOnly, starredOnly),
+    [pushFilter, category, lang, feedId, q, dateTo, unreadOnly, starredOnly],
   );
 
   const handleDateToChange = useCallback(
-    (v: string) => pushFilter(category, lang, feedId, q, dateFrom, v, unreadOnly),
-    [pushFilter, category, lang, feedId, q, dateFrom, unreadOnly],
+    (v: string) => pushFilter(category, lang, feedId, q, dateFrom, v, unreadOnly, starredOnly),
+    [pushFilter, category, lang, feedId, q, dateFrom, unreadOnly, starredOnly],
   );
 
   const handleUnreadOnlyChange = useCallback(
-    (v: boolean) => pushFilter(category, lang, feedId, q, dateFrom, dateTo, v),
-    [pushFilter, category, lang, feedId, q, dateFrom, dateTo],
+    (v: boolean) => pushFilter(category, lang, feedId, q, dateFrom, dateTo, v, starredOnly),
+    [pushFilter, category, lang, feedId, q, dateFrom, dateTo, starredOnly],
   );
 
-  const handleClear = useCallback(() => pushFilter("", "", "", q, "", "", false), [pushFilter, q]);
+  const handleStarredOnlyChange = useCallback(
+    (v: boolean) => pushFilter(category, lang, feedId, q, dateFrom, dateTo, unreadOnly, v),
+    [pushFilter, category, lang, feedId, q, dateFrom, dateTo, unreadOnly],
+  );
+
+  const handleClear = useCallback(
+    () => pushFilter("", "", "", q, "", "", false, false),
+    [pushFilter, q],
+  );
 
   // カード上のバッジ/取得元クリックでフィルタを適用する
   const handleFilterByCategory = useCallback(
-    (c: FeedCategory) => pushFilter(c, lang, "", q, dateFrom, dateTo, unreadOnly),
-    [pushFilter, lang, q, dateFrom, dateTo, unreadOnly],
+    (c: FeedCategory) => pushFilter(c, lang, "", q, dateFrom, dateTo, unreadOnly, starredOnly),
+    [pushFilter, lang, q, dateFrom, dateTo, unreadOnly, starredOnly],
   );
 
   const handleFilterByFeedId = useCallback(
-    (id: string) => pushFilter(category, lang, id, q, dateFrom, dateTo, unreadOnly),
-    [pushFilter, category, lang, q, dateFrom, dateTo, unreadOnly],
+    (id: string) => pushFilter(category, lang, id, q, dateFrom, dateTo, unreadOnly, starredOnly),
+    [pushFilter, category, lang, q, dateFrom, dateTo, unreadOnly, starredOnly],
   );
 
   const query = useMemo(
@@ -206,11 +236,13 @@ export default function App() {
     loadMore,
   } = useArticles(query);
 
-  // 未読フィルタはクライアントサイドで適用 (サーバー API は既読を知らないため)
-  const articles = useMemo(
-    () => (unreadOnly ? allArticles.filter((a) => !isRead(a.id)) : allArticles),
-    [allArticles, unreadOnly, isRead],
-  );
+  // 未読・スターフィルタはクライアントサイドで適用 (サーバー API は既読/スターを知らないため)
+  const articles = useMemo(() => {
+    let filtered = allArticles;
+    if (unreadOnly) filtered = filtered.filter((a) => !isRead(a.id));
+    if (starredOnly) filtered = filtered.filter((a) => isStarred(a.id));
+    return filtered;
+  }, [allArticles, unreadOnly, starredOnly, isRead, isStarred]);
 
   const handleActivate = useCallback(
     (id: number, url: string) => {
@@ -232,7 +264,10 @@ export default function App() {
     searchRef.current?.focus();
   }, []);
 
-  const handleClearAll = useCallback(() => pushFilter("", "", "", "", "", "", false), [pushFilter]);
+  const handleClearAll = useCallback(
+    () => pushFilter("", "", "", "", "", "", false, false),
+    [pushFilter],
+  );
 
   const handleToggleHelp = useCallback(() => setHelpOpen((prev) => !prev), []);
 
@@ -283,12 +318,14 @@ export default function App() {
           dateFrom={dateFrom}
           dateTo={dateTo}
           unreadOnly={unreadOnly}
+          starredOnly={starredOnly}
           onCategoryChange={handleCategoryChange}
           onLangChange={handleLangChange}
           onFeedChange={handleFeedChange}
           onDateFromChange={handleDateFromChange}
           onDateToChange={handleDateToChange}
           onUnreadOnlyChange={handleUnreadOnlyChange}
+          onStarredOnlyChange={handleStarredOnlyChange}
           onClear={handleClear}
         />
       </div>

--- a/apps/web/client/components/ArticleCard.tsx
+++ b/apps/web/client/components/ArticleCard.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useReadState } from "../hooks/useReadState";
+import { useStarredState } from "../hooks/useStarredState";
 import type { Article, FeedCategory } from "../types/api";
 
 interface Props {
@@ -39,8 +40,10 @@ function safeHref(url: string): string {
 
 export function ArticleCard({ article, focused, onFilterByCategory, onFilterByFeedId }: Props) {
   const { isRead, markRead, markUnread } = useReadState();
+  const { isStarred, toggleStar } = useStarredState();
   const [hovered, setHovered] = useState(false);
   const read = isRead(article.id);
+  const starred = isStarred(article.id);
 
   return (
     <article
@@ -60,6 +63,15 @@ export function ArticleCard({ article, focused, onFilterByCategory, onFilterByFe
         >
           {article.title}
         </a>
+        <button
+          type="button"
+          className="star-button"
+          onClick={() => toggleStar(article.id)}
+          aria-label={starred ? "スターを外す" : "スターを付ける"}
+          aria-pressed={starred}
+        >
+          {starred ? "★" : "☆"}
+        </button>
         {/* hover 時に既読 / 未読切り替えボタンを薄く表示 */}
         {hovered && (
           <button

--- a/apps/web/client/components/FilterBar.tsx
+++ b/apps/web/client/components/FilterBar.tsx
@@ -8,12 +8,14 @@ interface Props {
   dateFrom: string;
   dateTo: string;
   unreadOnly: boolean;
+  starredOnly: boolean;
   onCategoryChange: (c: FeedCategory | "") => void;
   onLangChange: (l: FeedLang | "") => void;
   onFeedChange: (id: string) => void;
   onDateFromChange: (v: string) => void;
   onDateToChange: (v: string) => void;
   onUnreadOnlyChange: (v: boolean) => void;
+  onStarredOnlyChange: (v: boolean) => void;
   onClear: () => void;
 }
 
@@ -25,12 +27,14 @@ export function FilterBar({
   dateFrom,
   dateTo,
   unreadOnly,
+  starredOnly,
   onCategoryChange,
   onLangChange,
   onFeedChange,
   onDateFromChange,
   onDateToChange,
   onUnreadOnlyChange,
+  onStarredOnlyChange,
   onClear,
 }: Props) {
   const visibleFeeds = feeds
@@ -43,7 +47,8 @@ export function FilterBar({
     feedId !== "" ||
     dateFrom !== "" ||
     dateTo !== "" ||
-    unreadOnly;
+    unreadOnly ||
+    starredOnly;
 
   return (
     <>
@@ -101,6 +106,15 @@ export function FilterBar({
           onChange={(e) => onUnreadOnlyChange(e.target.checked)}
         />
         未読のみ
+      </label>
+
+      <label className="unread-only-label">
+        <input
+          type="checkbox"
+          checked={starredOnly}
+          onChange={(e) => onStarredOnlyChange(e.target.checked)}
+        />
+        ★のみ
       </label>
 
       {hasFilter && (

--- a/apps/web/client/hooks/useStarredState.ts
+++ b/apps/web/client/hooks/useStarredState.ts
@@ -1,0 +1,74 @@
+import { useCallback, useSyncExternalStore } from "react";
+
+const STORAGE_KEY = "tnb-starred-articles";
+const MAX_IDS = 1000;
+
+function readStorage(): number[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((v): v is number => typeof v === "number");
+  } catch {
+    return [];
+  }
+}
+
+function writeStorage(ids: number[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(ids));
+  } catch {
+    // localStorage が使えない環境では無視
+  }
+}
+
+type Listener = () => void;
+const listeners = new Set<Listener>();
+
+function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+
+  const onStorage = (e: StorageEvent) => {
+    if (e.key === STORAGE_KEY) listener();
+  };
+  window.addEventListener("storage", onStorage);
+
+  return () => {
+    listeners.delete(listener);
+    window.removeEventListener("storage", onStorage);
+  };
+}
+
+function notify(): void {
+  for (const l of listeners) l();
+}
+
+function getSnapshot(): number[] {
+  return readStorage();
+}
+
+export interface StarredStateAPI {
+  isStarred: (id: number) => boolean;
+  toggleStar: (id: number) => void;
+}
+
+export function useStarredState(): StarredStateAPI {
+  const starredIds = useSyncExternalStore(subscribe, getSnapshot, () => []);
+
+  const isStarred = useCallback((id: number) => starredIds.includes(id), [starredIds]);
+
+  const toggleStar = useCallback((id: number) => {
+    const current = readStorage();
+    const already = current.includes(id);
+    if (already) {
+      writeStorage(current.filter((v) => v !== id));
+    } else {
+      // 新規追加は先頭に、LRU 1000 件超過分は破棄
+      writeStorage([id, ...current.filter((v) => v !== id)].slice(0, MAX_IDS));
+    }
+    notify();
+  }, []);
+
+  return { isStarred, toggleStar };
+}

--- a/apps/web/client/index.css
+++ b/apps/web/client/index.css
@@ -227,6 +227,25 @@ a:hover {
   color: var(--fg);
 }
 
+.star-button {
+  flex-shrink: 0;
+  padding: 2px 6px;
+  background: none;
+  color: var(--fg-muted);
+  border: none;
+  font-size: 1rem;
+  font-family: inherit;
+  cursor: pointer;
+  line-height: 1;
+  opacity: 0.5;
+}
+
+.star-button:hover,
+.star-button[aria-pressed="true"] {
+  opacity: 1;
+  color: #d29922;
+}
+
 /* hover 時にだけ表示する既読切り替えボタン */
 .read-toggle {
   flex-shrink: 0;


### PR DESCRIPTION
## Summary

- Add `useStarredState` hook with `useSyncExternalStore` + localStorage (LRU 1000 items, tab-sync via storage event)
- Add star toggle button (★/☆) to `ArticleCard` shown alongside read-toggle
- Add "★のみ" checkbox to `FilterBar` matching `unreadOnly` pattern
- Sync `starredOnly` state with `?starred=1` URL param in `App.tsx`
- Add `.star-button` CSS to `index.css`
- No worker-side changes

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm check` passes (warnings only, all pre-existing)
- [x] `pnpm test` passes (90 tests)
- [ ] Manual: star an article → reload → star persists; `?starred=1` URL reflects state

Closes #70