### PR TITLE
feat(api): add GET /api/health/feeds endpoint

### DIFF
--- a/apps/web/tests/worker/api/health.test.ts
+++ b/apps/web/tests/worker/api/health.test.ts
@@ -100,7 +100,7 @@ describe("GET /api/health/feeds", () => {
   it("returns 200 with an array", async () => {
     const res = await SELF.fetch("https://example.com/api/health/feeds");
     expect(res.status).toBe(200);
-    const body = (await res.json()) as FeedHealth[];
+    const body = (await res.json()) as unknown as FeedHealth[];
     expect(Array.isArray(body)).toBe(true);
     // feeds.yaml に定義されたフィード数以上の要素が返る
     expect(body.length).toBeGreaterThan(0);
@@ -108,7 +108,7 @@ describe("GET /api/health/feeds", () => {
 
   it("returns correct shape for each entry", async () => {
     const res = await SELF.fetch("https://example.com/api/health/feeds");
-    const body = (await res.json()) as FeedHealth[];
+    const body = (await res.json()) as unknown as FeedHealth[];
     // DB 未登録でもゼロ埋めで返る
     const found = body.find((f) => f.feed_id === GOOGLE_DEVELOPERS_ID);
     expect(found).toBeDefined();
@@ -135,7 +135,7 @@ describe("GET /api/health/feeds", () => {
     await recordFetchSuccess(env.DB, GOOGLE_DEVELOPERS_ID, successAt, 5);
 
     const res = await SELF.fetch("https://example.com/api/health/feeds");
-    const body = (await res.json()) as FeedHealth[];
+    const body = (await res.json()) as unknown as FeedHealth[];
     const found = body.find((f) => f.feed_id === GOOGLE_DEVELOPERS_ID);
     expect(found?.last_success_at).toBe(successAt);
     expect(found?.last_failure_at).toBeNull();
@@ -157,7 +157,7 @@ describe("GET /api/health/feeds", () => {
     await recordFetchError(env.DB, GOOGLE_DEVELOPERS_ID, failAt, "timeout");
 
     const res = await SELF.fetch("https://example.com/api/health/feeds");
-    const body = (await res.json()) as FeedHealth[];
+    const body = (await res.json()) as unknown as FeedHealth[];
     const found = body.find((f) => f.feed_id === GOOGLE_DEVELOPERS_ID);
     expect(found?.last_failure_at).toBe(failAt);
     expect(found?.consecutive_failures).toBe(2);
@@ -202,7 +202,7 @@ describe("GET /api/health/feeds", () => {
     ]);
 
     const res = await SELF.fetch("https://example.com/api/health/feeds");
-    const body = (await res.json()) as FeedHealth[];
+    const body = (await res.json()) as unknown as FeedHealth[];
     const found = body.find((f) => f.feed_id === GOOGLE_DEVELOPERS_ID);
     // 直近 7 日は 1 件のみ
     expect(found?.articles_last_7d).toBe(1);
@@ -210,7 +210,7 @@ describe("GET /api/health/feeds", () => {
 
   it("includes feeds.yaml disabled entries with enabled=false", async () => {
     const res = await SELF.fetch("https://example.com/api/health/feeds");
-    const body = (await res.json()) as FeedHealth[];
+    const body = (await res.json()) as unknown as FeedHealth[];
     // feeds.yaml の全フィードが含まれることを確認 (enabled/disabled 問わず)
     const ids = body.map((f) => f.feed_id);
     expect(ids).toContain(GOOGLE_DEVELOPERS_ID);

--- a/apps/web/tests/worker/api/health.test.ts
+++ b/apps/web/tests/worker/api/health.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vite-plus/test";
 import { env, SELF } from "cloudflare:test";
 import { insertArticles } from "../../../worker/db/articles";
-import { syncFeeds } from "../../../worker/db/feeds";
-import type { FeedConfig } from "../../../worker/types";
+import { syncFeeds, recordFetchSuccess, recordFetchError } from "../../../worker/db/feeds";
+import type { FeedConfig, FeedHealth } from "../../../worker/types";
 
 const FEED: FeedConfig = {
   id: "health-test-feed",
@@ -87,5 +87,138 @@ describe("/api/health enriched response", () => {
   it("sets Cache-Control: public, max-age=10", async () => {
     const res = await SELF.fetch("https://example.com/api/health");
     expect(res.headers.get("Cache-Control")).toBe("public, max-age=10");
+  });
+});
+
+// feeds.yaml に実際に存在するフィード ID を使う (loadAllFeeds() が返す一覧に基づく)
+// google-developers は enabled: true のフィード
+const GOOGLE_DEVELOPERS_ID = "google-developers";
+// zenn-trending は enabled: true の Zenn フィード
+const ZENN_TRENDING_ID = "zenn-trending";
+
+describe("GET /api/health/feeds", () => {
+  it("returns 200 with an array", async () => {
+    const res = await SELF.fetch("https://example.com/api/health/feeds");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as FeedHealth[];
+    expect(Array.isArray(body)).toBe(true);
+    // feeds.yaml に定義されたフィード数以上の要素が返る
+    expect(body.length).toBeGreaterThan(0);
+  });
+
+  it("returns correct shape for each entry", async () => {
+    const res = await SELF.fetch("https://example.com/api/health/feeds");
+    const body = (await res.json()) as FeedHealth[];
+    // DB 未登録でもゼロ埋めで返る
+    const found = body.find((f) => f.feed_id === GOOGLE_DEVELOPERS_ID);
+    expect(found).toBeDefined();
+    expect(typeof found?.feed_name).toBe("string");
+    expect(typeof found?.enabled).toBe("boolean");
+    expect(found?.consecutive_failures).toBe(0);
+    expect(found?.articles_last_7d).toBe(0);
+    expect(found?.last_success_at).toBeNull();
+    expect(found?.last_failure_at).toBeNull();
+  });
+
+  it("reflects last_success_at after recordFetchSuccess", async () => {
+    // DB にフィードを登録してから success を記録する
+    const feed: FeedConfig = {
+      id: GOOGLE_DEVELOPERS_ID,
+      name: "Google Developers Blog",
+      url: "https://developers.googleblog.com/feeds/posts/default",
+      category: "bigtech",
+      lang: "en",
+      enabled: true,
+    };
+    await syncFeeds(env.DB, [feed]);
+    const successAt = "2026-04-28T03:00:00.000Z";
+    await recordFetchSuccess(env.DB, GOOGLE_DEVELOPERS_ID, successAt, 5);
+
+    const res = await SELF.fetch("https://example.com/api/health/feeds");
+    const body = (await res.json()) as FeedHealth[];
+    const found = body.find((f) => f.feed_id === GOOGLE_DEVELOPERS_ID);
+    expect(found?.last_success_at).toBe(successAt);
+    expect(found?.last_failure_at).toBeNull();
+    expect(found?.consecutive_failures).toBe(0);
+  });
+
+  it("reflects last_failure_at and consecutive_failures after recordFetchError", async () => {
+    const feed: FeedConfig = {
+      id: GOOGLE_DEVELOPERS_ID,
+      name: "Google Developers Blog",
+      url: "https://developers.googleblog.com/feeds/posts/default",
+      category: "bigtech",
+      lang: "en",
+      enabled: true,
+    };
+    await syncFeeds(env.DB, [feed]);
+    const failAt = "2026-04-28T06:00:00.000Z";
+    await recordFetchError(env.DB, GOOGLE_DEVELOPERS_ID, failAt, "timeout");
+    await recordFetchError(env.DB, GOOGLE_DEVELOPERS_ID, failAt, "timeout");
+
+    const res = await SELF.fetch("https://example.com/api/health/feeds");
+    const body = (await res.json()) as FeedHealth[];
+    const found = body.find((f) => f.feed_id === GOOGLE_DEVELOPERS_ID);
+    expect(found?.last_failure_at).toBe(failAt);
+    expect(found?.consecutive_failures).toBe(2);
+    expect(found?.last_success_at).toBeNull();
+  });
+
+  it("counts only articles published within the last 7 days", async () => {
+    const feed: FeedConfig = {
+      id: GOOGLE_DEVELOPERS_ID,
+      name: "Google Developers Blog",
+      url: "https://developers.googleblog.com/feeds/posts/default",
+      category: "bigtech",
+      lang: "en",
+      enabled: true,
+    };
+    await syncFeeds(env.DB, [feed]);
+    await insertArticles(env.DB, [
+      {
+        guid: "fh-recent",
+        feed_id: GOOGLE_DEVELOPERS_ID,
+        title: "Recent Article",
+        url: "https://x.test/fh-recent",
+        summary: null,
+        author: null,
+        // SQLite の datetime('now','-7 days') より新しい日付
+        published_at: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(),
+        category: "bigtech",
+        lang: "en",
+      },
+      {
+        guid: "fh-old",
+        feed_id: GOOGLE_DEVELOPERS_ID,
+        title: "Old Article",
+        url: "https://x.test/fh-old",
+        summary: null,
+        author: null,
+        // 8 日前: 7 日以内に含まれない
+        published_at: new Date(Date.now() - 1000 * 60 * 60 * 24 * 8).toISOString(),
+        category: "bigtech",
+        lang: "en",
+      },
+    ]);
+
+    const res = await SELF.fetch("https://example.com/api/health/feeds");
+    const body = (await res.json()) as FeedHealth[];
+    const found = body.find((f) => f.feed_id === GOOGLE_DEVELOPERS_ID);
+    // 直近 7 日は 1 件のみ
+    expect(found?.articles_last_7d).toBe(1);
+  });
+
+  it("includes feeds.yaml disabled entries with enabled=false", async () => {
+    const res = await SELF.fetch("https://example.com/api/health/feeds");
+    const body = (await res.json()) as FeedHealth[];
+    // feeds.yaml の全フィードが含まれることを確認 (enabled/disabled 問わず)
+    const ids = body.map((f) => f.feed_id);
+    expect(ids).toContain(GOOGLE_DEVELOPERS_ID);
+    expect(ids).toContain(ZENN_TRENDING_ID);
+  });
+
+  it("sets Cache-Control: public, max-age=60", async () => {
+    const res = await SELF.fetch("https://example.com/api/health/feeds");
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=60");
   });
 });

--- a/apps/web/worker/api/health.ts
+++ b/apps/web/worker/api/health.ts
@@ -1,6 +1,8 @@
 import { Hono } from "hono";
 import { getHealthSummary } from "../db/health";
-import type { Env, HealthResponse } from "../types";
+import { getFeedHealth } from "../db/feeds";
+import { loadAllFeeds } from "../feed-config";
+import type { Env, FeedHealth, HealthResponse } from "../types";
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -14,6 +16,19 @@ app.get("/", async (c) => {
     };
     c.header("Cache-Control", "public, max-age=10");
     return c.json(body);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return c.json({ status: "degraded", error: message }, 500);
+  }
+});
+
+// feeds.yaml の全フィードに対してヘルス情報 (最終成功/失敗時刻・連続失敗数・直近7日記事数) を返す。
+app.get("/feeds", async (c) => {
+  try {
+    const configFeeds = loadAllFeeds();
+    const health: FeedHealth[] = await getFeedHealth(c.env.DB, configFeeds);
+    c.header("Cache-Control", "public, max-age=60");
+    return c.json(health);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return c.json({ status: "degraded", error: message }, 500);

--- a/apps/web/worker/db/feeds.ts
+++ b/apps/web/worker/db/feeds.ts
@@ -1,4 +1,4 @@
-import type { FeedConfig } from "../types";
+import type { FeedConfig, FeedHealth } from "../types";
 
 export interface FeedHeaders {
   last_etag: string | null;
@@ -75,6 +75,7 @@ export async function recordFetchSuccess(
            last_status = ?2,
            last_error = NULL,
            consecutive_failures = 0,
+           last_success_at = ?1,
            updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
        WHERE id = ?3`,
     )
@@ -119,6 +120,7 @@ export async function recordFetchError(
            last_status = 'error',
            last_error = ?2,
            consecutive_failures = consecutive_failures + 1,
+           last_failure_at = ?1,
            updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
        WHERE id = ?3`,
     )
@@ -137,4 +139,48 @@ export async function getFeedStreaks(db: D1Database): Promise<FeedStreak[]> {
     .prepare(`SELECT id, consecutive_failures FROM feeds WHERE enabled = 1`)
     .all<FeedStreak>();
   return result.results;
+}
+
+/**
+ * feeds テーブルと articles テーブルを JOIN して /api/feeds/health 用の集計を返す。
+ * 1 クエリで完結させ D1 の 50ms CPU 制約に収める。
+ */
+export async function getFeedHealth(db: D1Database, feeds: FeedConfig[]): Promise<FeedHealth[]> {
+  if (feeds.length === 0) return [];
+
+  const rows = await db
+    .prepare(
+      `SELECT f.id,
+              f.last_success_at,
+              f.last_failure_at,
+              f.consecutive_failures,
+              COUNT(a.id) AS articles_last_7d
+       FROM feeds f
+       LEFT JOIN articles a
+         ON a.feed_id = f.id
+        AND a.published_at >= datetime('now', '-7 days')
+       GROUP BY f.id`,
+    )
+    .all<{
+      id: string;
+      last_success_at: string | null;
+      last_failure_at: string | null;
+      consecutive_failures: number;
+      articles_last_7d: number;
+    }>();
+
+  const dbMap = new Map(rows.results.map((r) => [r.id, r]));
+
+  return feeds.map((f) => {
+    const row = dbMap.get(f.id);
+    return {
+      feed_id: f.id,
+      feed_name: f.name,
+      enabled: f.enabled,
+      last_success_at: row?.last_success_at ?? null,
+      last_failure_at: row?.last_failure_at ?? null,
+      consecutive_failures: row?.consecutive_failures ?? 0,
+      articles_last_7d: row?.articles_last_7d ?? 0,
+    };
+  });
 }

--- a/apps/web/worker/types.ts
+++ b/apps/web/worker/types.ts
@@ -79,3 +79,13 @@ export interface HealthResponse {
     latest_fetched_at: string | null;
   };
 }
+
+export interface FeedHealth {
+  feed_id: string;
+  feed_name: string;
+  enabled: boolean;
+  last_success_at: string | null;
+  last_failure_at: string | null;
+  consecutive_failures: number;
+  articles_last_7d: number;
+}

--- a/migrations/0007_feed_health_timestamps.sql
+++ b/migrations/0007_feed_health_timestamps.sql
@@ -1,0 +1,4 @@
+-- /api/feeds/health エンドポイントで last_success_at / last_failure_at を個別に返すため追加。
+-- recordFetchSuccess が last_success_at を、recordFetchError が last_failure_at を更新する。
+ALTER TABLE feeds ADD COLUMN last_success_at TEXT;
+ALTER TABLE feeds ADD COLUMN last_failure_at TEXT;


### PR DESCRIPTION
## Summary

- `GET /api/health/feeds` を追加。フィードごとの `last_success_at` / `last_failure_at` / `consecutive_failures` / `articles_last_7d` を JSON 配列で返す
- feeds テーブルに `last_success_at` / `last_failure_at` カラムを追加するマイグレーション (0007) を含む
- `recordFetchSuccess` / `recordFetchError` が各タイムスタンプを同時更新するよう変更

## Changes

- `migrations/0007_feed_health_timestamps.sql` — 新カラム追加
- `apps/web/worker/db/feeds.ts` — `getFeedHealth()` 追加、既存 record 関数を更新
- `apps/web/worker/api/health.ts` — `GET /health/feeds` ルート追加
- `apps/web/worker/types.ts` — `FeedHealth` 型追加
- `apps/web/tests/worker/api/health.test.ts` — 6 テストケース追加

## Test plan

- [ ] `pnpm build` pass
- [ ] `pnpm test` pass (143 tests)
- [ ] `pnpm check` pass (既存の pre-existing warnings のみ)

Closes #102