### PR TITLE
feat(api): enrich /api/health with db summary

### DIFF
--- a/apps/web/tests/worker/api/api.test.ts
+++ b/apps/web/tests/worker/api/api.test.ts
@@ -308,12 +308,27 @@ describe("/api/stats", () => {
 });
 
 describe("/api/health", () => {
-  it("returns ok with article count", async () => {
+  it("returns enriched health response with db summary", async () => {
     const res = await SELF.fetch("https://example.com/api/health");
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { status: string; articles: number };
+    const body = (await res.json()) as {
+      status: string;
+      now: string;
+      db: {
+        articles_total: number;
+        feeds_total: number;
+        feeds_enabled: number;
+        latest_published_at: string | null;
+        latest_fetched_at: string | null;
+      };
+    };
     expect(body.status).toBe("ok");
-    expect(body.articles).toBe(3);
+    expect(typeof body.now).toBe("string");
+    expect(body.db.articles_total).toBe(3);
+    // feeds are synced via syncFeeds in beforeEach (FEEDS has 3 entries, all enabled)
+    expect(body.db.feeds_total).toBeGreaterThanOrEqual(3);
+    expect(body.db.feeds_enabled).toBeGreaterThanOrEqual(3);
+    expect(body.db.latest_published_at).not.toBeNull();
   });
 });
 
@@ -417,9 +432,9 @@ describe("security headers", () => {
 });
 
 describe("cache headers", () => {
-  it("API responses use no-store", async () => {
+  it("/api/health uses public max-age=10", async () => {
     const res = await SELF.fetch("https://example.com/api/health");
-    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=10");
   });
 
   it("static asset under /assets/ uses immutable long max-age", async () => {

--- a/apps/web/tests/worker/api/health.test.ts
+++ b/apps/web/tests/worker/api/health.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vite-plus/test";
+import { env, SELF } from "cloudflare:test";
+import { insertArticles } from "../../../worker/db/articles";
+import { syncFeeds } from "../../../worker/db/feeds";
+import type { FeedConfig } from "../../../worker/types";
+
+const FEED: FeedConfig = {
+  id: "health-test-feed",
+  name: "Health Test Feed",
+  url: "https://x.test/health",
+  category: "bigtech",
+  lang: "en",
+  enabled: true,
+};
+
+describe("/api/health enriched response", () => {
+  it("returns 200 with correct shape when db is empty", async () => {
+    const res = await SELF.fetch("https://example.com/api/health");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      status: string;
+      now: string;
+      db: {
+        articles_total: number;
+        feeds_total: number;
+        feeds_enabled: number;
+        latest_published_at: string | null;
+        latest_fetched_at: string | null;
+      };
+    };
+    expect(body.status).toBe("ok");
+    expect(typeof body.now).toBe("string");
+    // empty db: latest_* must be null
+    expect(body.db.articles_total).toBe(0);
+    expect(body.db.latest_published_at).toBeNull();
+    expect(body.db.latest_fetched_at).toBeNull();
+  });
+
+  it("reflects inserted article and feed counts", async () => {
+    await syncFeeds(env.DB, [FEED]);
+    await insertArticles(env.DB, [
+      {
+        guid: "health-a1",
+        feed_id: "health-test-feed",
+        title: "Health Article",
+        url: "https://x.test/health/1",
+        summary: null,
+        author: null,
+        published_at: "2026-04-28T10:00:00.000Z",
+        category: "bigtech",
+        lang: "en",
+      },
+    ]);
+
+    const res = await SELF.fetch("https://example.com/api/health");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      status: string;
+      now: string;
+      db: {
+        articles_total: number;
+        feeds_total: number;
+        feeds_enabled: number;
+        latest_published_at: string | null;
+        latest_fetched_at: string | null;
+      };
+    };
+    expect(body.status).toBe("ok");
+    expect(body.db.articles_total).toBe(1);
+    expect(body.db.feeds_total).toBe(1);
+    expect(body.db.feeds_enabled).toBe(1);
+    expect(body.db.latest_published_at).toBe("2026-04-28T10:00:00.000Z");
+  });
+
+  it("counts disabled feeds separately", async () => {
+    const disabledFeed: FeedConfig = { ...FEED, id: "health-disabled-feed", enabled: false };
+    await syncFeeds(env.DB, [FEED, disabledFeed]);
+
+    const res = await SELF.fetch("https://example.com/api/health");
+    const body = (await res.json()) as {
+      db: { feeds_total: number; feeds_enabled: number };
+    };
+    expect(body.db.feeds_total).toBe(2);
+    expect(body.db.feeds_enabled).toBe(1);
+  });
+
+  it("sets Cache-Control: public, max-age=10", async () => {
+    const res = await SELF.fetch("https://example.com/api/health");
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=10");
+  });
+});

--- a/apps/web/worker/api/health.ts
+++ b/apps/web/worker/api/health.ts
@@ -1,12 +1,19 @@
 import { Hono } from "hono";
-import type { Env } from "../types";
+import { getHealthSummary } from "../db/health";
+import type { Env, HealthResponse } from "../types";
 
 const app = new Hono<{ Bindings: Env }>();
 
 app.get("/", async (c) => {
   try {
-    const r = await c.env.DB.prepare("SELECT COUNT(*) AS n FROM articles").first<{ n: number }>();
-    return c.json({ status: "ok", articles: r?.n ?? 0 });
+    const db = await getHealthSummary(c.env.DB);
+    const body: HealthResponse = {
+      status: "ok",
+      now: new Date().toISOString(),
+      db,
+    };
+    c.header("Cache-Control", "public, max-age=10");
+    return c.json(body);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return c.json({ status: "degraded", error: message }, 500);

--- a/apps/web/worker/db/health.ts
+++ b/apps/web/worker/db/health.ts
@@ -1,0 +1,42 @@
+export interface HealthSummary {
+  articles_total: number;
+  feeds_total: number;
+  feeds_enabled: number;
+  latest_published_at: string | null;
+  latest_fetched_at: string | null;
+}
+
+/** D1 batch で 1 round trip に集約して health 統計を返す。 */
+export async function getHealthSummary(db: D1Database): Promise<HealthSummary> {
+  const [articleStats, feedStats] = await db.batch([
+    db.prepare(
+      `SELECT COUNT(*) AS articles_total,
+              MAX(published_at) AS latest_published_at,
+              MAX(fetched_at) AS latest_fetched_at
+       FROM articles`,
+    ),
+    db.prepare(
+      `SELECT COUNT(*) AS feeds_total,
+              SUM(CASE WHEN enabled = 1 THEN 1 ELSE 0 END) AS feeds_enabled
+       FROM feeds`,
+    ),
+  ]);
+
+  const aRow = (articleStats.results[0] ?? {}) as {
+    articles_total: number;
+    latest_published_at: string | null;
+    latest_fetched_at: string | null;
+  };
+  const fRow = (feedStats.results[0] ?? {}) as {
+    feeds_total: number;
+    feeds_enabled: number | null;
+  };
+
+  return {
+    articles_total: aRow.articles_total ?? 0,
+    feeds_total: fRow.feeds_total ?? 0,
+    feeds_enabled: fRow.feeds_enabled ?? 0,
+    latest_published_at: aRow.latest_published_at ?? null,
+    latest_fetched_at: aRow.latest_fetched_at ?? null,
+  };
+}

--- a/apps/web/worker/types.ts
+++ b/apps/web/worker/types.ts
@@ -64,3 +64,15 @@ export interface FeedSummary {
   last_status: string | null;
   article_count: number;
 }
+
+export interface HealthResponse {
+  status: "ok" | "degraded";
+  now: string;
+  db: {
+    articles_total: number;
+    feeds_total: number;
+    feeds_enabled: number;
+    latest_published_at: string | null;
+    latest_fetched_at: string | null;
+  };
+}


### PR DESCRIPTION
## Summary
- Add `getHealthSummary(db)` in `apps/web/worker/db/health.ts` using D1 batch API (1 round trip) to collect `articles_total`, `feeds_total`, `feeds_enabled`, `latest_published_at`, `latest_fetched_at`
- Extend `apps/web/worker/api/health.ts` to return the enriched JSON and set `Cache-Control: public, max-age=10`
- Add `HealthResponse` interface to `apps/web/worker/types.ts`
- New test file `apps/web/tests/worker/api/health.test.ts` covering empty-db (null timestamps), insert with values, disabled-feed count split, and cache header assertion
- Update existing `/api/health` and `cache headers` assertions in `api.test.ts` for the new response shape

## Test plan
- [ ] `pnpm build` passes
- [ ] `pnpm check` passes (0 errors)
- [ ] `vp test run` passes (103 tests)
- [ ] CI green on this PR

Closes #76