### PR TITLE
feat: add GET /sitemap.xml endpoint

### DIFF
--- a/apps/web/tests/worker/api/sitemap.test.ts
+++ b/apps/web/tests/worker/api/sitemap.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vite-plus/test";
+import { SELF } from "cloudflare:test";
+
+describe("/sitemap.xml", () => {
+  it("returns 200 with Content-Type application/xml", async () => {
+    const res = await SELF.fetch("https://example.com/sitemap.xml");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("application/xml");
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=3600");
+  });
+
+  it("contains root URL <loc>", async () => {
+    const res = await SELF.fetch("https://example.com/sitemap.xml");
+    const text = await res.text();
+    expect(text).toContain("<loc>https://example.com/</loc>");
+    expect(text).toContain("<priority>1.0</priority>");
+    expect(text).toContain("<changefreq>hourly</changefreq>");
+  });
+
+  it("contains enabled feed_id URL (google-research)", async () => {
+    const res = await SELF.fetch("https://example.com/sitemap.xml");
+    const text = await res.text();
+    // feeds.yaml で enabled: true のフィードが含まれること
+    expect(text).toContain("/?feed_id=google-research");
+    expect(text).toContain("<changefreq>daily</changefreq>");
+    expect(text).toContain("<priority>0.6</priority>");
+  });
+});

--- a/apps/web/worker/api/sitemap.ts
+++ b/apps/web/worker/api/sitemap.ts
@@ -1,0 +1,58 @@
+import { Hono } from "hono";
+import type { Env } from "../types";
+import { loadEnabledFeeds } from "../feed-config";
+
+const app = new Hono<{ Bindings: Env }>();
+
+function escapeXml(input: string): string {
+  return input.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function buildSitemap(origin: string): string {
+  const feeds = loadEnabledFeeds();
+
+  const staticUrls = [
+    [
+      `<url>`,
+      `<loc>${escapeXml(origin)}/</loc>`,
+      `<changefreq>hourly</changefreq>`,
+      `<priority>1.0</priority>`,
+      `</url>`,
+    ].join(""),
+    [
+      `<url>`,
+      `<loc>${escapeXml(origin)}/api/openapi.json</loc>`,
+      `<priority>0.3</priority>`,
+      `</url>`,
+    ].join(""),
+  ];
+
+  const feedUrls = feeds.map((f) =>
+    [
+      `<url>`,
+      `<loc>${escapeXml(origin)}/?feed_id=${escapeXml(f.id)}</loc>`,
+      `<changefreq>daily</changefreq>`,
+      `<priority>0.6</priority>`,
+      `</url>`,
+    ].join(""),
+  );
+
+  return (
+    `<?xml version="1.0" encoding="UTF-8"?>` +
+    `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">` +
+    staticUrls.join("") +
+    feedUrls.join("") +
+    `</urlset>`
+  );
+}
+
+app.get("/sitemap.xml", (c) => {
+  const url = new URL(c.req.url);
+  const origin = `${url.protocol}//${url.host}`;
+  const xml = buildSitemap(origin);
+  c.header("Content-Type", "application/xml; charset=utf-8");
+  c.header("Cache-Control", "public, max-age=3600");
+  return c.body(xml);
+});
+
+export default app;

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import type { Env } from "./types";
 import api from "./api/router";
+import sitemap from "./api/sitemap";
 import syndication from "./api/syndication";
 import { collectAll } from "./collector";
 import { pruneOldArticles } from "./db/retention";
@@ -29,6 +30,7 @@ app.use("*", async (c, next) => {
 });
 
 app.route("/api", api);
+app.route("/", sitemap);
 app.route("/", syndication);
 
 // 静的アセットへのフォールバック (Cloudflare Static Assets binding)


### PR DESCRIPTION
## Summary

- `apps/web/worker/api/sitemap.ts` を新規追加し、Sitemap Protocol 0.9 準拠の XML を生成
- `apps/web/worker/index.ts` に `/sitemap.xml` ルートを登録
- `apps/web/tests/worker/api/sitemap.test.ts` にテスト 3 ケースを追加

## 仕様

- `GET /sitemap.xml` → `application/xml; charset=utf-8`
- `Cache-Control: public, max-age=3600`
- ルート URL (`priority=1.0`, `changefreq=hourly`)・`/api/openapi.json` (`priority=0.3`)・`loadEnabledFeeds()` で取得した enabled フィードのページ (`priority=0.6`, `changefreq=daily`) を列挙
- ホストは `c.req.url` から origin を抽出
- `&` `<` `>` を XML escape する utility を内包

## Test plan

- [ ] `200 + Content-Type: application/xml` を返すこと
- [ ] `<loc>https://example.com/</loc>` を含むこと
- [ ] enabled フィード (`google-research`) の `/?feed_id=google-research` を含むこと

Closes #122