### PR TITLE
feat: POST /api/admin/feeds/:id/enabled - runtime feed toggle

### DIFF
--- a/apps/web/tests/worker/api/admin.test.ts
+++ b/apps/web/tests/worker/api/admin.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it } from "vite-plus/test";
+import { env, SELF } from "cloudflare:test";
+import { syncFeeds } from "../../../worker/db/feeds";
+import type { FeedConfig } from "../../../worker/types";
+
+const TEST_FEED: FeedConfig = {
+  id: "test-feed",
+  name: "Test Feed",
+  url: "https://example.com/feed.xml",
+  category: "bigtech",
+  lang: "en",
+  enabled: true,
+};
+
+const AUTH_HEADER = { authorization: "Bearer test-admin-token" };
+
+beforeEach(async () => {
+  await syncFeeds(env.DB, [TEST_FEED]);
+});
+
+describe("POST /api/admin/feeds/:id/enabled", () => {
+  it("200: toggles enabled to false", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/feeds/test-feed/enabled", {
+      method: "POST",
+      headers: { ...AUTH_HEADER, "content-type": "application/json" },
+      body: JSON.stringify({ enabled: false }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { id: string; enabled: boolean };
+    expect(body.id).toBe("test-feed");
+    expect(body.enabled).toBe(false);
+  });
+
+  it("200: toggles enabled back to true", async () => {
+    // disable first
+    await SELF.fetch("https://example.com/api/admin/feeds/test-feed/enabled", {
+      method: "POST",
+      headers: { ...AUTH_HEADER, "content-type": "application/json" },
+      body: JSON.stringify({ enabled: false }),
+    });
+    const res = await SELF.fetch("https://example.com/api/admin/feeds/test-feed/enabled", {
+      method: "POST",
+      headers: { ...AUTH_HEADER, "content-type": "application/json" },
+      body: JSON.stringify({ enabled: true }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { id: string; enabled: boolean };
+    expect(body.enabled).toBe(true);
+  });
+
+  it("401: rejects unauthenticated request", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/feeds/test-feed/enabled", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ enabled: false }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("401: rejects invalid token", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/feeds/test-feed/enabled", {
+      method: "POST",
+      headers: { authorization: "Bearer wrong-token", "content-type": "application/json" },
+      body: JSON.stringify({ enabled: false }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("404: returns not found for unknown feed id", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/feeds/no-such-feed/enabled", {
+      method: "POST",
+      headers: { ...AUTH_HEADER, "content-type": "application/json" },
+      body: JSON.stringify({ enabled: false }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("400: rejects body without enabled field", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/feeds/test-feed/enabled", {
+      method: "POST",
+      headers: { ...AUTH_HEADER, "content-type": "application/json" },
+      body: JSON.stringify({ foo: "bar" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("400: rejects body with non-boolean enabled", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/feeds/test-feed/enabled", {
+      method: "POST",
+      headers: { ...AUTH_HEADER, "content-type": "application/json" },
+      body: JSON.stringify({ enabled: "true" }),
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/web/tests/worker/collector/d1Disabled.test.ts
+++ b/apps/web/tests/worker/collector/d1Disabled.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it } from "vite-plus/test";
+import { env } from "cloudflare:test";
+import { getEnabledFeedIds, setFeedEnabled, syncFeeds } from "../../../worker/db/feeds";
+import type { FeedConfig } from "../../../worker/types";
+
+const FEED_A: FeedConfig = {
+  id: "feed-a",
+  name: "Feed A",
+  url: "https://example.com/a.xml",
+  category: "bigtech",
+  lang: "en",
+  enabled: true,
+};
+
+const FEED_B: FeedConfig = {
+  id: "feed-b",
+  name: "Feed B",
+  url: "https://example.com/b.xml",
+  category: "ai",
+  lang: "en",
+  enabled: true,
+};
+
+beforeEach(async () => {
+  await syncFeeds(env.DB, [FEED_A, FEED_B]);
+});
+
+describe("getEnabledFeedIds + setFeedEnabled (D1 runtime toggle)", () => {
+  it("returns all feeds when both are enabled", async () => {
+    const ids = await getEnabledFeedIds(env.DB);
+    expect(ids.has("feed-a")).toBe(true);
+    expect(ids.has("feed-b")).toBe(true);
+  });
+
+  it("excludes a feed disabled via setFeedEnabled", async () => {
+    await setFeedEnabled(env.DB, "feed-b", false);
+
+    const ids = await getEnabledFeedIds(env.DB);
+    expect(ids.has("feed-a")).toBe(true);
+    // feed-b は D1 で disabled にされたため含まれない
+    expect(ids.has("feed-b")).toBe(false);
+  });
+
+  it("re-enables a feed and it appears again in getEnabledFeedIds", async () => {
+    await setFeedEnabled(env.DB, "feed-b", false);
+    await setFeedEnabled(env.DB, "feed-b", true);
+
+    const ids = await getEnabledFeedIds(env.DB);
+    expect(ids.has("feed-b")).toBe(true);
+  });
+
+  it("setFeedEnabled returns found=false for unknown id", async () => {
+    const result = await setFeedEnabled(env.DB, "no-such-feed", false);
+    expect(result.found).toBe(false);
+  });
+
+  it("setFeedEnabled returns found=true for existing feed", async () => {
+    const result = await setFeedEnabled(env.DB, "feed-a", false);
+    expect(result.found).toBe(true);
+  });
+});

--- a/apps/web/worker/api/admin.ts
+++ b/apps/web/worker/api/admin.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import type { Env } from "../types";
 import { collectAll } from "../collector";
+import { setFeedEnabled } from "../db/feeds";
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -42,6 +43,35 @@ app.post("/collect", async (c) => {
   }
   const result = await collectAll(c.env);
   return c.json(result);
+});
+
+app.post("/feeds/:id/enabled", async (c) => {
+  if (c.env.READONLY === "1") {
+    return c.json({ error: "read-only mode" }, 403);
+  }
+  const current = c.env.ADMIN_TOKEN;
+  const next = c.env.ADMIN_TOKEN_NEXT;
+  if (!current) {
+    return c.json({ error: "ADMIN_TOKEN is not configured" }, 503);
+  }
+  const auth = c.req.header("authorization") ?? "";
+  const token = auth.replace(/^Bearer\s+/i, "");
+  if (!token || !isValidAdminToken(token, current, next)) {
+    return c.json({ error: "unauthorized" }, 401);
+  }
+
+  const body = await c.req.json().catch(() => null);
+  if (!body || typeof (body as Record<string, unknown>).enabled !== "boolean") {
+    return c.json({ error: "invalid body: enabled must be a boolean" }, 400);
+  }
+  const enabled = (body as { enabled: boolean }).enabled;
+
+  const id = c.req.param("id");
+  const { found } = await setFeedEnabled(c.env.DB, id, enabled);
+  if (!found) {
+    return c.json({ error: "feed not found" }, 404);
+  }
+  return c.json({ id, enabled });
 });
 
 export default app;

--- a/apps/web/worker/collector/index.ts
+++ b/apps/web/worker/collector/index.ts
@@ -6,6 +6,7 @@ import { writeCollectorEvent } from "./metrics";
 import { maybeAlert } from "./alert";
 import { deleteOlderThan, insertArticles, type InsertableArticle } from "../db/articles";
 import {
+  getEnabledFeedIds,
   getFeedStreaks,
   loadFeedHeaders,
   recordFetchError,
@@ -283,12 +284,16 @@ export async function collectAll(env: Env): Promise<CollectAllResult> {
   const feeds = loadEnabledFeeds();
   await syncFeeds(env.DB, feeds);
 
+  // yaml の enabled=true を前提に、D1 で runtime disabled にされた feed を除外する
+  const d1EnabledIds = await getEnabledFeedIds(env.DB);
+  const activeFeeds = feeds.filter((f) => d1EnabledIds.has(f.id));
+
   const concurrency = Number(env.COLLECTOR_CONCURRENCY ?? "4") || 4;
   const timeoutMs = Number(env.COLLECTOR_TIMEOUT_MS ?? "10000") || 10000;
   const maxRetries = Number(env.COLLECTOR_RETRIES ?? "2") || 2;
   const summaryMax = Number(env.SUMMARY_MAX_LENGTH ?? "500") || 500;
 
-  const results = await runWithConcurrency(feeds, concurrency, (feed) =>
+  const results = await runWithConcurrency(activeFeeds, concurrency, (feed) =>
     collectFeed(env, feed, summaryMax, timeoutMs, maxRetries),
   );
 
@@ -307,7 +312,7 @@ export async function collectAll(env: Env): Promise<CollectAllResult> {
 
   const durationMs = Date.now() - start;
   console.log(
-    `[collector] feeds=${feeds.length} skipped304=${skipped304} inserted=${inserted} pruned=${pruned} retentionDays=${retentionDays} duration=${durationMs}ms`,
+    `[collector] feeds=${activeFeeds.length} skipped304=${skipped304} inserted=${inserted} pruned=${pruned} retentionDays=${retentionDays} duration=${durationMs}ms`,
   );
   for (const r of results) {
     if (r.status === "error") {
@@ -329,5 +334,5 @@ export async function collectAll(env: Env): Promise<CollectAllResult> {
     }
   }
 
-  return { total: feeds.length, inserted, pruned, results, durationMs };
+  return { total: activeFeeds.length, inserted, pruned, results, durationMs };
 }

--- a/apps/web/worker/db/feeds.ts
+++ b/apps/web/worker/db/feeds.ts
@@ -82,6 +82,30 @@ export async function recordFetchSuccess(
     .run();
 }
 
+/** D1 の feeds.enabled を更新する。id が存在しない場合は found=false を返す。 */
+export async function setFeedEnabled(
+  db: D1Database,
+  id: string,
+  enabled: boolean,
+): Promise<{ found: boolean }> {
+  const result = await db
+    .prepare(
+      `UPDATE feeds
+       SET enabled = ?1,
+           updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+       WHERE id = ?2`,
+    )
+    .bind(enabled ? 1 : 0, id)
+    .run();
+  return { found: (result.meta.changes ?? 0) > 0 };
+}
+
+/** D1 で enabled=1 の feed id を Set で返す。collector での in-memory check 用。 */
+export async function getEnabledFeedIds(db: D1Database): Promise<Set<string>> {
+  const rows = await db.prepare(`SELECT id FROM feeds WHERE enabled = 1`).all<{ id: string }>();
+  return new Set(rows.results.map((r) => r.id));
+}
+
 export async function recordFetchError(
   db: D1Database,
   feedId: string,


### PR DESCRIPTION
## Summary

- Add `POST /api/admin/feeds/:id/enabled` endpoint authenticated with `Bearer ADMIN_TOKEN`
- Add `setFeedEnabled(db, id, enabled)` and `getEnabledFeedIds(db)` to `apps/web/worker/db/feeds.ts`
- `collectAll` now fetches D1 enabled IDs once and filters active feeds, so yaml `enabled=true` AND D1 `enabled=1` are both required

## Test plan

- [x] `apps/web/tests/worker/api/admin.test.ts` — 7 cases (200 toggle off, 200 toggle back on, 401 no auth, 401 wrong token, 404 unknown id, 400 missing field, 400 non-boolean)
- [x] `apps/web/tests/worker/collector/d1Disabled.test.ts` — 5 cases verifying `setFeedEnabled`/`getEnabledFeedIds` behavior
- [x] All 119 tests pass (`vp test run`)
- [x] `vp check` exits 0 (warnings are pre-existing)

Closes #93