### PR TITLE
feat(client): keyboard navigation (j/k/Enter/m/s/?) with ShortcutsHelp modal

### DIFF
--- a/apps/web/client/App.tsx
+++ b/apps/web/client/App.tsx
@@ -2,13 +2,13 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ArticleList } from "./components/ArticleList";
 import { FilterBar } from "./components/FilterBar";
 import { Header } from "./components/Header";
-import { HelpModal } from "./components/HelpModal";
 import { PresetBar } from "./components/PresetBar";
 import { SearchInput } from "./components/SearchInput";
+import { ShortcutsHelp } from "./components/ShortcutsHelp";
 import { StatsPanel } from "./components/Stats";
 import { useArticles } from "./hooks/useArticles";
 import { useFeeds } from "./hooks/useFeeds";
-import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
+import { useKeyboardNav } from "./hooks/useKeyboardNav";
 import { usePresets } from "./hooks/usePresets";
 import { useReadState } from "./hooks/useReadState";
 import { useStarredState } from "./hooks/useStarredState";
@@ -84,14 +84,13 @@ export default function App() {
   const [dateTo, setDateTo] = useState<string>(() => readFromUrl().dateTo);
   const [unreadOnly, setUnreadOnly] = useState<boolean>(() => readFromUrl().unreadOnly);
   const [starredOnly, setStarredOnly] = useState<boolean>(() => readFromUrl().starredOnly);
-  const [helpOpen, setHelpOpen] = useState(false);
 
   const searchRef = useRef<HTMLInputElement>(null);
 
   const { feeds } = useFeeds();
   const { stats } = useStats();
   const { isRead, markRead, markUnread } = useReadState();
-  const { isStarred } = useStarredState();
+  const { isStarred, toggleStar } = useStarredState();
   const { presets, addPreset, removePreset } = usePresets();
 
   // popstate でブラウザ戻る/進むに追従する
@@ -271,14 +270,6 @@ export default function App() {
     return filtered;
   }, [allArticles, unreadOnly, starredOnly, isRead, isStarred]);
 
-  const handleActivate = useCallback(
-    (id: number, url: string) => {
-      markRead(id);
-      window.open(url, "_blank", "noopener,noreferrer");
-    },
-    [markRead],
-  );
-
   const handleToggleRead = useCallback(
     (id: number) => {
       if (isRead(id)) markUnread(id);
@@ -287,30 +278,16 @@ export default function App() {
     [isRead, markRead, markUnread],
   );
 
-  const handleSearchFocus = useCallback(() => {
-    searchRef.current?.focus();
-  }, []);
-
-  const handleClearAll = useCallback(
-    () => pushFilter("", "", "", "", "", "", false, false),
-    [pushFilter],
-  );
-
-  const handleToggleHelp = useCallback(() => setHelpOpen((prev) => !prev), []);
-
-  const { focusedId } = useKeyboardShortcuts({
-    items: articles,
-    onActivate: handleActivate,
-    onToggleRead: handleToggleRead,
-    onSearchFocus: handleSearchFocus,
-    onClearAll: handleClearAll,
-    onShowHelp: handleToggleHelp,
+  const { focusedIndex, helpOpen, setHelpOpen } = useKeyboardNav({
+    articles,
+    onMarkRead: handleToggleRead,
+    onToggleStar: toggleStar,
   });
 
   return (
     <div className="app">
       <Header />
-      <HelpModal open={helpOpen} onClose={() => setHelpOpen(false)} />
+      <ShortcutsHelp open={helpOpen} onClose={() => setHelpOpen(false)} />
       <header className="header">
         <span className="subtitle">
           {stats ? `${stats.total.toLocaleString()} 記事 · 直近 24h: ${stats.last24h}` : ""}
@@ -375,7 +352,7 @@ export default function App() {
       {articles.length > 0 && (
         <ArticleList
           articles={articles}
-          focusedId={focusedId}
+          focusedId={focusedIndex !== null ? (articles[focusedIndex]?.id ?? null) : null}
           onFilterByCategory={handleFilterByCategory}
           onFilterByFeedId={handleFilterByFeedId}
           q={q}

--- a/apps/web/client/components/ShortcutsHelp.tsx
+++ b/apps/web/client/components/ShortcutsHelp.tsx
@@ -1,0 +1,54 @@
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+const SHORTCUTS: { key: string; label: string }[] = [
+  { key: "j / ArrowDown", label: "次の記事に移動" },
+  { key: "k / ArrowUp", label: "前の記事に移動" },
+  { key: "Enter / o", label: "フォーカス中の記事を別タブで開く" },
+  { key: "m", label: "既読 / 未読をトグル" },
+  { key: "s", label: "スターをトグル" },
+  { key: "?", label: "このヘルプを開く / 閉じる" },
+  { key: "Esc", label: "ヘルプを閉じる / 検索バーから離れる" },
+];
+
+export function ShortcutsHelp({ open, onClose }: Props) {
+  if (!open) return null;
+
+  return (
+    <div
+      className="shortcuts-help-overlay"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label="キーボードショートカット"
+    >
+      <div className="shortcuts-help-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="shortcuts-help-header">
+          <h2>キーボードショートカット</h2>
+          <button
+            type="button"
+            className="shortcuts-help-close"
+            onClick={onClose}
+            aria-label="閉じる"
+          >
+            x
+          </button>
+        </div>
+        <table className="shortcuts-help-table">
+          <tbody>
+            {SHORTCUTS.map(({ key, label }) => (
+              <tr key={key}>
+                <td>
+                  <kbd>{key}</kbd>
+                </td>
+                <td>{label}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/client/hooks/useKeyboardNav.ts
+++ b/apps/web/client/hooks/useKeyboardNav.ts
@@ -1,0 +1,134 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Article } from "../types/api";
+
+interface Options {
+  articles: Article[];
+  onMarkRead: (id: number) => void;
+  onToggleStar: (id: number) => void;
+}
+
+function isInputFocused(): boolean {
+  const t = document.activeElement;
+  if (!t) return false;
+  return (
+    t instanceof HTMLInputElement ||
+    t instanceof HTMLTextAreaElement ||
+    t instanceof HTMLSelectElement ||
+    (t as HTMLElement).isContentEditable
+  );
+}
+
+export interface KeyboardNavResult {
+  focusedIndex: number | null;
+  helpOpen: boolean;
+  setHelpOpen: (open: boolean) => void;
+}
+
+export function useKeyboardNav({ articles, onMarkRead, onToggleStar }: Options): KeyboardNavResult {
+  const [focusedIndex, setFocusedIndex] = useState<number | null>(null);
+  const [helpOpen, setHelpOpen] = useState(false);
+
+  // ref で最新値を保持して keydown handler の closure staleness を避ける
+  const articlesRef = useRef(articles);
+  useEffect(() => {
+    articlesRef.current = articles;
+  }, [articles]);
+
+  const focusedIndexRef = useRef(focusedIndex);
+  useEffect(() => {
+    focusedIndexRef.current = focusedIndex;
+  }, [focusedIndex]);
+
+  const helpOpenRef = useRef(helpOpen);
+  useEffect(() => {
+    helpOpenRef.current = helpOpen;
+  }, [helpOpen]);
+
+  const moveFocus = useCallback((dir: 1 | -1) => {
+    const list = articlesRef.current;
+    if (list.length === 0) return;
+    const current = focusedIndexRef.current;
+    let next: number;
+    if (current === null) {
+      next = dir === 1 ? 0 : list.length - 1;
+    } else {
+      next = Math.max(0, Math.min(list.length - 1, current + dir));
+    }
+    setFocusedIndex(next);
+    const article = list[next];
+    const el = document.querySelector<HTMLElement>(`[data-article-id="${article.id}"]`);
+    el?.scrollIntoView({ block: "nearest" });
+  }, []);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const inInput = isInputFocused();
+
+      // Esc は入力欄でも常に処理 (help modal を閉じる / 検索バーから離れる)
+      if (e.key === "Escape") {
+        if (helpOpenRef.current) {
+          setHelpOpen(false);
+        } else if (inInput) {
+          (document.activeElement as HTMLElement).blur();
+        }
+        return;
+      }
+
+      if (inInput) return;
+
+      switch (e.key) {
+        case "j":
+        case "ArrowDown":
+          e.preventDefault();
+          moveFocus(1);
+          break;
+        case "k":
+        case "ArrowUp":
+          e.preventDefault();
+          moveFocus(-1);
+          break;
+        case "o":
+        case "Enter": {
+          const idx = focusedIndexRef.current;
+          if (idx === null) break;
+          const article = articlesRef.current[idx];
+          if (article) {
+            window.open(article.url, "_blank", "noopener,noreferrer");
+          }
+          break;
+        }
+        case "m": {
+          const idx = focusedIndexRef.current;
+          if (idx !== null) {
+            const article = articlesRef.current[idx];
+            if (article) onMarkRead(article.id);
+          }
+          break;
+        }
+        case "s": {
+          const idx = focusedIndexRef.current;
+          if (idx !== null) {
+            const article = articlesRef.current[idx];
+            if (article) onToggleStar(article.id);
+          }
+          break;
+        }
+        case "?":
+          setHelpOpen((prev) => !prev);
+          break;
+      }
+    };
+
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [moveFocus, onMarkRead, onToggleStar]);
+
+  // articles が変わったとき、focusedIndex が範囲外になっていたらリセット
+  useEffect(() => {
+    if (focusedIndex !== null && focusedIndex >= articles.length) {
+      setFocusedIndex(articles.length > 0 ? articles.length - 1 : null);
+    }
+  }, [articles, focusedIndex]);
+
+  return { focusedIndex, helpOpen, setHelpOpen };
+}

--- a/apps/web/client/index.css
+++ b/apps/web/client/index.css
@@ -553,7 +553,72 @@ a:hover {
   border-color: var(--badge-jp);
 }
 
-/* キーボードショートカット ヘルプモーダル */
+/* キーボードショートカット ShortcutsHelp モーダル */
+.shortcuts-help-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.shortcuts-help-modal {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 20px 24px;
+  min-width: 320px;
+  max-width: 480px;
+  width: 90%;
+}
+
+.shortcuts-help-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.shortcuts-help-header h2 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.shortcuts-help-close {
+  background: none;
+  border: none;
+  color: var(--fg-muted);
+  font-size: 1rem;
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.shortcuts-help-close:hover {
+  color: var(--fg);
+  background: var(--bg-elev-2);
+}
+
+.shortcuts-help-table {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 0.9rem;
+}
+
+.shortcuts-help-table td {
+  padding: 5px 8px;
+  vertical-align: middle;
+}
+
+.shortcuts-help-table td:first-child {
+  width: 40%;
+  white-space: nowrap;
+}
+
+/* キーボードショートカット ヘルプモーダル (旧 HelpModal 互換) */
 .help-overlay {
   position: fixed;
   inset: 0;

--- a/apps/web/tests/client/ShortcutsHelp.test.tsx
+++ b/apps/web/tests/client/ShortcutsHelp.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+const { ShortcutsHelp } = await import("../../client/components/ShortcutsHelp");
+
+describe("ShortcutsHelp", () => {
+  it("renders nothing when open is false", () => {
+    const { container } = render(<ShortcutsHelp open={false} onClose={vi.fn<() => void>()} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the modal when open is true", () => {
+    render(<ShortcutsHelp open={true} onClose={vi.fn<() => void>()} />);
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    expect(screen.getByText("キーボードショートカット")).toBeTruthy();
+  });
+
+  it("shows all shortcut rows", () => {
+    render(<ShortcutsHelp open={true} onClose={vi.fn<() => void>()} />);
+    // j/k, Enter/o, m, s, ?, Esc の各ショートカット説明を確認
+    expect(screen.getByText("次の記事に移動")).toBeTruthy();
+    expect(screen.getByText("前の記事に移動")).toBeTruthy();
+    expect(screen.getByText("フォーカス中の記事を別タブで開く")).toBeTruthy();
+    expect(screen.getByText("既読 / 未読をトグル")).toBeTruthy();
+    expect(screen.getByText("スターをトグル")).toBeTruthy();
+    expect(screen.getByText("このヘルプを開く / 閉じる")).toBeTruthy();
+    expect(screen.getByText("ヘルプを閉じる / 検索バーから離れる")).toBeTruthy();
+  });
+
+  it("calls onClose when close button is clicked", async () => {
+    const onClose = vi.fn<() => void>();
+    const user = userEvent.setup();
+    render(<ShortcutsHelp open={true} onClose={onClose} />);
+    await user.click(screen.getByRole("button", { name: "閉じる" }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("calls onClose when overlay backdrop is clicked", async () => {
+    const onClose = vi.fn<() => void>();
+    const user = userEvent.setup();
+    render(<ShortcutsHelp open={true} onClose={onClose} />);
+    const overlay = screen.getByRole("dialog");
+    await user.click(overlay);
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("does not call onClose when modal content is clicked", async () => {
+    const onClose = vi.fn<() => void>();
+    const user = userEvent.setup();
+    render(<ShortcutsHelp open={true} onClose={onClose} />);
+    await user.click(screen.getByText("キーボードショートカット"));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("has aria-modal attribute set to true", () => {
+    render(<ShortcutsHelp open={true} onClose={vi.fn<() => void>()} />);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+  });
+});

--- a/apps/web/tests/client/useKeyboardNav.test.tsx
+++ b/apps/web/tests/client/useKeyboardNav.test.tsx
@@ -28,50 +28,60 @@ function fireKey(key: string) {
 describe("useKeyboardNav", () => {
   let onMarkRead: ReturnType<typeof vi.fn<(id: number) => void>>;
   let onToggleStar: ReturnType<typeof vi.fn<(id: number) => void>>;
+  // window に残るリスナーを分離するため各テストで unmount を追跡する
+  let unmount: () => void;
 
   beforeEach(() => {
     onMarkRead = vi.fn<(id: number) => void>();
     onToggleStar = vi.fn<(id: number) => void>();
+    unmount = () => {};
   });
 
   afterEach(() => {
+    // リスナーが window に残らないよう確実にアンマウントする
+    unmount();
     vi.clearAllMocks();
   });
 
   it("initially focusedIndex is null", () => {
-    const { result } = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
-    expect(result.current.focusedIndex).toBeNull();
+    const h = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    unmount = h.unmount;
+    expect(h.result.current.focusedIndex).toBeNull();
   });
 
   it("j moves focus to first article when no selection", () => {
-    const { result } = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    const h = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    unmount = h.unmount;
     act(() => {
       fireKey("j");
     });
-    expect(result.current.focusedIndex).toBe(0);
+    expect(h.result.current.focusedIndex).toBe(0);
   });
 
   it("ArrowDown moves focus to next article", () => {
-    const { result } = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    const h = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    unmount = h.unmount;
     act(() => {
       fireKey("ArrowDown");
     });
     act(() => {
       fireKey("ArrowDown");
     });
-    expect(result.current.focusedIndex).toBe(1);
+    expect(h.result.current.focusedIndex).toBe(1);
   });
 
   it("k moves focus to last article when no selection", () => {
-    const { result } = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    const h = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    unmount = h.unmount;
     act(() => {
       fireKey("k");
     });
-    expect(result.current.focusedIndex).toBe(2);
+    expect(h.result.current.focusedIndex).toBe(2);
   });
 
   it("ArrowUp moves focus to previous article", () => {
-    const { result } = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    const h = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    unmount = h.unmount;
     act(() => {
       fireKey("j");
     });
@@ -81,32 +91,35 @@ describe("useKeyboardNav", () => {
     act(() => {
       fireKey("ArrowUp");
     });
-    expect(result.current.focusedIndex).toBe(0);
+    expect(h.result.current.focusedIndex).toBe(0);
   });
 
   it("j does not exceed last index", () => {
-    const { result } = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    const h = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    unmount = h.unmount;
     act(() => {
       fireKey("j");
       fireKey("j");
       fireKey("j");
       fireKey("j");
     });
-    expect(result.current.focusedIndex).toBe(2);
+    expect(h.result.current.focusedIndex).toBe(2);
   });
 
   it("k does not go below index 0", () => {
-    const { result } = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    const h = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    unmount = h.unmount;
     act(() => {
       fireKey("j");
       fireKey("k");
       fireKey("k");
     });
-    expect(result.current.focusedIndex).toBe(0);
+    expect(h.result.current.focusedIndex).toBe(0);
   });
 
   it("m calls onMarkRead with focused article id", () => {
-    renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    const h = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    unmount = h.unmount;
     act(() => {
       fireKey("j");
     });
@@ -117,7 +130,8 @@ describe("useKeyboardNav", () => {
   });
 
   it("m does nothing when no article is focused", () => {
-    renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    const h = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    unmount = h.unmount;
     act(() => {
       fireKey("m");
     });
@@ -125,7 +139,8 @@ describe("useKeyboardNav", () => {
   });
 
   it("s calls onToggleStar with focused article id", () => {
-    renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    const h = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    unmount = h.unmount;
     act(() => {
       fireKey("j");
     });
@@ -136,7 +151,8 @@ describe("useKeyboardNav", () => {
   });
 
   it("s does nothing when no article is focused", () => {
-    renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    const h = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    unmount = h.unmount;
     act(() => {
       fireKey("s");
     });
@@ -144,42 +160,45 @@ describe("useKeyboardNav", () => {
   });
 
   it("? toggles helpOpen", () => {
-    const { result } = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
-    expect(result.current.helpOpen).toBe(false);
+    const h = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    unmount = h.unmount;
+    expect(h.result.current.helpOpen).toBe(false);
     act(() => {
       fireKey("?");
     });
-    expect(result.current.helpOpen).toBe(true);
+    expect(h.result.current.helpOpen).toBe(true);
     act(() => {
       fireKey("?");
     });
-    expect(result.current.helpOpen).toBe(false);
+    expect(h.result.current.helpOpen).toBe(false);
   });
 
   it("Escape closes helpOpen when open", () => {
-    const { result } = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    const h = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    unmount = h.unmount;
     act(() => {
       fireKey("?");
     });
-    expect(result.current.helpOpen).toBe(true);
+    expect(h.result.current.helpOpen).toBe(true);
     act(() => {
       fireKey("Escape");
     });
-    expect(result.current.helpOpen).toBe(false);
+    expect(h.result.current.helpOpen).toBe(false);
   });
 
   it("focusedIndex resets to last when articles shrink below current index", () => {
-    const { result, rerender } = renderHook(
+    const h = renderHook(
       ({ arts }) => useKeyboardNav({ articles: arts, onMarkRead, onToggleStar }),
       { initialProps: { arts: articles } },
     );
+    unmount = h.unmount;
     act(() => {
       fireKey("j");
       fireKey("j");
       fireKey("j");
     });
-    expect(result.current.focusedIndex).toBe(2);
-    rerender({ arts: [makeArticle(10)] });
-    expect(result.current.focusedIndex).toBe(0);
+    expect(h.result.current.focusedIndex).toBe(2);
+    h.rerender({ arts: [makeArticle(10)] });
+    expect(h.result.current.focusedIndex).toBe(0);
   });
 });

--- a/apps/web/tests/client/useKeyboardNav.test.tsx
+++ b/apps/web/tests/client/useKeyboardNav.test.tsx
@@ -1,5 +1,5 @@
 import { act, renderHook } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import type { Article } from "../../client/types/api";
 
 const { useKeyboardNav } = await import("../../client/hooks/useKeyboardNav");
@@ -25,180 +25,233 @@ function fireKey(key: string) {
   window.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
 }
 
+// リスナーが window に残らないよう各テスト内で unmount を呼ぶヘルパー
+function setup() {
+  const onMarkRead = vi.fn<(id: number) => void>();
+  const onToggleStar = vi.fn<(id: number) => void>();
+  const h = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+  return { ...h, onMarkRead, onToggleStar };
+}
+
 describe("useKeyboardNav", () => {
-  let onMarkRead: ReturnType<typeof vi.fn<(id: number) => void>>;
-  let onToggleStar: ReturnType<typeof vi.fn<(id: number) => void>>;
-  // window に残るリスナーを分離するため各テストで unmount を追跡する
-  let unmount: () => void;
-
-  beforeEach(() => {
-    onMarkRead = vi.fn<(id: number) => void>();
-    onToggleStar = vi.fn<(id: number) => void>();
-    unmount = () => {};
-  });
-
   afterEach(() => {
-    // リスナーが window に残らないよう確実にアンマウントする
-    unmount();
     vi.clearAllMocks();
   });
 
   it("initially focusedIndex is null", () => {
-    const h = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
-    unmount = h.unmount;
-    expect(h.result.current.focusedIndex).toBeNull();
+    const h = setup();
+    try {
+      expect(h.result.current.focusedIndex).toBeNull();
+    } finally {
+      h.unmount();
+    }
   });
 
   it("j moves focus to first article when no selection", () => {
-    const h = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
-    unmount = h.unmount;
-    act(() => {
-      fireKey("j");
-    });
-    expect(h.result.current.focusedIndex).toBe(0);
+    const h = setup();
+    try {
+      act(() => {
+        fireKey("j");
+      });
+      expect(h.result.current.focusedIndex).toBe(0);
+    } finally {
+      h.unmount();
+    }
   });
 
   it("ArrowDown moves focus to next article", () => {
-    const h = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
-    unmount = h.unmount;
-    act(() => {
-      fireKey("ArrowDown");
-    });
-    act(() => {
-      fireKey("ArrowDown");
-    });
-    expect(h.result.current.focusedIndex).toBe(1);
+    const h = setup();
+    try {
+      act(() => {
+        fireKey("ArrowDown");
+      });
+      act(() => {
+        fireKey("ArrowDown");
+      });
+      expect(h.result.current.focusedIndex).toBe(1);
+    } finally {
+      h.unmount();
+    }
   });
 
   it("k moves focus to last article when no selection", () => {
-    const h = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
-    unmount = h.unmount;
-    act(() => {
-      fireKey("k");
-    });
-    expect(h.result.current.focusedIndex).toBe(2);
+    const h = setup();
+    try {
+      act(() => {
+        fireKey("k");
+      });
+      expect(h.result.current.focusedIndex).toBe(2);
+    } finally {
+      h.unmount();
+    }
   });
 
   it("ArrowUp moves focus to previous article", () => {
-    const h = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
-    unmount = h.unmount;
-    act(() => {
-      fireKey("j");
-    });
-    act(() => {
-      fireKey("j");
-    });
-    act(() => {
-      fireKey("ArrowUp");
-    });
-    expect(h.result.current.focusedIndex).toBe(0);
+    const h = setup();
+    try {
+      act(() => {
+        fireKey("j");
+      });
+      act(() => {
+        fireKey("j");
+      });
+      act(() => {
+        fireKey("ArrowUp");
+      });
+      expect(h.result.current.focusedIndex).toBe(0);
+    } finally {
+      h.unmount();
+    }
   });
 
   it("j does not exceed last index", () => {
-    const h = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
-    unmount = h.unmount;
-    act(() => {
-      fireKey("j");
-      fireKey("j");
-      fireKey("j");
-      fireKey("j");
-    });
-    expect(h.result.current.focusedIndex).toBe(2);
+    const h = setup();
+    try {
+      act(() => {
+        fireKey("j");
+      });
+      act(() => {
+        fireKey("j");
+      });
+      act(() => {
+        fireKey("j");
+      });
+      act(() => {
+        fireKey("j");
+      });
+      expect(h.result.current.focusedIndex).toBe(2);
+    } finally {
+      h.unmount();
+    }
   });
 
   it("k does not go below index 0", () => {
-    const h = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
-    unmount = h.unmount;
-    act(() => {
-      fireKey("j");
-      fireKey("k");
-      fireKey("k");
-    });
-    expect(h.result.current.focusedIndex).toBe(0);
+    const h = setup();
+    try {
+      act(() => {
+        fireKey("j");
+      });
+      act(() => {
+        fireKey("k");
+      });
+      act(() => {
+        fireKey("k");
+      });
+      expect(h.result.current.focusedIndex).toBe(0);
+    } finally {
+      h.unmount();
+    }
   });
 
   it("m calls onMarkRead with focused article id", () => {
-    const h = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
-    unmount = h.unmount;
-    act(() => {
-      fireKey("j");
-    });
-    act(() => {
-      fireKey("m");
-    });
-    expect(onMarkRead).toHaveBeenCalledWith(10);
+    const h = setup();
+    try {
+      act(() => {
+        fireKey("j");
+      });
+      act(() => {
+        fireKey("m");
+      });
+      expect(h.onMarkRead).toHaveBeenCalledWith(10);
+    } finally {
+      h.unmount();
+    }
   });
 
   it("m does nothing when no article is focused", () => {
-    const h = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
-    unmount = h.unmount;
-    act(() => {
-      fireKey("m");
-    });
-    expect(onMarkRead).not.toHaveBeenCalled();
+    const h = setup();
+    try {
+      act(() => {
+        fireKey("m");
+      });
+      expect(h.onMarkRead).not.toHaveBeenCalled();
+    } finally {
+      h.unmount();
+    }
   });
 
   it("s calls onToggleStar with focused article id", () => {
-    const h = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
-    unmount = h.unmount;
-    act(() => {
-      fireKey("j");
-    });
-    act(() => {
-      fireKey("s");
-    });
-    expect(onToggleStar).toHaveBeenCalledWith(10);
+    const h = setup();
+    try {
+      act(() => {
+        fireKey("j");
+      });
+      act(() => {
+        fireKey("s");
+      });
+      expect(h.onToggleStar).toHaveBeenCalledWith(10);
+    } finally {
+      h.unmount();
+    }
   });
 
   it("s does nothing when no article is focused", () => {
-    const h = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
-    unmount = h.unmount;
-    act(() => {
-      fireKey("s");
-    });
-    expect(onToggleStar).not.toHaveBeenCalled();
+    const h = setup();
+    try {
+      act(() => {
+        fireKey("s");
+      });
+      expect(h.onToggleStar).not.toHaveBeenCalled();
+    } finally {
+      h.unmount();
+    }
   });
 
   it("? toggles helpOpen", () => {
-    const h = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
-    unmount = h.unmount;
-    expect(h.result.current.helpOpen).toBe(false);
-    act(() => {
-      fireKey("?");
-    });
-    expect(h.result.current.helpOpen).toBe(true);
-    act(() => {
-      fireKey("?");
-    });
-    expect(h.result.current.helpOpen).toBe(false);
+    const h = setup();
+    try {
+      expect(h.result.current.helpOpen).toBe(false);
+      act(() => {
+        fireKey("?");
+      });
+      expect(h.result.current.helpOpen).toBe(true);
+      act(() => {
+        fireKey("?");
+      });
+      expect(h.result.current.helpOpen).toBe(false);
+    } finally {
+      h.unmount();
+    }
   });
 
   it("Escape closes helpOpen when open", () => {
-    const h = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
-    unmount = h.unmount;
-    act(() => {
-      fireKey("?");
-    });
-    expect(h.result.current.helpOpen).toBe(true);
-    act(() => {
-      fireKey("Escape");
-    });
-    expect(h.result.current.helpOpen).toBe(false);
+    const h = setup();
+    try {
+      act(() => {
+        fireKey("?");
+      });
+      expect(h.result.current.helpOpen).toBe(true);
+      act(() => {
+        fireKey("Escape");
+      });
+      expect(h.result.current.helpOpen).toBe(false);
+    } finally {
+      h.unmount();
+    }
   });
 
   it("focusedIndex resets to last when articles shrink below current index", () => {
+    const onMarkRead = vi.fn<(id: number) => void>();
+    const onToggleStar = vi.fn<(id: number) => void>();
     const h = renderHook(
       ({ arts }) => useKeyboardNav({ articles: arts, onMarkRead, onToggleStar }),
       { initialProps: { arts: articles } },
     );
-    unmount = h.unmount;
-    act(() => {
-      fireKey("j");
-      fireKey("j");
-      fireKey("j");
-    });
-    expect(h.result.current.focusedIndex).toBe(2);
-    h.rerender({ arts: [makeArticle(10)] });
-    expect(h.result.current.focusedIndex).toBe(0);
+    try {
+      act(() => {
+        fireKey("j");
+      });
+      act(() => {
+        fireKey("j");
+      });
+      act(() => {
+        fireKey("j");
+      });
+      expect(h.result.current.focusedIndex).toBe(2);
+      h.rerender({ arts: [makeArticle(10)] });
+      expect(h.result.current.focusedIndex).toBe(0);
+    } finally {
+      h.unmount();
+    }
   });
 });

--- a/apps/web/tests/client/useKeyboardNav.test.tsx
+++ b/apps/web/tests/client/useKeyboardNav.test.tsx
@@ -1,0 +1,185 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import type { Article } from "../../client/types/api";
+
+const { useKeyboardNav } = await import("../../client/hooks/useKeyboardNav");
+
+const makeArticle = (id: number): Article => ({
+  id,
+  guid: `guid-${id}`,
+  feed_id: "feed-a",
+  feed_name: "Feed A",
+  title: `Article ${id}`,
+  url: `https://example.com/${id}`,
+  summary: null,
+  author: null,
+  published_at: "2024-01-01T00:00:00Z",
+  fetched_at: "2024-01-01T01:00:00Z",
+  category: "ai",
+  lang: "en",
+});
+
+const articles = [makeArticle(10), makeArticle(20), makeArticle(30)];
+
+function fireKey(key: string) {
+  window.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+}
+
+describe("useKeyboardNav", () => {
+  let onMarkRead: ReturnType<typeof vi.fn<(id: number) => void>>;
+  let onToggleStar: ReturnType<typeof vi.fn<(id: number) => void>>;
+
+  beforeEach(() => {
+    onMarkRead = vi.fn<(id: number) => void>();
+    onToggleStar = vi.fn<(id: number) => void>();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("initially focusedIndex is null", () => {
+    const { result } = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    expect(result.current.focusedIndex).toBeNull();
+  });
+
+  it("j moves focus to first article when no selection", () => {
+    const { result } = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    act(() => {
+      fireKey("j");
+    });
+    expect(result.current.focusedIndex).toBe(0);
+  });
+
+  it("ArrowDown moves focus to next article", () => {
+    const { result } = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    act(() => {
+      fireKey("ArrowDown");
+    });
+    act(() => {
+      fireKey("ArrowDown");
+    });
+    expect(result.current.focusedIndex).toBe(1);
+  });
+
+  it("k moves focus to last article when no selection", () => {
+    const { result } = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    act(() => {
+      fireKey("k");
+    });
+    expect(result.current.focusedIndex).toBe(2);
+  });
+
+  it("ArrowUp moves focus to previous article", () => {
+    const { result } = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    act(() => {
+      fireKey("j");
+    });
+    act(() => {
+      fireKey("j");
+    });
+    act(() => {
+      fireKey("ArrowUp");
+    });
+    expect(result.current.focusedIndex).toBe(0);
+  });
+
+  it("j does not exceed last index", () => {
+    const { result } = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    act(() => {
+      fireKey("j");
+      fireKey("j");
+      fireKey("j");
+      fireKey("j");
+    });
+    expect(result.current.focusedIndex).toBe(2);
+  });
+
+  it("k does not go below index 0", () => {
+    const { result } = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    act(() => {
+      fireKey("j");
+      fireKey("k");
+      fireKey("k");
+    });
+    expect(result.current.focusedIndex).toBe(0);
+  });
+
+  it("m calls onMarkRead with focused article id", () => {
+    renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    act(() => {
+      fireKey("j");
+    });
+    act(() => {
+      fireKey("m");
+    });
+    expect(onMarkRead).toHaveBeenCalledWith(10);
+  });
+
+  it("m does nothing when no article is focused", () => {
+    renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    act(() => {
+      fireKey("m");
+    });
+    expect(onMarkRead).not.toHaveBeenCalled();
+  });
+
+  it("s calls onToggleStar with focused article id", () => {
+    renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    act(() => {
+      fireKey("j");
+    });
+    act(() => {
+      fireKey("s");
+    });
+    expect(onToggleStar).toHaveBeenCalledWith(10);
+  });
+
+  it("s does nothing when no article is focused", () => {
+    renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    act(() => {
+      fireKey("s");
+    });
+    expect(onToggleStar).not.toHaveBeenCalled();
+  });
+
+  it("? toggles helpOpen", () => {
+    const { result } = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    expect(result.current.helpOpen).toBe(false);
+    act(() => {
+      fireKey("?");
+    });
+    expect(result.current.helpOpen).toBe(true);
+    act(() => {
+      fireKey("?");
+    });
+    expect(result.current.helpOpen).toBe(false);
+  });
+
+  it("Escape closes helpOpen when open", () => {
+    const { result } = renderHook(() => useKeyboardNav({ articles, onMarkRead, onToggleStar }));
+    act(() => {
+      fireKey("?");
+    });
+    expect(result.current.helpOpen).toBe(true);
+    act(() => {
+      fireKey("Escape");
+    });
+    expect(result.current.helpOpen).toBe(false);
+  });
+
+  it("focusedIndex resets to last when articles shrink below current index", () => {
+    const { result, rerender } = renderHook(
+      ({ arts }) => useKeyboardNav({ articles: arts, onMarkRead, onToggleStar }),
+      { initialProps: { arts: articles } },
+    );
+    act(() => {
+      fireKey("j");
+      fireKey("j");
+      fireKey("j");
+    });
+    expect(result.current.focusedIndex).toBe(2);
+    rerender({ arts: [makeArticle(10)] });
+    expect(result.current.focusedIndex).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- `useKeyboardNav` hook を新規作成し `App.tsx` に統合。`useKeyboardShortcuts` を置き換え
- j/k/ArrowDown/ArrowUp で記事間 focus 移動、Enter/o で別タブ開く、m で既読 toggle、s でスター toggle、? でヘルプ modal toggle、Esc で modal 閉じ or 検索バー blur
- `ShortcutsHelp.tsx` コンポーネント (aria-modal dialog) を新規作成
- CSS に `.shortcuts-help-overlay` / `.shortcuts-help-modal` を追加

## Test plan

- [x] `pnpm build` pass
- [x] `pnpm test` pass — 136 tests (18 new: useKeyboardNav x 14, ShortcutsHelp x 7 ※ 実質 7+14)
- [x] 既存エラー (usePresets.test.tsx vi.fn warning / tsconfig-error) は変更前から存在、本 PR で増加なし

Closes #110