### PR TITLE
feat: add English engineering blog feeds (discord-engineering)

### DIFF
--- a/apps/web/worker/feeds.yaml
+++ b/apps/web/worker/feeds.yaml
@@ -113,6 +113,13 @@ feeds:
     lang: en
     enabled: true
 
+  - id: discord-engineering
+    name: Discord Blog
+    url: https://discord.com/blog/rss.xml
+    category: bigtech
+    lang: en
+    enabled: true
+
   # ─────────── AI labs ───────────
   - id: openai-blog
     name: OpenAI News


### PR DESCRIPTION
## Summary

Adds verified English engineering blog feeds to `apps/web/worker/feeds.yaml` under the `bigtech` category.

Closes #79

## Added feeds (1)

| id | url | verification |
|---|---|---|
| discord-engineering | https://discord.com/blog/rss.xml | 200 `application/rss+xml` |

## Not added (6)

- `https://stripe.com/blog/feed.rss` — already exists as `stripe-engineering`
- `https://www.datadoghq.com/blog/engineering/feed/` — 404 (alternative `/blog/feed/` also 404)
- `https://vercel.com/blog/feed.xml` — 404 (returns HTML)
- `https://shopify.engineering/blog.atom` — 404 (alternative `/feed` also 404)
- `https://linear.app/blog/rss` — redirects to 404 (returns HTML)
- `https://www.figma.com/blog/feed/atom/` — 404 (alternative `/blog/feed/` returns HTML)

## Verification

- `node tools/validate-feeds.mjs` — discord-engineering: 200 OK (`application/rss+xml`, HEAD)
- All other existing feeds pass (netflix-techblog fails with `fetch failed`, pre-existing issue unrelated to this PR)
- `id` uniqueness confirmed

## Checklist

- [x] URL verified with HEAD: 200 + valid RSS/Atom Content-Type
- [x] `id` is unique across all feeds
- [x] `category: bigtech`, `lang: en`, `enabled: true`
- [x] validate-feeds.mjs pass for discord-engineering