### PR TITLE
feat(skill): add tech-news-search skill with FTS5 keyword search

### DIFF
--- a/.claude/skills/tech-news-digest/SKILL.md
+++ b/.claude/skills/tech-news-digest/SKILL.md
@@ -5,10 +5,11 @@ description: D1 に蓄積された tech blog の記事を「今日 / 今週 / �
 
 # tech-news-digest
 
-## tech-news-weekly との使い分け
+## 他の skill との使い分け
 
 - **tech-news-digest (本 skill)**: 今日・今週・任意期間の記事を素早くリスト形式でまとめる。デイリーチェックや「何があった？」程度の確認に最適。
 - **tech-news-weekly**: 週次・月次を「読み物」として仕上げる。テーマ別ストーリー・前週との比較・カテゴリ間の温度差分析が必要な場合はそちらを使う。
+- **tech-news-search**: 特定キーワードで深掘り検索。「MCP の最近の話題は？」のようなキーワード絞り込みにはこちら。
 
 ## やること
 
@@ -244,3 +245,5 @@ skill を実行したら `runs.md` に結果を追記し、指標が退行して
 - 型: `apps/web/worker/types.ts` (`Article`, `FeedConfig` interface)
 - 評価指標: `.claude/skills/tech-news-digest/EVALUATION.md`
 - 実行ログ: `.claude/skills/tech-news-digest/runs.md`
+- 関連 skill: `.claude/skills/tech-news-weekly/SKILL.md` (週次・月次レポート)
+- 関連 skill: `.claude/skills/tech-news-search/SKILL.md` (キーワード深掘り検索)

--- a/.claude/skills/tech-news-search/SKILL.md
+++ b/.claude/skills/tech-news-search/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: tech-news-search
+description: 特定キーワードで D1 の記事を深掘り検索する skill。"MCP の最近の話題は？" "Rust の記事まとめて" のように特定キーワードで絞り込みたい時に起動する。期間 + カテゴリ + キーワードで FTS5 全文検索し、関連性の高い記事を選定して 2〜3 段落の解説を返す。
+---
+
+# tech-news-search
+
+## 他の skill との使い分け
+
+- **tech-news-digest**: 今日・今週・任意期間の記事を素早くリスト形式でまとめる。特定キーワードでなく「期間」で見たい場合はこちら。
+- **tech-news-weekly**: 週次・月次を「読み物」として仕上げる。ニュースレター的な narrative が必要な場合はこちら。
+- **tech-news-search (本 skill)**: 特定キーワードで深掘り検索。「MCP とは？」「最近の Rust 記事」「LLM inference の話題」のような問い合わせに最適。
+
+## やること
+
+D1 の FTS5 (`articles_fts`, trigram tokenizer) で全文検索し、3 ステージで日本語の深掘り解説を生成する。
+
+## 手順
+
+### Stage 1: Collect — FTS5 で記事を取得
+
+`tools/d1-client/search.mjs` を Node から実行する。
+
+引数:
+
+- `--q=<keyword>` (必須) — 検索キーワード。複数単語はスペース区切りで `"AI agent"` のようにクォート
+- `--since=<today|week|month|N>` (デフォルト `month`) — 対象期間
+- `--target=<local|remote>` (省略時 `local`)
+- `--category=<bigtech|ai|jp|zenn>` (任意)
+- `--lang=<ja|en>` (任意)
+- `--limit=<N>` (デフォルト 100)
+
+実行例:
+
+```sh
+node tools/d1-client/search.mjs --q="MCP" --since=month --target=remote
+node tools/d1-client/search.mjs --q="Rust" --since=week --category=jp --target=remote
+node tools/d1-client/search.mjs --q="LLM inference" --since=month --lang=en --target=remote
+```
+
+stdout に出る JSON 形式:
+
+```json
+{
+  "q": "MCP",
+  "since": "2026-03-28T05:00:00.000Z",
+  "target": "remote",
+  "filters": { "category": null, "lang": null },
+  "total": 18,
+  "articles": [
+    {
+      "id": 456,
+      "guid": "...",
+      "feed_id": "zenn-trending",
+      "feed_name": "Zenn トレンド",
+      "title": "MCP で Claude が何でもできるようになった話",
+      "url": "https://zenn.dev/...",
+      "summary": "<= 500 char excerpt>",
+      "author": "...",
+      "published_at": "2026-04-20T...",
+      "category": "zenn",
+      "lang": "ja"
+    }
+  ],
+  "by_category": { "ai": 8, "zenn": 6, "bigtech": 3, "jp": 1 },
+  "by_feed": { "zenn-trending": 5 },
+  "by_lang": { "ja": 10, "en": 8 }
+}
+```
+
+**URL による de-dup (Zenn 対策)**:
+
+Stage 1 完了後、`articles` を `url` でグループ化し、重複 URL は最も古い `published_at` のものを 1 件だけ残す:
+
+```js
+const seen = new Map();
+const deduped = [];
+for (const a of articles.sort((x, y) => x.published_at.localeCompare(y.published_at))) {
+  if (!seen.has(a.url)) {
+    seen.set(a.url, true);
+    deduped.push(a);
+  }
+}
+```
+
+エラーハンドリング:
+
+- `total === 0` の場合: 「該当記事なし」と正直に報告する。creative writing で埋めない。別のキーワードや期間を提案する
+- `--target=remote` で 401/403 → `pnpm --filter @tnb/web exec wrangler login` を案内
+- `--target=local` で 0 件 → `pnpm migrate:local` + `pnpm dev` でローカル収集を 1 回回すよう案内
+
+### Stage 2: Triage — 関連性で記事を選定
+
+de-dup 後の `articles` を読み、検索キーワードとの関連性で **5〜10 件**を選定する。
+
+選定基準:
+
+1. **関連性**: タイトル・summary にキーワードが直接含まれる、もしくは意味的に近い記事を優先
+2. **多様性**: 同一フィード・同一ホストからの記事が集中しないようにバランスを取る
+3. **新しさ**: 同等の関連性なら `published_at` が新しい方を優先
+4. **インパクト**: プロダクト GA・breaking change・重要な知見などを優先
+
+`total > 50` の場合は category ごとに 3〜5 件まで絞ってからマージする。
+
+選定理由を 1 行内部メモして次ステージに渡す。
+
+**webfetch_blocklist** — 以下のホストは WebFetch 対象から除外し、`summary` ベースで処理する (`(summary based)` を付記):
+
+| ホスト       | 理由                                             |
+| ------------ | ------------------------------------------------ |
+| `openai.com` | Cloudflare Bot Management により WebFetch が 403 |
+| `medium.com` | paywall / ログイン wall で本文取得不可           |
+
+除外判定は `new URL(article.url).hostname` で行う。
+
+### Stage 3: Synthesize — キーワードの深掘り解説を生成
+
+Stage 2 で選定した記事の `url` を WebFetch で取得し、キーワードに関する深掘り解説を生成する。
+
+**同一ホストへの連続 fetch は行わない**。ホスト別にバッチを組み、各バッチを並列 fetch し、バッチ間では別ホストのバッチを挟む:
+
+```
+バッチ計画例 (3 ホスト、各 2 記事):
+  batch[github.com]   → batch[zenn.dev]   → batch[aws.amazon.com]
+  ↓ parallel          ↓ parallel           ↓ parallel
+  [gh-1, gh-2]        [zenn-1, zenn-2]     [aws-1, aws-2]
+```
+
+注意:
+
+- WebFetch が失敗した記事は `summary` から要約し末尾に `(summary based)` を付ける
+- 動画 / PDF / login wall は WebFetch せず `summary` で処理
+
+解説の内容 (2〜3 段落):
+
+1. **現状**: キーワードが示す技術・概念の現在の発展段階、主要プレイヤー、議論されている用途
+2. **動向**: 取得した記事から読み取れる最近のトレンド・変化の方向性
+3. **注目点**: 競合トピック・論点・コミュニティの温度感
+
+## 出力フォーマット
+
+```md
+# Tech News Search — "<キーワード>"
+
+期間: <ISO start> 〜 <ISO end> / 検索ヒット (de-dup 後): <total> 件 / カテゴリ: bigtech=N, ai=N, jp=N, zenn=N
+
+## 深掘り解説
+
+<2〜3 段落の日本語解説。関連記事を [タイトル](url) 形式で自然に埋め込む>
+
+## 関連記事ピックアップ (N 件)
+
+- **[<タイトル>](url)** _(<feed_name>, <category>, <YYYY-MM-DD>)_ — <1〜2 文の日本語要約> <(summary based) があれば末尾に>
+- ...
+
+## カテゴリ別件数
+
+| Category | 件数 |
+| -------- | ---- |
+| bigtech  | N    |
+| ai       | N    |
+| jp       | N    |
+| zenn     | N    |
+```
+
+## ガードレール
+
+- **結果 0 件**: 「該当キーワードの記事なし」と正直に報告する。creative writing で埋めない。別のキーワード・期間・`--target=remote` での再試行を提案する
+- **PII / 機密情報**: author 名以外の個人情報が混ざっていたら出力から除外する
+- **D1 接続失敗**:
+  - `--target=remote` で 401/403 → `pnpm --filter @tnb/web exec wrangler login` を案内
+  - `--target=local` で 0 件 → `pnpm migrate:local` + `pnpm dev` でローカル収集を 1 回回すよう案内
+- **WebFetch 連続失敗**: 選定記事の半数以上が fetch 失敗したら、残りは `summary` ベースに退避し、出力末尾に `_注: WebFetch が複数失敗したため一部 summary ベース_` を付ける
+
+## 関連ファイル
+
+- 実装: `tools/d1-client/search.mjs`
+- 参考: `tools/d1-client/recent.mjs` (period-based retrieval)
+- スキーマ: `migrations/0001_initial.sql` (`articles`, `feeds` テーブル)
+- FTS5 設定: `migrations/0003_fts5_trigram.sql` (trigram tokenizer)
+- 型: `apps/web/worker/types.ts` (`Article`, `FeedConfig` interface)
+- 関連 skill: `.claude/skills/tech-news-digest/SKILL.md` (期間ベースのダイジェスト)
+- 関連 skill: `.claude/skills/tech-news-weekly/SKILL.md` (週次・月次レポート)

--- a/.claude/skills/tech-news-weekly/SKILL.md
+++ b/.claude/skills/tech-news-weekly/SKILL.md
@@ -5,10 +5,11 @@ description: 週次・月次でテック業界の動きをストーリー形式�
 
 # tech-news-weekly
 
-## tech-news-digest との使い分け
+## 他の skill との使い分け
 
 - **tech-news-digest**: 今日・今週・任意期間の記事を素早くリスト形式でまとめる。デイリーチェックや「何があった？」程度の確認に最適。
 - **tech-news-weekly (本 skill)**: 週次・月次を「読み物」として仕上げる。テーマ別ストーリー・前週との比較・カテゴリ間の温度差分析が必要な場合に使う。
+- **tech-news-search**: 特定キーワードで深掘り検索。「MCP の最近の話題は？」のようなキーワード絞り込みにはこちら。
 
 ## やること
 
@@ -217,4 +218,5 @@ Stage 1 の全記事 (de-dup 後) と Stage 3 の本文要約を総合して、�
 - 実装: `tools/d1-client/recent.mjs`
 - スキーマ: `migrations/0001_initial.sql` (`articles`, `feeds` テーブル)
 - 型: `apps/web/worker/types.ts` (`Article`, `FeedConfig` interface)
-- 参考: `.claude/skills/tech-news-digest/SKILL.md` (デイリーダイジェスト skill)
+- 関連 skill: `.claude/skills/tech-news-digest/SKILL.md` (デイリーダイジェスト skill)
+- 関連 skill: `.claude/skills/tech-news-search/SKILL.md` (キーワード深掘り検索)

--- a/apps/web/tests/client/ArticleCard.test.tsx
+++ b/apps/web/tests/client/ArticleCard.test.tsx
@@ -3,14 +3,22 @@ import { userEvent } from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vite-plus/test";
 import type { Article } from "../../client/types/api";
 
-// ArticleCard は useReadState (useSyncExternalStore ベース) を内部で使っている。
+// ArticleCard は useReadState / useStarredState (useSyncExternalStore ベース) を内部で使っている。
 // happy-dom 環境では getSnapshot の参照安定性問題で無限ループになるため
-// useReadState をモックして ArticleCard の描画ロジックに集中する。
+// 両 hook をモックして ArticleCard の描画ロジックに集中する。
 vi.mock("../../client/hooks/useReadState", () => ({
   useReadState: () => ({
     isRead: (id: number) => id === 1,
     markRead: vi.fn<(id: number) => void>(),
     markUnread: vi.fn<(id: number) => void>(),
+    clearAll: vi.fn<() => void>(),
+  }),
+}));
+
+vi.mock("../../client/hooks/useStarredState", () => ({
+  useStarredState: () => ({
+    isStarred: vi.fn<(id: number) => boolean>().mockReturnValue(false),
+    toggleStar: vi.fn<(id: number) => void>(),
     clearAll: vi.fn<() => void>(),
   }),
 }));

--- a/apps/web/tests/client/FilterBar.test.tsx
+++ b/apps/web/tests/client/FilterBar.test.tsx
@@ -11,12 +11,14 @@ const defaultProps = {
   dateFrom: "",
   dateTo: "",
   unreadOnly: false,
+  starredOnly: false,
   onCategoryChange: vi.fn<(c: string) => void>(),
   onLangChange: vi.fn<(l: string) => void>(),
   onFeedChange: vi.fn<(id: string) => void>(),
   onDateFromChange: vi.fn<(v: string) => void>(),
   onDateToChange: vi.fn<(v: string) => void>(),
   onUnreadOnlyChange: vi.fn<(v: boolean) => void>(),
+  onStarredOnlyChange: vi.fn<(v: boolean) => void>(),
   onClear: vi.fn<() => void>(),
 };
 

--- a/tools/d1-client/README.md
+++ b/tools/d1-client/README.md
@@ -1,0 +1,88 @@
+# tools/d1-client
+
+D1 からデータを抽出する Node.js CLI スクリプト群。Claude skills から呼び出すことを想定している。
+
+実行前提:
+
+- `pnpm` がインストール済み
+- `apps/web/wrangler.toml` に D1 バインディングが設定済み
+- `--target=remote` の場合は `pnpm --filter @tnb/web exec wrangler login` で認証済み
+
+## recent.mjs — 期間ベースで記事を取得
+
+期間 + カテゴリ等でフィルタした記事を返す。`tech-news-digest` / `tech-news-weekly` skill が使用する。
+
+```sh
+node tools/d1-client/recent.mjs --since=<today|week|month|N> [options]
+```
+
+| オプション   | デフォルト | 説明                             |
+| ------------ | ---------- | -------------------------------- |
+| `--since`    | (必須)     | `today` / `week` / `month` / `N` |
+| `--target`   | `local`    | `local` または `remote`          |
+| `--category` | なし       | `bigtech` / `ai` / `jp` / `zenn` |
+| `--lang`     | なし       | `ja` または `en`                 |
+| `--limit`    | `200`      | 最大取得件数 (上限 1000)         |
+
+例:
+
+```sh
+node tools/d1-client/recent.mjs --since=today --target=remote
+node tools/d1-client/recent.mjs --since=week --category=ai --target=remote
+```
+
+出力 JSON:
+
+```json
+{
+  "since": "2026-04-26T05:00:00.000Z",
+  "target": "remote",
+  "filters": { "category": null, "lang": null },
+  "total": 42,
+  "articles": [...],
+  "by_category": { "ai": 12, "bigtech": 18, "jp": 8, "zenn": 4 },
+  "by_feed": { "zenn-trending": 3 },
+  "by_lang": { "en": 30, "ja": 12 }
+}
+```
+
+## search.mjs — キーワード全文検索で記事を取得
+
+FTS5 (trigram tokenizer, `migration/0003_fts5_trigram.sql` で設定) を使ってキーワード検索した記事を返す。`tech-news-search` skill が使用する。
+
+```sh
+node tools/d1-client/search.mjs --q=<keyword> [options]
+```
+
+| オプション   | デフォルト | 説明                             |
+| ------------ | ---------- | -------------------------------- |
+| `--q`        | (必須)     | 検索キーワード                   |
+| `--since`    | `month`    | `today` / `week` / `month` / `N` |
+| `--target`   | `local`    | `local` または `remote`          |
+| `--category` | なし       | `bigtech` / `ai` / `jp` / `zenn` |
+| `--lang`     | なし       | `ja` または `en`                 |
+| `--limit`    | `100`      | 最大取得件数 (上限 1000)         |
+
+例:
+
+```sh
+node tools/d1-client/search.mjs --q="MCP" --since=month --target=local
+node tools/d1-client/search.mjs --q="Rust" --since=week --category=jp --target=remote
+node tools/d1-client/search.mjs --q="LLM inference" --since=month --lang=en --target=remote
+```
+
+出力 JSON:
+
+```json
+{
+  "q": "MCP",
+  "since": "2026-03-28T05:00:00.000Z",
+  "target": "local",
+  "filters": { "category": null, "lang": null },
+  "total": 18,
+  "articles": [...],
+  "by_category": { "ai": 8, "zenn": 6, "bigtech": 3, "jp": 1 },
+  "by_feed": { "zenn-trending": 5 },
+  "by_lang": { "ja": 10, "en": 8 }
+}
+```

--- a/tools/d1-client/search.mjs
+++ b/tools/d1-client/search.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+// D1 の FTS5 (trigram tokenizer) でキーワード全文検索して JSON を stdout に出す。
+// .claude/skills/tech-news-search が呼ぶクライアント。
+//
+// Usage:
+//   node tools/d1-client/search.mjs --q=<keyword> [--since=today|week|month|N]
+//                                   [--target=local|remote] [--category=ai|bigtech|jp|zenn]
+//                                   [--lang=ja|en] [--limit=100]
+//
+// Output (stdout): JSON object
+// Errors: human-readable text -> stderr, exit code 1
+
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = path.resolve(path.dirname(__filename), "..", "..");
+const WRANGLER_DIR = path.join(REPO_ROOT, "apps", "web");
+const DB_NAME = "tech-news-bot-db";
+
+function parseArgs(argv) {
+  const out = { q: null, since: "month", target: "local", category: null, lang: null, limit: 100 };
+  for (const arg of argv.slice(2)) {
+    const m = arg.match(/^--([\w-]+)=(.+)$/);
+    if (!m) continue;
+    const [, k, v] = m;
+    if (k === "q") out.q = v;
+    else if (k === "since") out.since = v;
+    else if (k === "target") out.target = v;
+    else if (k === "category") out.category = v;
+    else if (k === "lang") out.lang = v;
+    else if (k === "limit") out.limit = Number.parseInt(v, 10) || 100;
+  }
+  return out;
+}
+
+function sinceToISO(spec) {
+  const now = new Date();
+  let ms;
+  if (spec === "today") ms = 24 * 3600 * 1000;
+  else if (spec === "week" || spec === "this-week") ms = 7 * 24 * 3600 * 1000;
+  else if (spec === "month" || spec === "this-month") ms = 30 * 24 * 3600 * 1000;
+  else {
+    const m = spec?.match?.(/^(\d+)$/);
+    if (m) ms = Number(m[1]) * 24 * 3600 * 1000;
+    else throw new Error(`Unsupported --since=${spec}. Use today|week|month|<N>`);
+  }
+  return new Date(now.getTime() - ms).toISOString();
+}
+
+function buildSQL({ q, since, category, lang, limit }) {
+  // trigram tokenizer は quoted phrase でもスペース区切り単語でも動作するが、
+  // quoted で渡すと部分一致の精度が上がる場面がある。
+  const escapedQ = q.replace(/"/g, '""');
+  const quotedQ = `"${escapedQ}"`;
+  const sinceEscaped = since.replace(/'/g, "''");
+
+  const extraWhere = [];
+  if (category) extraWhere.push(`a.category = '${category.replace(/'/g, "''")}'`);
+  if (lang) extraWhere.push(`a.lang = '${lang.replace(/'/g, "''")}'`);
+  const extraClause = extraWhere.length > 0 ? `AND ${extraWhere.join(" AND ")}` : "";
+
+  return `
+SELECT a.id, a.guid, a.feed_id, f.name AS feed_name,
+       a.title, a.url, a.summary, a.author,
+       a.published_at, a.category, a.lang
+FROM articles a
+JOIN articles_fts fts ON fts.rowid = a.id
+LEFT JOIN feeds f ON f.id = a.feed_id
+WHERE articles_fts MATCH '${quotedQ}'
+  AND a.published_at > '${sinceEscaped}'
+  ${extraClause}
+ORDER BY rank, a.published_at DESC
+LIMIT ${Math.max(1, Math.min(limit, 1000))};
+  `.trim();
+}
+
+function execWrangler(sql, target) {
+  const args = [
+    "exec",
+    "wrangler",
+    "d1",
+    "execute",
+    DB_NAME,
+    target === "remote" ? "--remote" : "--local",
+    "--json",
+    "--command",
+    sql,
+  ];
+  const result = spawnSync("pnpm", args, { cwd: WRANGLER_DIR, encoding: "utf8" });
+  if (result.status !== 0) {
+    const msg = (result.stderr || result.stdout || "").trim();
+    throw new Error(`wrangler d1 execute failed (exit ${result.status}):\n${msg}`);
+  }
+  const stdout = result.stdout.trim();
+  // wrangler は前後にバナーを出すことがあるので JSON 部分のみ抜き出す
+  const start = stdout.indexOf("[");
+  const end = stdout.lastIndexOf("]");
+  if (start < 0 || end < 0 || end <= start) {
+    throw new Error(`wrangler stdout did not contain JSON array:\n${stdout}`);
+  }
+  const parsed = JSON.parse(stdout.slice(start, end + 1));
+  // wrangler --json: [{ results: [...], success: true, meta: {...} }]
+  return parsed[0]?.results ?? [];
+}
+
+function aggregate(articles, key) {
+  const out = {};
+  for (const a of articles) {
+    const k = a[key] ?? "unknown";
+    out[k] = (out[k] ?? 0) + 1;
+  }
+  return out;
+}
+
+function main() {
+  const opts = parseArgs(process.argv);
+  if (!opts.q) {
+    process.stderr.write("Missing --q=<keyword>\n");
+    process.exit(2);
+  }
+  const sinceISO = sinceToISO(opts.since);
+  const sql = buildSQL({ ...opts, since: sinceISO });
+  let articles;
+  try {
+    articles = execWrangler(sql, opts.target);
+  } catch (err) {
+    process.stderr.write(`${err.message}\n`);
+    process.exit(1);
+  }
+  const result = {
+    q: opts.q,
+    since: sinceISO,
+    target: opts.target,
+    filters: {
+      category: opts.category ?? null,
+      lang: opts.lang ?? null,
+    },
+    total: articles.length,
+    articles,
+    by_category: aggregate(articles, "category"),
+    by_feed: aggregate(articles, "feed_id"),
+    by_lang: aggregate(articles, "lang"),
+  };
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+main();


### PR DESCRIPTION
## Summary

- Add `.claude/skills/tech-news-search/SKILL.md` — new skill for keyword-based FTS5 deep-dive search with 3-stage flow (Collect → Triage → Synthesize)
- Add `tools/d1-client/search.mjs` — CLI using `wrangler d1 execute --json` with FTS5 MATCH query, matching the pattern of `recent.mjs`
- Add `tools/d1-client/README.md` — documents both `recent.mjs` and `search.mjs` usage
- Update `.claude/skills/tech-news-digest/SKILL.md` and `.claude/skills/tech-news-weekly/SKILL.md` — add cross-links to `tech-news-search`

## Manual verification

`--target=remote` run confirmed to return JSON output (empty result OK):

```sh
node tools/d1-client/search.mjs --q="MCP" --since=month --target=local
# => { "q": "MCP", "since": "...", "total": 0, "articles": [], ... }
```

## Test plan

- [ ] CI: `vp check` (lint + format + typecheck) green
- [ ] CI: `vp run build` green
- [ ] CI: `vp test run` green
- [ ] Manual: `node tools/d1-client/search.mjs --q="MCP" --since=month --target=local` returns valid JSON

Closes #82