### PR TITLE
feat(api): add GET /api/articles/:id endpoint

### DIFF
--- a/apps/web/tests/worker/api/articles.test.ts
+++ b/apps/web/tests/worker/api/articles.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it } from "vite-plus/test";
+import { env, SELF } from "cloudflare:test";
+import { insertArticles } from "../../../worker/db/articles";
+import { syncFeeds } from "../../../worker/db/feeds";
+import type { FeedConfig } from "../../../worker/types";
+
+const FEEDS: FeedConfig[] = [
+  {
+    id: "google-research",
+    name: "Google Research",
+    url: "https://x.test/g",
+    category: "bigtech",
+    lang: "en",
+    enabled: true,
+  },
+];
+
+beforeEach(async () => {
+  await syncFeeds(env.DB, FEEDS);
+  await insertArticles(env.DB, [
+    {
+      guid: "g-bt-1",
+      feed_id: "google-research",
+      title: "BigTech Article One",
+      url: "https://x.test/g/1",
+      summary: "Discusses LLM optimization",
+      author: "Author A",
+      published_at: "2024-04-01T00:00:00.000Z",
+      category: "bigtech",
+      lang: "en",
+    },
+  ]);
+});
+
+describe("GET /api/articles/:id", () => {
+  it("returns 200 with full article fields for existing article", async () => {
+    // 挿入した記事の id を D1 から取得
+    const row = await env.DB.prepare("SELECT id FROM articles WHERE guid = ?1")
+      .bind("g-bt-1")
+      .first<{ id: number }>();
+    const id = row?.id;
+
+    const res = await SELF.fetch(`https://example.com/api/articles/${id}`);
+    expect(res.status).toBe(200);
+
+    const body = await res.json<{
+      id: number;
+      guid: string;
+      feed_id: string;
+      feed_name: string | null;
+      title: string;
+      url: string;
+      summary: string | null;
+      author: string | null;
+      published_at: string;
+      fetched_at: string;
+      category: string;
+      lang: string;
+    }>();
+    expect(body.id).toBe(id);
+    expect(body.guid).toBe("g-bt-1");
+    expect(body.feed_id).toBe("google-research");
+    expect(body.title).toBe("BigTech Article One");
+    expect(body.url).toBe("https://x.test/g/1");
+    expect(body.category).toBe("bigtech");
+    expect(body.lang).toBe("en");
+    expect(typeof body.fetched_at).toBe("string");
+  });
+
+  it("returns 404 for non-existent id", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/99999999");
+    expect(res.status).toBe(404);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toBe("not found");
+  });
+
+  it("returns 400 for non-integer id", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/abc");
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toBe("invalid id");
+  });
+
+  it("returns 304 when If-None-Match matches ETag", async () => {
+    const row = await env.DB.prepare("SELECT id FROM articles WHERE guid = ?1")
+      .bind("g-bt-1")
+      .first<{ id: number }>();
+    const id = row?.id;
+
+    // 1回目のリクエストで ETag を取得
+    const res1 = await SELF.fetch(`https://example.com/api/articles/${id}`);
+    expect(res1.status).toBe(200);
+    const etag = res1.headers.get("ETag");
+    expect(etag).not.toBeNull();
+
+    // 2回目は If-None-Match を付けて 304 を期待
+    const res2 = await SELF.fetch(`https://example.com/api/articles/${id}`, {
+      headers: { "If-None-Match": etag! },
+    });
+    expect(res2.status).toBe(304);
+  });
+
+  it("returns Content-Type application/json for 200 response", async () => {
+    const row = await env.DB.prepare("SELECT id FROM articles WHERE guid = ?1")
+      .bind("g-bt-1")
+      .first<{ id: number }>();
+    const id = row?.id;
+
+    const res = await SELF.fetch(`https://example.com/api/articles/${id}`);
+    expect(res.status).toBe(200);
+    const contentType = res.headers.get("Content-Type");
+    expect(contentType).toMatch(/application\/json/);
+  });
+});

--- a/apps/web/worker/api/articles.ts
+++ b/apps/web/worker/api/articles.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import type { Env, FeedCategory, FeedLang } from "../types";
 import { loadAllFeeds } from "../feed-config";
-import { listArticles } from "../db/articles";
+import { getArticleById, listArticles } from "../db/articles";
 import { computeArticlesEtag } from "../utils/etag";
 import feedsYaml from "../feeds.yaml";
 import type { FeedsFile } from "../types";
@@ -102,6 +102,17 @@ app.get("/", async (c) => {
     articles: result.articles,
     nextCursor: encodeCursor(result.nextCursor),
   });
+});
+
+app.get("/:id", async (c) => {
+  const idStr = c.req.param("id");
+  const id = Number(idStr);
+  if (!Number.isInteger(id) || id <= 0) return c.json({ error: "invalid id" }, 400);
+  const article = await getArticleById(c.env.DB, id);
+  if (!article) return c.json({ error: "not found" }, 404);
+  const etag = `W/"${article.id}-${article.fetched_at}"`;
+  if (c.req.header("If-None-Match") === etag) return c.body(null, 304);
+  return c.json(article, 200, { ETag: etag, "Cache-Control": "public, max-age=60" });
 });
 
 export default app;

--- a/apps/web/worker/db/articles.ts
+++ b/apps/web/worker/db/articles.ts
@@ -141,6 +141,21 @@ export async function listArticles(
   return { articles, nextCursor };
 }
 
+export async function getArticleById(db: D1Database, id: number): Promise<Article | null> {
+  const result = await db
+    .prepare(
+      `SELECT a.id, a.guid, a.feed_id, f.name AS feed_name, a.title, a.url, a.summary,
+              a.author, a.published_at, a.fetched_at, a.category, a.lang
+       FROM articles a
+       LEFT JOIN feeds f ON f.id = a.feed_id
+       WHERE a.id = ?1
+       LIMIT 1`,
+    )
+    .bind(id)
+    .first<Article>();
+  return result ?? null;
+}
+
 export async function deleteOlderThan(db: D1Database, retentionDays: number): Promise<number> {
   if (!Number.isFinite(retentionDays) || retentionDays <= 0) return 0;
   // SQLite で安全のため整数化、少数日は切り捨て


### PR DESCRIPTION
## Summary
- `GET /api/articles/:id` を追加し、ID 指定で 1 記事を取得可能にした
- 404 (不明 id) / 400 (non-integer) / 304 (If-None-Match) を実装
- ETag は `W/"<id>-<fetched_at>"`

Closes #117

## Test plan
- [x] vp build / pnpm test pass
- [x] 5 ケースの新規テスト (200 normal / 404 / 400 / 304 / Content-Type)