### PR TITLE
feat(client): add Header component with dark mode toggle

### DIFF
--- a/apps/web/client/App.tsx
+++ b/apps/web/client/App.tsx
@@ -1,16 +1,15 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ArticleList } from "./components/ArticleList";
 import { FilterBar } from "./components/FilterBar";
+import { Header } from "./components/Header";
 import { HelpModal } from "./components/HelpModal";
 import { SearchInput } from "./components/SearchInput";
-import { ThemeToggle } from "./components/ThemeToggle";
 import { useArticles } from "./hooks/useArticles";
 import { useFeeds } from "./hooks/useFeeds";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { useReadState } from "./hooks/useReadState";
 import { useStarredState } from "./hooks/useStarredState";
 import { useStats } from "./hooks/useStats";
-import { useTheme } from "./hooks/useTheme";
 import type { FeedCategory, FeedLang } from "./types/api";
 
 function formatRelative(iso: string): string {
@@ -86,7 +85,6 @@ export default function App() {
 
   const searchRef = useRef<HTMLInputElement>(null);
 
-  const { theme, toggleTheme } = useTheme();
   const { feeds } = useFeeds();
   const { stats } = useStats();
   const { isRead, markRead, markUnread } = useReadState();
@@ -282,10 +280,9 @@ export default function App() {
 
   return (
     <div className="app">
+      <Header />
       <HelpModal open={helpOpen} onClose={() => setHelpOpen(false)} />
       <header className="header">
-        <h1>Tech News Bot</h1>
-        <ThemeToggle theme={theme} onToggle={toggleTheme} />
         <span className="subtitle">
           {stats ? `${stats.total.toLocaleString()} 記事 · 直近 24h: ${stats.last24h}` : ""}
           {feeds.length > 0 ? ` · ${feeds.length} sources` : ""}

--- a/apps/web/client/components/Header.tsx
+++ b/apps/web/client/components/Header.tsx
@@ -1,0 +1,67 @@
+import { useTheme } from "../hooks/useTheme";
+
+function SunIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="5" />
+      <line x1="12" y1="1" x2="12" y2="3" />
+      <line x1="12" y1="21" x2="12" y2="23" />
+      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+      <line x1="1" y1="12" x2="3" y2="12" />
+      <line x1="21" y1="12" x2="23" y2="12" />
+      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+    </svg>
+  );
+}
+
+function MoonIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+    </svg>
+  );
+}
+
+export function Header() {
+  const { theme, toggleTheme } = useTheme();
+  const label = theme === "dark" ? "Switch to light mode" : "Switch to dark mode";
+
+  return (
+    <header className="app-header">
+      <h1>Tech News Bot</h1>
+      <button
+        type="button"
+        className="theme-toggle"
+        onClick={toggleTheme}
+        aria-label={label}
+        title={label}
+      >
+        {theme === "dark" ? <SunIcon /> : <MoonIcon />}
+      </button>
+    </header>
+  );
+}

--- a/apps/web/client/index.css
+++ b/apps/web/client/index.css
@@ -69,6 +69,20 @@ a:hover {
   padding: 24px 16px 64px;
 }
 
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 0;
+  margin-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+.app-header h1 {
+  font-size: 1.4rem;
+  margin: 0;
+}
+
 .header {
   display: flex;
   justify-content: space-between;
@@ -76,11 +90,6 @@ a:hover {
   flex-wrap: wrap;
   gap: 8px;
   margin-bottom: 16px;
-}
-
-.header h1 {
-  font-size: 1.4rem;
-  margin: 0;
 }
 
 .theme-toggle {

--- a/apps/web/tests/client/Header.test.tsx
+++ b/apps/web/tests/client/Header.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+// useTheme をモックして theme と toggleTheme を制御する
+const mockToggleTheme = vi.fn<() => void>();
+let mockTheme: "light" | "dark" = "light";
+
+vi.mock("../../client/hooks/useTheme", () => ({
+  useTheme: () => ({
+    get theme() {
+      return mockTheme;
+    },
+    toggleTheme: mockToggleTheme,
+  }),
+}));
+
+const { Header } = await import("../../client/components/Header");
+
+describe("Header", () => {
+  it("renders the site name heading", () => {
+    mockTheme = "light";
+    render(<Header />);
+    expect(screen.getByRole("heading", { level: 1 })).toBeTruthy();
+  });
+
+  it("shows 'Switch to dark mode' aria-label when theme is light", () => {
+    mockTheme = "light";
+    render(<Header />);
+    expect(screen.getByRole("button", { name: "Switch to dark mode" })).toBeTruthy();
+  });
+
+  it("shows 'Switch to light mode' aria-label when theme is dark", () => {
+    mockTheme = "dark";
+    render(<Header />);
+    expect(screen.getByRole("button", { name: "Switch to light mode" })).toBeTruthy();
+  });
+
+  it("calls toggleTheme when the button is clicked", async () => {
+    mockTheme = "light";
+    mockToggleTheme.mockClear();
+    const user = userEvent.setup();
+    render(<Header />);
+    await user.click(screen.getByRole("button", { name: "Switch to dark mode" }));
+    expect(mockToggleTheme).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `apps/web/client/components/Header.tsx` — self-contained component that calls `useTheme()` and renders site name + SVG-icon theme toggle button
- Update `apps/web/client/App.tsx` — import `<Header />`, remove `useTheme` call and old `ThemeToggle` usage from the main render tree
- Add `.app-header` CSS rule to `apps/web/client/index.css`
- Add `apps/web/tests/client/Header.test.tsx` — covers `toggleTheme` spy, aria-label for light/dark modes

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm check` passes (0 errors, pre-existing warnings only)
- [x] `pnpm test` — 107 tests pass (worker suite)
- [x] `pnpm test:client` — 18 tests pass (client suite, including new Header tests)

Closes #88