### PR TITLE
feat: add per-feed RSS/JSON Feed endpoints (/feeds/:id.xml, /feeds/:id.json)

### DIFF
--- a/apps/web/tests/worker/api/syndication.test.ts
+++ b/apps/web/tests/worker/api/syndication.test.ts
@@ -4,10 +4,12 @@ import { insertArticles } from "../../../worker/db/articles";
 import { syncFeeds } from "../../../worker/db/feeds";
 import type { FeedConfig } from "../../../worker/types";
 
+// loadAllFeeds() は実際の feeds.yaml を参照するため、テスト用フィードの id は
+// feeds.yaml に定義された実際の id に合わせる必要がある
 const FEEDS: FeedConfig[] = [
   {
     id: "openai-blog",
-    name: "OpenAI",
+    name: "OpenAI News",
     url: "https://x.test/o",
     category: "ai",
     lang: "en",
@@ -15,7 +17,7 @@ const FEEDS: FeedConfig[] = [
   },
   {
     id: "mercari-engineering",
-    name: "Mercari",
+    name: "Mercari Engineering Blog",
     url: "https://x.test/m",
     category: "jp",
     lang: "ja",
@@ -100,5 +102,93 @@ describe("/feed.xml", () => {
     const text = await res.text();
     expect(text).toContain("g-ai");
     expect(text).not.toContain("g-jp");
+  });
+});
+
+describe("/feeds/:id.xml (per-feed RSS)", () => {
+  it("returns 200 with only articles from the specified feed_id", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/openai-blog.xml");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("application/rss+xml");
+    const text = await res.text();
+    expect(text).toContain("g-ai");
+    expect(text).not.toContain("g-jp");
+    // channel.title には feeds.yaml の name が入る
+    expect(text).toContain("<title>OpenAI News</title>");
+  });
+
+  it("returns 404 for unknown feed_id", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/unknown-feed.xml");
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 304 on If-None-Match match (ETag round-trip)", async () => {
+    const res1 = await SELF.fetch("https://example.com/feeds/openai-blog.xml");
+    expect(res1.status).toBe(200);
+    const etag = res1.headers.get("ETag")!;
+    expect(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
+
+    const res2 = await SELF.fetch("https://example.com/feeds/openai-blog.xml", {
+      headers: { "If-None-Match": etag },
+    });
+    expect(res2.status).toBe(304);
+    expect(res2.headers.get("ETag")).toBe(etag);
+  });
+
+  // enabled: false のフィードでも feeds.yaml に id が定義されていれば 200 を返すことを確認する。
+  // google-research は feeds.yaml で enabled: true だが、ここでは enabled: false として
+  // DB に登録し、それでも過去記事が配信されることを検証する。
+  it("serves past articles for a feed regardless of enabled flag in DB", async () => {
+    await syncFeeds(env.DB, [
+      {
+        id: "google-research",
+        name: "Google Research Blog",
+        url: "https://x.test/gr",
+        category: "bigtech",
+        lang: "en",
+        // DB 上では disabled に設定
+        enabled: false,
+      },
+    ]);
+    await insertArticles(env.DB, [
+      {
+        guid: "g-gr",
+        feed_id: "google-research",
+        title: "Google Research Article",
+        url: "https://x.test/gr/1",
+        summary: null,
+        author: null,
+        published_at: "2024-04-01T00:00:00.000Z",
+        category: "bigtech",
+        lang: "en",
+      },
+    ]);
+    // feeds.yaml に "google-research" が存在するため 200 が返る
+    const res = await SELF.fetch("https://example.com/feeds/google-research.xml");
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain("g-gr");
+  });
+});
+
+describe("/feeds/:id.json (per-feed JSON Feed)", () => {
+  it("returns 200 with JSON Feed v1.1 for the specified feed_id", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/mercari-engineering.json");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("application/feed+json");
+    const body = (await res.json()) as {
+      version: string;
+      title: string;
+      items: { id: string }[];
+    };
+    expect(body.version).toBe("https://jsonfeed.org/version/1.1");
+    // title には feeds.yaml の name が入る
+    expect(body.title).toBe("Mercari Engineering Blog");
+    expect(body.items.map((i) => i.id)).toEqual(["g-jp"]);
+  });
+
+  it("returns 404 for unknown feed_id", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/no-such-feed.json");
+    expect(res.status).toBe(404);
   });
 });

--- a/apps/web/worker/api/syndication.ts
+++ b/apps/web/worker/api/syndication.ts
@@ -1,7 +1,9 @@
 import { Hono } from "hono";
+import type { Context } from "hono";
 import type { Env, FeedCategory, FeedLang, FeedsFile } from "../types";
 import { listArticles } from "../db/articles";
 import { computeSyndicationEtag } from "../utils/etag";
+import { loadAllFeeds } from "../feed-config";
 import feedsYaml from "../feeds.yaml";
 
 const FEEDS_VERSION = (feedsYaml as FeedsFile).version;
@@ -50,10 +52,20 @@ function siteOrigin(reqUrl: string): string {
   }
 }
 
-app.get("/feed.json", async (c) => {
-  const { category, lang } = parseFilters(c);
+interface BuildFeedOpts {
+  feedId?: string;
+  category?: FeedCategory;
+  lang?: FeedLang;
+  /** feeds.yaml の name (per-feed 時に channel.title へ使用) */
+  feedName?: string;
+}
 
-  const etag = await computeSyndicationEtag(c.env.DB, FEEDS_VERSION, { category, lang });
+async function buildJsonFeed(
+  c: Context<{ Bindings: Env }>,
+  opts: BuildFeedOpts,
+): Promise<Response> {
+  const { feedId, category, lang, feedName } = opts;
+  const etag = await computeSyndicationEtag(c.env.DB, FEEDS_VERSION, { category, lang, feedId });
   if (c.req.header("If-None-Match") === etag) {
     c.header("ETag", etag);
     c.header("Cache-Control", "public, max-age=60");
@@ -63,16 +75,19 @@ app.get("/feed.json", async (c) => {
   const result = await listArticles(c.env.DB, {
     category,
     lang,
+    feedId,
     limit: FEED_LIMIT,
     cursor: null,
   });
   const origin = siteOrigin(c.req.url);
   const feedUrl = new URL(c.req.url).toString();
+  const title = feedName ?? SITE_TITLE;
+  const description = feedName ? `${feedName} の最新記事` : SITE_DESCRIPTION;
 
   const json = {
     version: "https://jsonfeed.org/version/1.1",
-    title: SITE_TITLE,
-    description: SITE_DESCRIPTION,
+    title,
+    description,
     home_page_url: origin || undefined,
     feed_url: feedUrl,
     language: lang ?? "und",
@@ -93,12 +108,11 @@ app.get("/feed.json", async (c) => {
   c.header("ETag", etag);
   c.header("Cache-Control", "public, max-age=60");
   return c.body(JSON.stringify(json));
-});
+}
 
-app.get("/feed.xml", async (c) => {
-  const { category, lang } = parseFilters(c);
-
-  const etag = await computeSyndicationEtag(c.env.DB, FEEDS_VERSION, { category, lang });
+async function buildRssFeed(c: Context<{ Bindings: Env }>, opts: BuildFeedOpts): Promise<Response> {
+  const { feedId, category, lang, feedName } = opts;
+  const etag = await computeSyndicationEtag(c.env.DB, FEEDS_VERSION, { category, lang, feedId });
   if (c.req.header("If-None-Match") === etag) {
     c.header("ETag", etag);
     c.header("Cache-Control", "public, max-age=60");
@@ -108,12 +122,15 @@ app.get("/feed.xml", async (c) => {
   const result = await listArticles(c.env.DB, {
     category,
     lang,
+    feedId,
     limit: FEED_LIMIT,
     cursor: null,
   });
   const origin = siteOrigin(c.req.url);
   const feedUrl = new URL(c.req.url).toString();
   const lastBuild = result.articles[0]?.published_at ?? new Date().toISOString();
+  const title = feedName ?? SITE_TITLE;
+  const description = feedName ? `${feedName} の最新記事` : SITE_DESCRIPTION;
 
   const items = result.articles
     .map((a) => {
@@ -137,9 +154,9 @@ app.get("/feed.xml", async (c) => {
     `<?xml version="1.0" encoding="UTF-8"?>` +
     `<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">` +
     `<channel>` +
-    `<title>${escapeXml(SITE_TITLE)}</title>` +
+    `<title>${escapeXml(title)}</title>` +
     `<link>${escapeXml(origin)}</link>` +
-    `<description>${escapeXml(SITE_DESCRIPTION)}</description>` +
+    `<description>${escapeXml(description)}</description>` +
     `<language>${escapeXml(lang ?? "und")}</language>` +
     `<lastBuildDate>${toRfc822(lastBuild)}</lastBuildDate>` +
     `<atom:link href="${escapeXml(feedUrl)}" rel="self" type="application/rss+xml"/>` +
@@ -150,6 +167,44 @@ app.get("/feed.xml", async (c) => {
   c.header("ETag", etag);
   c.header("Cache-Control", "public, max-age=60");
   return c.body(xml);
+}
+
+app.get("/feed.json", async (c) => {
+  const { category, lang } = parseFilters(c);
+  return buildJsonFeed(c, { category, lang });
+});
+
+app.get("/feed.xml", async (c) => {
+  const { category, lang } = parseFilters(c);
+  return buildRssFeed(c, { category, lang });
+});
+
+// per-feed エンドポイント: feeds.yaml に定義された id のみ受け付ける
+// enabled: false でも過去記事の履歴閲覧ができるよう全フィードを対象とする
+// ":id.xml" パターンは Hono の RegExpRouter でパラメータ解析が壊れることがあるため、
+// ワイルドカードで受け取り拡張子を手動で分離する。
+app.get("/feeds/:filename", async (c) => {
+  const filename = c.req.param("filename");
+  let feedId: string;
+  let format: "xml" | "json";
+
+  if (filename.endsWith(".xml")) {
+    feedId = filename.slice(0, -4);
+    format = "xml";
+  } else if (filename.endsWith(".json")) {
+    feedId = filename.slice(0, -5);
+    format = "json";
+  } else {
+    return c.notFound();
+  }
+
+  const feedConfig = loadAllFeeds().find((f) => f.id === feedId);
+  if (!feedConfig) return c.notFound();
+
+  if (format === "xml") {
+    return buildRssFeed(c, { feedId, feedName: feedConfig.name, lang: feedConfig.lang });
+  }
+  return buildJsonFeed(c, { feedId, feedName: feedConfig.name, lang: feedConfig.lang });
 });
 
 export default app;

--- a/apps/web/worker/utils/etag.ts
+++ b/apps/web/worker/utils/etag.ts
@@ -12,6 +12,7 @@ export interface ArticlesEtagParams {
 export interface SyndicationEtagParams {
   category?: FeedCategory;
   lang?: FeedLang;
+  feedId?: string;
 }
 
 // MAX(published_at) を取るだけの軽量クエリでリビジョンを取得する
@@ -93,9 +94,13 @@ export async function computeSyndicationEtag(
     conditions.push(`lang = ?${binds.length + 1}`);
     binds.push(params.lang);
   }
+  if (params.feedId) {
+    conditions.push(`feed_id = ?${binds.length + 1}`);
+    binds.push(params.feedId);
+  }
 
   const maxPublished = await fetchMaxPublishedAt(db, conditions, binds);
-  const paramStr = [opt(params.category), opt(params.lang)].join("|");
+  const paramStr = [opt(params.category), opt(params.lang), opt(params.feedId)].join("|");
   const source = `${maxPublished}|v${feedsVersion}|${paramStr}`;
   const hash = await sha256Hex16(source);
   return `W/"${hash}"`;


### PR DESCRIPTION
## Summary

- `GET /feeds/:id.xml` — 指定 feed_id の最新 50 記事を RSS 2.0 で配信。`<channel><title>` は `feeds.yaml` の `name` を使用
- `GET /feeds/:id.json` — 同 JSON Feed v1.1 形式
- 不明な `feed_id` (feeds.yaml に未定義) は 404
- ETag / 304 は既存の `computeSyndicationEtag` を `feedId` 対応に拡張して付与
- `enabled: false` のフィードでも `loadAllFeeds()` (全フィード対象) で判定するため過去記事を配信可能

## 実装メモ

Hono の `RegExpRouter` は `:id.xml` のようなドットを含むリテラルサフィックスを持つパターンで paramAssoc が壊れるバグがあるため、`:filename` でワイルドカード受けして拡張子を手動分離するアプローチを採用。

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `apps/web/worker/api/syndication.ts` | `buildRssFeed` / `buildJsonFeed` ヘルパーに refactor、`/feeds/:filename` ルート追加 |
| `apps/web/worker/utils/etag.ts` | `SyndicationEtagParams` に `feedId` を追加 |
| `apps/web/tests/worker/api/syndication.test.ts` | per-feed テスト 5 ケース追加 |

## Test plan

- [x] `vp check` pass (0 errors, 85 warnings は既存)
- [x] `vp test run` pass (142 tests passed)
- [x] per-feed XML 200 + 該当記事のみ + Content-Type `application/rss+xml`
- [x] per-feed JSON 200 + JSON Feed v1.1 format
- [x] 不明 feed_id で 404
- [x] ETag If-None-Match で 304
- [x] enabled:false フィードでも過去記事を配信

Closes #106