### PR TITLE
fix(client): stabilize getSnapshot references in useReadState and useStarredState

### DIFF
--- a/apps/web/client/hooks/useReadState.ts
+++ b/apps/web/client/hooks/useReadState.ts
@@ -3,16 +3,14 @@ import { useCallback, useSyncExternalStore } from "react";
 const STORAGE_KEY = "tnb-read-articles";
 const MAX_IDS = 1000;
 
-// localStorage から既読 id 配列を読む (新しい順に保存)
-function readStorage(): number[] {
+function parse(raw: string | null): Set<number> {
+  if (!raw) return new Set();
   try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return [];
     const parsed: unknown = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
-    return parsed.filter((v): v is number => typeof v === "number");
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter((v): v is number => typeof v === "number"));
   } catch {
-    return [];
+    return new Set();
   }
 }
 
@@ -22,6 +20,19 @@ function writeStorage(ids: number[]): void {
   } catch {
     // localStorage が使えない環境では無視
   }
+}
+
+// useSyncExternalStore の getSnapshot は参照同一性を要求するため
+// raw 文字列をキャッシュキーにして同一内容なら同じ Set 参照を返す
+let cachedRaw: string | null = null;
+let cachedSet: Set<number> = new Set();
+
+function getSnapshot(): Set<number> {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (raw === cachedRaw) return cachedSet;
+  cachedRaw = raw;
+  cachedSet = parse(raw);
+  return cachedSet;
 }
 
 // useSyncExternalStore 用サブスクライバー管理
@@ -47,10 +58,6 @@ function notify(): void {
   for (const l of listeners) l();
 }
 
-function getSnapshot(): number[] {
-  return readStorage();
-}
-
 export interface ReadStateAPI {
   /** 指定 id が既読かどうか */
   isRead: (id: number) => boolean;
@@ -63,28 +70,31 @@ export interface ReadStateAPI {
 }
 
 export function useReadState(): ReadStateAPI {
-  const readIds = useSyncExternalStore(subscribe, getSnapshot, () => []);
+  const readSet = useSyncExternalStore(subscribe, getSnapshot, () => new Set<number>());
 
-  const isRead = useCallback((id: number) => readIds.includes(id), [readIds]);
+  const isRead = useCallback((id: number) => readSet.has(id), [readSet]);
 
   const markRead = useCallback((id: number) => {
-    const current = readStorage();
+    const current = getSnapshot();
     // すでに既読なら先頭に移動して更新 (LRU の定義通り)
-    const without = current.filter((v) => v !== id);
-    const next = [id, ...without].slice(0, MAX_IDS);
-    writeStorage(next);
+    const arr = [id, ...Array.from(current).filter((v) => v !== id)].slice(0, MAX_IDS);
+    writeStorage(arr);
+    // キャッシュを無効化して次の getSnapshot で再読み込みさせる
+    cachedRaw = null;
     notify();
   }, []);
 
   const markUnread = useCallback((id: number) => {
-    const current = readStorage();
-    const next = current.filter((v) => v !== id);
-    writeStorage(next);
+    const current = getSnapshot();
+    const arr = Array.from(current).filter((v) => v !== id);
+    writeStorage(arr);
+    cachedRaw = null;
     notify();
   }, []);
 
   const clearAll = useCallback(() => {
     writeStorage([]);
+    cachedRaw = null;
     notify();
   }, []);
 

--- a/apps/web/client/hooks/useStarredState.ts
+++ b/apps/web/client/hooks/useStarredState.ts
@@ -3,15 +3,14 @@ import { useCallback, useSyncExternalStore } from "react";
 const STORAGE_KEY = "tnb-starred-articles";
 const MAX_IDS = 1000;
 
-function readStorage(): number[] {
+function parse(raw: string | null): Set<number> {
+  if (!raw) return new Set();
   try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return [];
     const parsed: unknown = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
-    return parsed.filter((v): v is number => typeof v === "number");
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter((v): v is number => typeof v === "number"));
   } catch {
-    return [];
+    return new Set();
   }
 }
 
@@ -21,6 +20,19 @@ function writeStorage(ids: number[]): void {
   } catch {
     // localStorage が使えない環境では無視
   }
+}
+
+// useSyncExternalStore の getSnapshot は参照同一性を要求するため
+// raw 文字列をキャッシュキーにして同一内容なら同じ Set 参照を返す
+let cachedRaw: string | null = null;
+let cachedSet: Set<number> = new Set();
+
+function getSnapshot(): Set<number> {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (raw === cachedRaw) return cachedSet;
+  cachedRaw = raw;
+  cachedSet = parse(raw);
+  return cachedSet;
 }
 
 type Listener = () => void;
@@ -44,29 +56,26 @@ function notify(): void {
   for (const l of listeners) l();
 }
 
-function getSnapshot(): number[] {
-  return readStorage();
-}
-
 export interface StarredStateAPI {
   isStarred: (id: number) => boolean;
   toggleStar: (id: number) => void;
 }
 
 export function useStarredState(): StarredStateAPI {
-  const starredIds = useSyncExternalStore(subscribe, getSnapshot, () => []);
+  const starredSet = useSyncExternalStore(subscribe, getSnapshot, () => new Set<number>());
 
-  const isStarred = useCallback((id: number) => starredIds.includes(id), [starredIds]);
+  const isStarred = useCallback((id: number) => starredSet.has(id), [starredSet]);
 
   const toggleStar = useCallback((id: number) => {
-    const current = readStorage();
-    const already = current.includes(id);
-    if (already) {
-      writeStorage(current.filter((v) => v !== id));
+    const current = getSnapshot();
+    if (current.has(id)) {
+      writeStorage(Array.from(current).filter((v) => v !== id));
     } else {
       // 新規追加は先頭に、LRU 1000 件超過分は破棄
-      writeStorage([id, ...current.filter((v) => v !== id)].slice(0, MAX_IDS));
+      writeStorage([id, ...Array.from(current).filter((v) => v !== id)].slice(0, MAX_IDS));
     }
+    // キャッシュを無効化して次の getSnapshot で再読み込みさせる
+    cachedRaw = null;
     notify();
   }, []);
 

--- a/apps/web/tests/client/ArticleCard.test.tsx
+++ b/apps/web/tests/client/ArticleCard.test.tsx
@@ -1,27 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vite-plus/test";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import type { Article } from "../../client/types/api";
-
-// ArticleCard は useReadState / useStarredState (useSyncExternalStore ベース) を内部で使っている。
-// happy-dom 環境では getSnapshot の参照安定性問題で無限ループになるため
-// 両 hook をモックして ArticleCard の描画ロジックに集中する。
-vi.mock("../../client/hooks/useReadState", () => ({
-  useReadState: () => ({
-    isRead: (id: number) => id === 1,
-    markRead: vi.fn<(id: number) => void>(),
-    markUnread: vi.fn<(id: number) => void>(),
-    clearAll: vi.fn<() => void>(),
-  }),
-}));
-
-vi.mock("../../client/hooks/useStarredState", () => ({
-  useStarredState: () => ({
-    isStarred: vi.fn<(id: number) => boolean>().mockReturnValue(false),
-    toggleStar: vi.fn<(id: number) => void>(),
-    clearAll: vi.fn<() => void>(),
-  }),
-}));
 
 const { ArticleCard } = await import("../../client/components/ArticleCard");
 
@@ -43,13 +23,19 @@ const baseArticle: Article = {
 const noop = () => {};
 
 describe("ArticleCard", () => {
+  beforeEach(() => {
+    // テスト間の localStorage 状態を隔離する
+    localStorage.clear();
+  });
+
   it("renders the article title", () => {
     render(<ArticleCard article={baseArticle} onFilterByCategory={noop} onFilterByFeedId={noop} />);
     expect(screen.getByText("Sample Article Title")).toBeTruthy();
   });
 
   it("applies read class when isRead returns true", () => {
-    // モックで id=1 は既読として返す
+    // localStorage に id=1 を既読として設定してから描画する
+    localStorage.setItem("tnb-read-articles", JSON.stringify([1]));
     const { container } = render(
       <ArticleCard article={baseArticle} onFilterByCategory={noop} onFilterByFeedId={noop} />,
     );

--- a/apps/web/tests/client/useReadState.test.tsx
+++ b/apps/web/tests/client/useReadState.test.tsx
@@ -1,45 +1,15 @@
 import { act, renderHook } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { beforeEach, describe, expect, it } from "vite-plus/test";
 
-// useSyncExternalStore の getSnapshot は参照同一性を要求するが、
-// useReadState の実装は毎回 JSON.parse した新しい配列を返すため happy-dom 環境で
-// 無限ループが発生する。モジュールをモックして内部ストアを直接制御する。
-vi.mock("../../client/hooks/useReadState", async () => {
-  const { useCallback, useState } = await import("react");
-
-  function useReadState() {
-    const [readIds, setReadIds] = useState<number[]>([]);
-
-    const isRead = useCallback((id: number) => readIds.includes(id), [readIds]);
-    const markRead = useCallback(
-      (id: number) => setReadIds((prev) => (prev.includes(id) ? prev : [id, ...prev])),
-      [],
-    );
-    const markUnread = useCallback(
-      (id: number) => setReadIds((prev) => prev.filter((v) => v !== id)),
-      [],
-    );
-    const clearAll = useCallback(() => setReadIds([]), []);
-
-    return { isRead, markRead, markUnread, clearAll };
-  }
-
-  return { useReadState };
-});
-
-// モックした useReadState を import (vi.mock が先に適用される)
 const { useReadState } = await import("../../client/hooks/useReadState");
 
-describe("useReadState (mock)", () => {
+describe("useReadState", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    // テスト間の localStorage 状態を隔離する
+    localStorage.clear();
   });
 
-  afterEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it("initially returns an empty read list", () => {
+  it("initially returns an empty read set", () => {
     const { result } = renderHook(() => useReadState());
     expect(result.current.isRead(1)).toBe(false);
   });
@@ -68,8 +38,6 @@ describe("useReadState (mock)", () => {
     const { result } = renderHook(() => useReadState());
     act(() => {
       result.current.markRead(1);
-    });
-    act(() => {
       result.current.markRead(2);
     });
     act(() => {
@@ -77,5 +45,13 @@ describe("useReadState (mock)", () => {
     });
     expect(result.current.isRead(1)).toBe(false);
     expect(result.current.isRead(2)).toBe(false);
+  });
+
+  it("returns the same Set reference when raw is unchanged", () => {
+    // raw が変わっていなければ getSnapshot が同じ参照を返すことを確認する
+    localStorage.setItem("tnb-read-articles", JSON.stringify([5, 6]));
+    const { result } = renderHook(() => useReadState());
+    expect(result.current.isRead(5)).toBe(true);
+    expect(result.current.isRead(99)).toBe(false);
   });
 });

--- a/apps/web/tests/client/useStarredState.test.tsx
+++ b/apps/web/tests/client/useStarredState.test.tsx
@@ -1,0 +1,57 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vite-plus/test";
+
+const { useStarredState } = await import("../../client/hooks/useStarredState");
+
+describe("useStarredState", () => {
+  beforeEach(() => {
+    // テスト間の localStorage 状態を隔離する
+    localStorage.clear();
+  });
+
+  it("initially returns an empty starred set", () => {
+    const { result } = renderHook(() => useStarredState());
+    expect(result.current.isStarred(1)).toBe(false);
+  });
+
+  it("toggleStar adds an article to starred", () => {
+    const { result } = renderHook(() => useStarredState());
+    act(() => {
+      result.current.toggleStar(42);
+    });
+    expect(result.current.isStarred(42)).toBe(true);
+  });
+
+  it("toggleStar removes an already starred article", () => {
+    const { result } = renderHook(() => useStarredState());
+    act(() => {
+      result.current.toggleStar(10);
+    });
+    expect(result.current.isStarred(10)).toBe(true);
+    act(() => {
+      result.current.toggleStar(10);
+    });
+    expect(result.current.isStarred(10)).toBe(false);
+  });
+
+  it("maintains other starred articles when toggling one", () => {
+    const { result } = renderHook(() => useStarredState());
+    act(() => {
+      result.current.toggleStar(1);
+      result.current.toggleStar(2);
+    });
+    act(() => {
+      result.current.toggleStar(1);
+    });
+    expect(result.current.isStarred(1)).toBe(false);
+    expect(result.current.isStarred(2)).toBe(true);
+  });
+
+  it("returns the same Set reference when raw is unchanged", () => {
+    // raw が変わっていなければ getSnapshot が同じ参照を返すことを確認する
+    localStorage.setItem("tnb-starred-articles", JSON.stringify([7, 8]));
+    const { result } = renderHook(() => useStarredState());
+    expect(result.current.isStarred(7)).toBe(true);
+    expect(result.current.isStarred(99)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- useReadState / useStarredState の getSnapshot が毎回新しい配列を返していたため、happy-dom 環境で無限ループ、実ブラウザで不要な再レンダリングが発生していた
- usePresets (#98) で採用済みの raw 文字列キャッシュ + 参照安定化パターン（同一 raw なら同じ Set 参照を返す）を両 hook に適用
- ArticleCard.test.tsx から不要な vi.mock を削除し、localStorage を直接操作する実テストに置き換え
- useReadState.test.tsx をモックなしの実 hook テストに書き換え
- useStarredState.test.tsx を新規追加（5 ケース）

## Test plan

- [x] pnpm check pass（errors 0）
- [x] pnpm build && pnpm test pass（136 tests passed）
- [x] ArticleCard.test.tsx の vi.mock 削除後も全テスト通過確認済み

Closes #100