### PR TITLE
feat(client): add X / Hatena / copy-URL share buttons to ArticleCard

### DIFF
--- a/apps/web/client/components/ArticleCard.tsx
+++ b/apps/web/client/components/ArticleCard.tsx
@@ -3,6 +3,7 @@ import { useReadState } from "../hooks/useReadState";
 import { useStarredState } from "../hooks/useStarredState";
 import type { Article, FeedCategory } from "../types/api";
 import { highlight } from "../utils/highlight";
+import { ShareButtons } from "./ShareButtons";
 
 interface Props {
   article: Article;
@@ -118,6 +119,7 @@ export function ArticleCard({
         )}
       </div>
       {article.summary && <p className="summary">{highlight(article.summary, q)}</p>}
+      <ShareButtons url={article.url} title={article.title} />
     </article>
   );
 }

--- a/apps/web/client/components/ShareButtons.tsx
+++ b/apps/web/client/components/ShareButtons.tsx
@@ -1,0 +1,113 @@
+import { useState } from "react";
+
+interface Props {
+  url: string;
+  title: string;
+}
+
+export function ShareButtons({ url, title }: Props) {
+  const [copied, setCopied] = useState(false);
+
+  const encUrl = encodeURIComponent(url);
+  const encTitle = encodeURIComponent(title);
+
+  const xHref = `https://twitter.com/intent/tweet?url=${encUrl}&text=${encTitle}`;
+  const hatenaHref = `https://b.hatena.ne.jp/add?mode=confirm&url=${encUrl}&title=${encTitle}`;
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // clipboard API 非対応環境では無視
+    }
+  }
+
+  return (
+    <div className="share-buttons">
+      <a
+        href={xHref}
+        target="_blank"
+        rel="noopener"
+        className="share-button"
+        aria-label="X (Twitter) でシェア"
+      >
+        {/* X (Twitter) logo */}
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 1200 1227"
+          fill="currentColor"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
+        >
+          <path d="M714.163 519.284L1160.89 0H1055.03L667.137 450.887L357.328 0H0L468.492 681.821L0 1226.37H105.866L515.491 750.218L842.672 1226.37H1200L714.137 519.284H714.163ZM569.165 687.828L521.697 619.934L144.011 79.6944H306.615L611.412 515.685L658.88 583.579L1055.08 1150.3H892.476L569.165 687.854V687.828Z" />
+        </svg>
+      </a>
+      <a
+        href={hatenaHref}
+        target="_blank"
+        rel="noopener"
+        className="share-button"
+        aria-label="はてなブックマークに追加"
+      >
+        {/* Hatena Bookmark "B!" mark */}
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 64 64"
+          fill="currentColor"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
+        >
+          <rect width="64" height="64" rx="6" fill="currentColor" fillOpacity="0" />
+          <text
+            x="32"
+            y="48"
+            textAnchor="middle"
+            fontSize="44"
+            fontWeight="bold"
+            fontFamily="sans-serif"
+            fill="currentColor"
+          >
+            B!
+          </text>
+        </svg>
+      </a>
+      <button
+        type="button"
+        className={`share-button${copied ? " share-button-copied" : ""}`}
+        aria-label="URLをコピー"
+        onClick={handleCopy}
+      >
+        {copied ? (
+          /* checkmark */
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 16 16"
+            fill="currentColor"
+            xmlns="http://www.w3.org/2000/svg"
+            aria-hidden="true"
+          >
+            <path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.75.75 0 0 1 1.06-1.06L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0z" />
+          </svg>
+        ) : (
+          /* copy icon */
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 16 16"
+            fill="currentColor"
+            xmlns="http://www.w3.org/2000/svg"
+            aria-hidden="true"
+          >
+            <path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z" />
+            <path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z" />
+          </svg>
+        )}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/client/index.css
+++ b/apps/web/client/index.css
@@ -516,6 +516,43 @@ a:hover {
   opacity: 1;
 }
 
+/* シェアボタン */
+.share-buttons {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.share-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  background: var(--bg-elev-2);
+  color: var(--fg-muted);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  cursor: pointer;
+  text-decoration: none;
+  font-family: inherit;
+  transition:
+    color 0.1s ease,
+    border-color 0.1s ease;
+}
+
+.share-button:hover {
+  color: var(--fg);
+  border-color: var(--accent);
+  text-decoration: none;
+}
+
+.share-button-copied {
+  color: var(--badge-jp);
+  border-color: var(--badge-jp);
+}
+
 /* キーボードショートカット ヘルプモーダル */
 .help-overlay {
   position: fixed;

--- a/apps/web/tests/client/ShareButtons.test.tsx
+++ b/apps/web/tests/client/ShareButtons.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { describe, expect, it } from "vite-plus/test";
+import { ShareButtons } from "../../client/components/ShareButtons";
+
+const TEST_URL = "https://example.com/article?q=hello world";
+const TEST_TITLE = "Sample & Article <Title>";
+
+describe("ShareButtons", () => {
+  it("X anchor href encodes url and title", () => {
+    render(<ShareButtons url={TEST_URL} title={TEST_TITLE} />);
+    const xLink = screen.getByRole("link", { name: /X \(Twitter\)/i });
+    const href = xLink.getAttribute("href") ?? "";
+    expect(href).toContain("twitter.com/intent/tweet");
+    expect(href).toContain(encodeURIComponent(TEST_URL));
+    expect(href).toContain(encodeURIComponent(TEST_TITLE));
+  });
+
+  it("Hatena anchor href encodes url and title", () => {
+    render(<ShareButtons url={TEST_URL} title={TEST_TITLE} />);
+    const hatenaLink = screen.getByRole("link", { name: /はてなブックマーク/i });
+    const href = hatenaLink.getAttribute("href") ?? "";
+    expect(href).toContain("b.hatena.ne.jp/add");
+    expect(href).toContain(encodeURIComponent(TEST_URL));
+    expect(href).toContain(encodeURIComponent(TEST_TITLE));
+  });
+
+  it("X and Hatena links open in new tab with noopener", () => {
+    render(<ShareButtons url={TEST_URL} title={TEST_TITLE} />);
+    for (const label of [/X \(Twitter\)/i, /はてなブックマーク/i]) {
+      const link = screen.getByRole("link", { name: label });
+      expect(link.getAttribute("target")).toBe("_blank");
+      expect(link.getAttribute("rel")).toContain("noopener");
+    }
+  });
+
+  it("all interactive elements have aria-label", () => {
+    render(<ShareButtons url={TEST_URL} title={TEST_TITLE} />);
+    expect(screen.getByRole("link", { name: /X \(Twitter\)/i })).toBeTruthy();
+    expect(screen.getByRole("link", { name: /はてなブックマーク/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /URLをコピー/i })).toBeTruthy();
+  });
+
+  it("copy button click succeeds and shows copied state", async () => {
+    // happy-dom は Clipboard API を実装しているため writeText は実際に呼ばれる。
+    // spy が happy-dom の内部 window コンテキストを越えられないため、
+    // クリック後に "Copied" 状態が表示されることで動作を確認する。
+    const user = userEvent.setup();
+    render(<ShareButtons url={TEST_URL} title={TEST_TITLE} />);
+
+    const copyBtn = screen.getByRole("button", { name: /URLをコピー/i });
+    await user.click(copyBtn);
+
+    // writeText 成功後に aria-label が変わることで "copied" 状態を検証
+    // (SVG のみ表示のため button の aria-label は変わらない; class 変化で確認)
+    expect(copyBtn.classList.contains("share-button-copied")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `ShareButtons.tsx` component with X (Twitter), Hatena Bookmark, and Copy URL buttons using inline SVG icons
- Integrate `<ShareButtons>` into `ArticleCard.tsx` footer (below summary)
- Add `.share-buttons` / `.share-button` CSS to `index.css`
- Add `tests/client/ShareButtons.test.tsx` covering href encoding, noopener, aria-labels, and copy state

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm check` passes (0 errors, warnings are pre-existing)
- [x] `pnpm test` (worker) — 107 tests pass
- [x] `pnpm test:client` — 19 tests pass (5 new ShareButtons tests)

Closes #90