### PR TITLE
feat(api): replace Scalar with Swagger UI 5.x on /api/docs

### DIFF
--- a/apps/web/tests/worker/api/openapi.test.ts
+++ b/apps/web/tests/worker/api/openapi.test.ts
@@ -28,4 +28,17 @@ describe("/api/docs", () => {
     expect(res.status).toBe(200);
     expect(res.headers.get("Content-Type")).toContain("text/html");
   });
+
+  it("HTML contains swagger-ui div and bundle script", async () => {
+    const res = await SELF.fetch("https://example.com/api/docs");
+    const body = await res.text();
+    expect(body).toContain('id="swagger-ui"');
+    expect(body).toContain("swagger-ui-bundle.js");
+  });
+
+  it("spec URL points to /api/openapi.json", async () => {
+    const res = await SELF.fetch("https://example.com/api/docs");
+    const body = await res.text();
+    expect(body).toContain("/api/openapi.json");
+  });
 });

--- a/apps/web/worker/api/docs.ts
+++ b/apps/web/worker/api/docs.ts
@@ -8,40 +8,31 @@ app.get("/openapi.json", (c) => {
   return c.json(openApiSchema);
 });
 
-// Scalar API Reference UI — loaded via CDN, no npm dep needed.
-// CSP on /api/docs is loosened so the CDN script can execute.
-app.get("/docs", (c) => {
-  const html = `<!DOCTYPE html>
-<html lang="en">
+const SWAGGER_UI_HTML = `<!DOCTYPE html>
+<html>
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>tech-news-bot API Reference</title>
+  <meta charset="UTF-8">
+  <title>tech-news-bot API Docs</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css">
 </head>
 <body>
-  <script
-    id="api-reference"
-    data-url="/api/openapi.json"
-    src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+  <div id="swagger-ui"></div>
+  <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+  <script>
+    window.ui = SwaggerUIBundle({
+      url: '/api/openapi.json',
+      dom_id: '#swagger-ui',
+      deepLinking: true,
+      presets: [SwaggerUIBundle.presets.apis]
+    });
+  </script>
 </body>
 </html>`;
 
-  // Override CSP so Scalar's CDN script can load and run.
-  c.header(
-    "Content-Security-Policy",
-    [
-      "default-src 'self'",
-      "script-src 'self' https://cdn.jsdelivr.net 'unsafe-inline'",
-      "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://fonts.googleapis.com",
-      "font-src 'self' https://fonts.gstatic.com",
-      "img-src 'self' data: https:",
-      "connect-src 'self' https://cdn.jsdelivr.net",
-      "frame-ancestors 'none'",
-      "base-uri 'self'",
-    ].join("; "),
-  );
-  c.header("Content-Type", "text/html; charset=utf-8");
-  return c.body(html);
-});
+app.get("/docs", (c) =>
+  c.html(SWAGGER_UI_HTML, 200, {
+    "Cache-Control": "public, max-age=86400, immutable",
+  }),
+);
 
 export default app;


### PR DESCRIPTION
## Summary

- `/api/docs` で Scalar API Reference を Swagger UI 5.x (CDN: jsdelivr) に置き換え
- HTML テンプレートを `SWAGGER_UI_HTML` 定数として `docs.ts` 内に inline 化
- レスポンスに `Cache-Control: public, max-age=86400, immutable` を付与
- Scalar 向けに設定していた CSP ヘッダーを削除 (仕様上 CSP 制限なし)
- `/api/openapi.json` は変更なし (既存動作を維持)

## Test plan

- [x] `pnpm check` pass (lint + typecheck)
- [x] `pnpm test` pass (155 tests)
- [x] `/api/docs` 200 + text/html (既存)
- [x] HTML 内に `id="swagger-ui"` と `swagger-ui-bundle.js` が含まれる (新規)
- [x] spec URL が `/api/openapi.json` を指している (新規)

Closes #113