### PR TITLE
fix(test): add starredOnly props to FilterBar test fixture

### DIFF
--- a/apps/web/tests/client/ArticleCard.test.tsx
+++ b/apps/web/tests/client/ArticleCard.test.tsx
@@ -3,15 +3,21 @@ import { userEvent } from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vite-plus/test";
 import type { Article } from "../../client/types/api";
 
-// ArticleCard は useReadState (useSyncExternalStore ベース) を内部で使っている。
-// happy-dom 環境では getSnapshot の参照安定性問題で無限ループになるため
-// useReadState をモックして ArticleCard の描画ロジックに集中する。
+// ArticleCard は useReadState / useStarredState (どちらも useSyncExternalStore ベース) を
+// 内部で使っており、happy-dom 環境では getSnapshot の参照安定性問題で
+// 無限ループになるため両方ともモックして ArticleCard の描画ロジックに集中する。
 vi.mock("../../client/hooks/useReadState", () => ({
   useReadState: () => ({
     isRead: (id: number) => id === 1,
     markRead: vi.fn<(id: number) => void>(),
     markUnread: vi.fn<(id: number) => void>(),
     clearAll: vi.fn<() => void>(),
+  }),
+}));
+vi.mock("../../client/hooks/useStarredState", () => ({
+  useStarredState: () => ({
+    isStarred: () => false,
+    toggleStar: vi.fn<(id: number) => void>(),
   }),
 }));
 

--- a/apps/web/tests/client/FilterBar.test.tsx
+++ b/apps/web/tests/client/FilterBar.test.tsx
@@ -11,12 +11,14 @@ const defaultProps = {
   dateFrom: "",
   dateTo: "",
   unreadOnly: false,
+  starredOnly: false,
   onCategoryChange: vi.fn<(c: string) => void>(),
   onLangChange: vi.fn<(l: string) => void>(),
   onFeedChange: vi.fn<(id: string) => void>(),
   onDateFromChange: vi.fn<(v: string) => void>(),
   onDateToChange: vi.fn<(v: string) => void>(),
   onUnreadOnlyChange: vi.fn<(v: boolean) => void>(),
+  onStarredOnlyChange: vi.fn<(v: boolean) => void>(),
   onClear: vi.fn<() => void>(),
 };
 


### PR DESCRIPTION
## Summary
- main の vp check (typecheck) が TS2739 で 5 件失敗していたのを修正
- PR #74 (SPA test 基盤) と PR #78 (starred articles) が並行マージされ、後者が `FilterBar` に追加した必須 props (`starredOnly`, `onStarredOnlyChange`) を test fixture が欠いていた

## Why
今は CI fail のため main の最新 commit から派生する全 PR が test stage で落ちる。

## Test plan
- [x] `pnpm --filter @tnb/web run typecheck` pass
- [x] `pnpm --filter @tnb/web run test:client` の FilterBar テストが pass (ArticleCard 側の Maximum update depth は本 PR の対象外、別途 issue 化予定)