### PR TITLE
feat(client): トースト通知システムの実装

### DIFF
--- a/apps/web/client/App.tsx
+++ b/apps/web/client/App.tsx
@@ -6,6 +6,7 @@ import { PresetBar } from "./components/PresetBar";
 import { SearchInput } from "./components/SearchInput";
 import { ShortcutsHelp } from "./components/ShortcutsHelp";
 import { StatsPanel } from "./components/Stats";
+import { ToastContainer } from "./components/ToastContainer";
 import { useArticles } from "./hooks/useArticles";
 import { useFeeds } from "./hooks/useFeeds";
 import { useKeyboardNav } from "./hooks/useKeyboardNav";
@@ -13,6 +14,7 @@ import { usePresets } from "./hooks/usePresets";
 import { useReadState } from "./hooks/useReadState";
 import { useStarredState } from "./hooks/useStarredState";
 import { useStats } from "./hooks/useStats";
+import { ToastContext, useToastState } from "./hooks/useToast";
 import type { FeedCategory, FeedLang } from "./types/api";
 
 function formatRelative(iso: string): string {
@@ -75,7 +77,7 @@ function buildSearch(
   return s ? `?${s}` : window.location.pathname;
 }
 
-export default function App() {
+function AppInner() {
   const [category, setCategory] = useState<FeedCategory | "">(() => readFromUrl().category);
   const [lang, setLang] = useState<FeedLang | "">(() => readFromUrl().lang);
   const [feedId, setFeedId] = useState<string>(() => readFromUrl().feedId);
@@ -364,6 +366,16 @@ export default function App() {
           {loadingMore ? "読み込み中…" : "もっと読み込む"}
         </button>
       )}
+      <ToastContainer />
     </div>
+  );
+}
+
+export default function App() {
+  const toastState = useToastState();
+  return (
+    <ToastContext.Provider value={toastState}>
+      <AppInner />
+    </ToastContext.Provider>
   );
 }

--- a/apps/web/client/components/ShareButtons.tsx
+++ b/apps/web/client/components/ShareButtons.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useToast } from "../hooks/useToast";
 
 interface Props {
   url: string;
@@ -7,6 +8,7 @@ interface Props {
 
 export function ShareButtons({ url, title }: Props) {
   const [copied, setCopied] = useState(false);
+  const { show } = useToast();
 
   const encUrl = encodeURIComponent(url);
   const encTitle = encodeURIComponent(title);
@@ -19,6 +21,7 @@ export function ShareButtons({ url, title }: Props) {
       await navigator.clipboard.writeText(url);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
+      show("リンクをコピーしました", "success");
     } catch {
       // clipboard API 非対応環境では無視
     }

--- a/apps/web/client/components/Toast.tsx
+++ b/apps/web/client/components/Toast.tsx
@@ -1,0 +1,27 @@
+import type { Toast as ToastData } from "../hooks/useToast";
+
+interface Props {
+  toast: ToastData;
+  onDismiss: (id: string) => void;
+}
+
+export function Toast({ toast, onDismiss }: Props) {
+  return (
+    <div
+      className={`toast toast-${toast.kind}`}
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      <span className="toast-msg">{toast.msg}</span>
+      <button
+        type="button"
+        className="toast-close"
+        aria-label="閉じる"
+        onClick={() => onDismiss(toast.id)}
+      >
+        x
+      </button>
+    </div>
+  );
+}

--- a/apps/web/client/components/ToastContainer.tsx
+++ b/apps/web/client/components/ToastContainer.tsx
@@ -1,0 +1,15 @@
+import { useToastContext } from "../hooks/useToast";
+import { Toast } from "./Toast";
+
+export function ToastContainer() {
+  const ctx = useToastContext();
+  if (!ctx || ctx.toasts.length === 0) return null;
+
+  return (
+    <div className="toast-container" aria-label="通知">
+      {ctx.toasts.map((toast) => (
+        <Toast key={toast.id} toast={toast} onDismiss={ctx.dismiss} />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/client/hooks/useToast.ts
+++ b/apps/web/client/hooks/useToast.ts
@@ -1,0 +1,71 @@
+import { createContext, useCallback, useContext, useId, useRef, useState } from "react";
+
+export type ToastKind = "info" | "success" | "error";
+
+export interface Toast {
+  id: string;
+  msg: string;
+  kind: ToastKind;
+}
+
+interface ToastContextValue {
+  toasts: Toast[];
+  show: (msg: string, kind?: ToastKind) => void;
+  dismiss: (id: string) => void;
+}
+
+const MAX_TOASTS = 3;
+const DISMISS_MS = 4000;
+
+export const ToastContext = createContext<ToastContextValue | undefined>(undefined);
+
+/**
+ * ToastProvider の外 (Provider なし環境) から呼ばれた場合は no-op を返す。
+ * Provider 内では実際のトースト操作を提供する。
+ */
+export function useToast(): { show: (msg: string, kind?: ToastKind) => void } {
+  const ctx = useContext(ToastContext);
+  if (!ctx) {
+    // Provider なし環境では何もしない
+    return { show: () => {} };
+  }
+  return { show: ctx.show };
+}
+
+// Context 値をそのまま取得したい内部コンポーネント向け
+export function useToastContext(): ToastContextValue | undefined {
+  return useContext(ToastContext);
+}
+
+// Provider 実装は ToastContainer / App 側で行うため、
+// ここでは Context と hook のみを export する。
+// 状態管理の実体は useToastState() として切り出す。
+export function useToastState(): ToastContextValue {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  // useId はサーバーサイドでも安全な id 生成。ブラウザ環境なので Date.now() prefix で衝突回避。
+  const baseId = useId();
+  // useRef で counter を管理することで useCallback の deps に含める必要をなくす
+  const counterRef = useRef(0);
+
+  const dismiss = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const show = useCallback(
+    (msg: string, kind: ToastKind = "info") => {
+      const id = `${baseId}-${Date.now()}-${counterRef.current++}`;
+      setToasts((prev) => {
+        const next = [...prev, { id, msg, kind }];
+        // 最大件数を超えたら古いものから削除
+        return next.length > MAX_TOASTS ? next.slice(next.length - MAX_TOASTS) : next;
+      });
+      // 4 秒後に自動 dismiss
+      setTimeout(() => {
+        setToasts((prev) => prev.filter((t) => t.id !== id));
+      }, DISMISS_MS);
+    },
+    [baseId],
+  );
+
+  return { toasts, show, dismiss };
+}

--- a/apps/web/client/index.css
+++ b/apps/web/client/index.css
@@ -787,3 +787,83 @@ kbd {
   white-space: nowrap;
   width: 160px;
 }
+
+/* トースト通知 */
+@keyframes toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.toast-container {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  z-index: 200;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  pointer-events: none;
+}
+
+.toast {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  font-size: 0.9rem;
+  min-width: 220px;
+  max-width: 360px;
+  pointer-events: auto;
+  animation: toast-in 0.2s ease;
+}
+
+.toast-success {
+  border-color: var(--badge-jp);
+  color: var(--badge-jp);
+}
+
+.toast-error {
+  border-color: #f85149;
+  color: #f85149;
+}
+
+.toast-msg {
+  flex: 1;
+  color: var(--fg);
+}
+
+.toast-success .toast-msg {
+  color: var(--badge-jp);
+}
+
+.toast-error .toast-msg {
+  color: #f85149;
+}
+
+.toast-close {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: var(--fg-muted);
+  font-size: 0.85rem;
+  font-family: inherit;
+  cursor: pointer;
+  padding: 0 2px;
+  line-height: 1;
+  opacity: 0.7;
+}
+
+.toast-close:hover {
+  opacity: 1;
+  color: var(--fg);
+}

--- a/apps/web/tests/client/useToast.test.tsx
+++ b/apps/web/tests/client/useToast.test.tsx
@@ -8,11 +8,7 @@ function ToastTestBed({ msg, kind }: { msg: string; kind?: ToastKind }) {
   const state = useToastState();
   return (
     <ToastContext.Provider value={state}>
-      <button
-        type="button"
-        onClick={() => state.show(msg, kind)}
-        data-testid="trigger"
-      >
+      <button type="button" onClick={() => state.show(msg, kind)} data-testid="trigger">
         show
       </button>
       <ToastContainer />

--- a/apps/web/tests/client/useToast.test.tsx
+++ b/apps/web/tests/client/useToast.test.tsx
@@ -1,0 +1,126 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { ToastContainer } from "../../client/components/ToastContainer";
+import { type ToastKind, ToastContext, useToastState } from "../../client/hooks/useToast";
+
+// テスト用コンポーネント: ボタン押下で show を呼び出せるようにする
+function ToastTestBed({ msg, kind }: { msg: string; kind?: ToastKind }) {
+  const state = useToastState();
+  return (
+    <ToastContext.Provider value={state}>
+      <button
+        type="button"
+        onClick={() => state.show(msg, kind)}
+        data-testid="trigger"
+      >
+        show
+      </button>
+      <ToastContainer />
+    </ToastContext.Provider>
+  );
+}
+
+describe("useToast / ToastContainer", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("Provider 内で show を呼ぶと toast が DOM に表示される", () => {
+    render(<ToastTestBed msg="テスト通知" kind="info" />);
+
+    act(() => {
+      fireEvent.click(screen.getByTestId("trigger"));
+    });
+
+    expect(screen.getByText("テスト通知")).toBeTruthy();
+  });
+
+  it("4 秒後にトーストが自動 dismiss される", () => {
+    render(<ToastTestBed msg="自動削除通知" kind="info" />);
+
+    act(() => {
+      fireEvent.click(screen.getByTestId("trigger"));
+    });
+
+    expect(screen.getByText("自動削除通知")).toBeTruthy();
+
+    act(() => {
+      vi.advanceTimersByTime(4001);
+    });
+
+    expect(screen.queryByText("自動削除通知")).toBeNull();
+  });
+
+  it("x ボタンクリックでトーストが dismiss される", () => {
+    render(<ToastTestBed msg="手動削除通知" kind="success" />);
+
+    act(() => {
+      fireEvent.click(screen.getByTestId("trigger"));
+    });
+
+    expect(screen.getByText("手動削除通知")).toBeTruthy();
+
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /閉じる/i }));
+    });
+
+    expect(screen.queryByText("手動削除通知")).toBeNull();
+  });
+
+  it("最大 3 件を超えると古いトーストが削除される", () => {
+    function MultiShowBed() {
+      const state = useToastState();
+      return (
+        <ToastContext.Provider value={state}>
+          {(["通知1", "通知2", "通知3", "通知4"] as const).map((msg) => (
+            <button
+              key={msg}
+              type="button"
+              data-testid={msg}
+              onClick={() => state.show(msg, "info")}
+            >
+              {msg}
+            </button>
+          ))}
+          <ToastContainer />
+        </ToastContext.Provider>
+      );
+    }
+
+    render(<MultiShowBed />);
+
+    act(() => {
+      // 4 件連続で追加
+      for (const msg of ["通知1", "通知2", "通知3", "通知4"]) {
+        fireEvent.click(screen.getByTestId(msg));
+      }
+    });
+
+    // .toast-msg 要素のみで判定 (ボタンのテキストは除外)
+    const toastMsgs = document.querySelectorAll(".toast-msg");
+    const msgs = [...toastMsgs].map((el) => el.textContent);
+
+    // 最新 3 件のみ残り、最古の「通知1」は消える
+    expect(msgs).not.toContain("通知1");
+    expect(msgs).toContain("通知2");
+    expect(msgs).toContain("通知3");
+    expect(msgs).toContain("通知4");
+    expect(toastMsgs).toHaveLength(3);
+  });
+
+  it("toast 要素に aria-live='polite' と role='status' が設定されている", () => {
+    render(<ToastTestBed msg="aria テスト" kind="error" />);
+
+    act(() => {
+      fireEvent.click(screen.getByTestId("trigger"));
+    });
+
+    const toastEl = screen.getByRole("status");
+    expect(toastEl).toBeTruthy();
+    expect(toastEl.getAttribute("aria-live")).toBe("polite");
+  });
+});


### PR DESCRIPTION
## Summary

- `useToast()` hook で `show(msg, kind?)` を提供 (React Context + useState)
- `ToastContainer` / `Toast` コンポーネントで top-right 固定表示 (position: fixed)
- 自動 dismiss 4 秒、x ボタンで手動閉じ、最大 3 件制限 (超過時は古いものから削除)
- `aria-live="polite"` / `role="status"` でアクセシビリティ対応
- ShareButtons コピー成功時に `show("リンクをコピーしました", "success")` を呼ぶ
- 依存追加なし (React Context + useState のみ)

## Test plan

- [x] `useToast.test.tsx` に 5 ケース追加 (表示・自動 dismiss・手動閉じ・最大 3 件・aria)
- [x] `vp test run --config vitest.client.config.ts` 全 70 ケース pass
- [x] `vp test run` (worker) 全 171 ケース pass
- [x] `vp build` success

Closes #121