### PR TITLE
feat: add GET /api/articles/random endpoint

### DIFF
--- a/apps/web/tests/worker/api/articles.test.ts
+++ b/apps/web/tests/worker/api/articles.test.ts
@@ -13,6 +13,14 @@ const FEEDS: FeedConfig[] = [
     lang: "en",
     enabled: true,
   },
+  {
+    id: "openai-blog",
+    name: "OpenAI Blog",
+    url: "https://x.test/o",
+    category: "ai",
+    lang: "en",
+    enabled: true,
+  },
 ];
 
 beforeEach(async () => {
@@ -29,7 +37,73 @@ beforeEach(async () => {
       category: "bigtech",
       lang: "en",
     },
+    {
+      guid: "o-ai-1",
+      feed_id: "openai-blog",
+      title: "AI Article One",
+      url: "https://x.test/o/1",
+      summary: "Discusses GPT",
+      author: "Author B",
+      published_at: "2024-04-02T00:00:00.000Z",
+      category: "ai",
+      lang: "en",
+    },
+    {
+      guid: "o-ai-2",
+      feed_id: "openai-blog",
+      title: "AI Article Two",
+      url: "https://x.test/o/2",
+      summary: "Discusses DALL-E",
+      author: "Author C",
+      published_at: "2024-04-03T00:00:00.000Z",
+      category: "ai",
+      lang: "en",
+    },
   ]);
+});
+
+describe("GET /api/articles/random", () => {
+  it("returns 200 with articles array using default n=10", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/random");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    const body = await res.json<{ articles: unknown[] }>();
+    expect(Array.isArray(body.articles)).toBe(true);
+    // DB に 3 件しかないので 3 件以下
+    expect(body.articles.length).toBeLessThanOrEqual(3);
+  });
+
+  it("returns n=5 articles when n=5 is specified and enough records exist", async () => {
+    // DB には 3 件しかないため n=2 で 2 件返ることを確認
+    const res = await SELF.fetch("https://example.com/api/articles/random?n=2");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ articles: unknown[] }>();
+    expect(body.articles.length).toBe(2);
+  });
+
+  it("returns only ai category articles when category=ai", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/random?category=ai");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ articles: { category: string }[] }>();
+    expect(body.articles.length).toBeGreaterThan(0);
+    for (const article of body.articles) {
+      expect(article.category).toBe("ai");
+    }
+  });
+
+  it("returns 400 when n=0", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/random?n=0");
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toBe("n must be 1-50");
+  });
+
+  it("returns 400 when n=100", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/random?n=100");
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toBe("n must be 1-50");
+  });
 });
 
 describe("GET /api/articles/:id", () => {

--- a/apps/web/worker/api/articles.ts
+++ b/apps/web/worker/api/articles.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import type { Env, FeedCategory, FeedLang } from "../types";
 import { loadAllFeeds } from "../feed-config";
-import { getArticleById, listArticles } from "../db/articles";
+import { getArticleById, getRandomArticles, listArticles } from "../db/articles";
 import { computeArticlesEtag } from "../utils/etag";
 import feedsYaml from "../feeds.yaml";
 import type { FeedsFile } from "../types";
@@ -102,6 +102,26 @@ app.get("/", async (c) => {
     articles: result.articles,
     nextCursor: encodeCursor(result.nextCursor),
   });
+});
+
+app.get("/random", async (c) => {
+  const n = Number(c.req.query("n") ?? "10");
+  if (!Number.isInteger(n) || n < 1 || n > 50) return c.json({ error: "n must be 1-50" }, 400);
+
+  const categoryRaw = c.req.query("category");
+  const langRaw = c.req.query("lang");
+  const feedIdRaw = c.req.query("feed_id") ?? undefined;
+
+  const category =
+    categoryRaw && (VALID_CATEGORIES as string[]).includes(categoryRaw)
+      ? (categoryRaw as FeedCategory)
+      : undefined;
+  const lang =
+    langRaw && (VALID_LANGS as string[]).includes(langRaw) ? (langRaw as FeedLang) : undefined;
+  const feedId = feedIdRaw && VALID_FEED_IDS.has(feedIdRaw) ? feedIdRaw : undefined;
+
+  const articles = await getRandomArticles(c.env.DB, { n, category, lang, feedId });
+  return c.json({ articles }, 200, { "Cache-Control": "no-store" });
 });
 
 app.get("/:id", async (c) => {

--- a/apps/web/worker/db/articles.ts
+++ b/apps/web/worker/db/articles.ts
@@ -141,6 +141,53 @@ export async function listArticles(
   return { articles, nextCursor };
 }
 
+export interface GetRandomArticlesParams {
+  n: number;
+  category?: FeedCategory;
+  lang?: FeedLang;
+  feedId?: string;
+}
+
+export async function getRandomArticles(
+  db: D1Database,
+  params: GetRandomArticlesParams,
+): Promise<Article[]> {
+  const conds: string[] = [];
+  const binds: unknown[] = [];
+
+  if (params.category) {
+    conds.push(`a.category = ?${binds.length + 1}`);
+    binds.push(params.category);
+  }
+  if (params.lang) {
+    conds.push(`a.lang = ?${binds.length + 1}`);
+    binds.push(params.lang);
+  }
+  if (params.feedId) {
+    conds.push(`a.feed_id = ?${binds.length + 1}`);
+    binds.push(params.feedId);
+  }
+
+  const where = conds.length > 0 ? `WHERE ${conds.join(" AND ")}` : "";
+  const sql = `
+    SELECT a.id, a.guid, a.feed_id, f.name AS feed_name, a.title, a.url, a.summary,
+           a.author, a.published_at, a.fetched_at, a.category, a.lang
+    FROM articles a
+    LEFT JOIN feeds f ON f.id = a.feed_id
+    ${where}
+    ORDER BY RANDOM()
+    LIMIT ?${binds.length + 1}
+  `;
+  binds.push(params.n);
+
+  const result = await db
+    .prepare(sql)
+    .bind(...binds)
+    .all<Article>();
+
+  return result.results ?? [];
+}
+
 export async function getArticleById(db: D1Database, id: number): Promise<Article | null> {
   const result = await db
     .prepare(


### PR DESCRIPTION
## Summary

- `apps/web/worker/db/articles.ts` に `getRandomArticles(db, { n, category?, lang?, feedId? })` を追加 (`ORDER BY RANDOM() LIMIT n`)
- `apps/web/worker/api/articles.ts` に `/random` ルートを `/:id` の前に追加。`n` は 1-50 の範囲外で 400、レスポンスに `Cache-Control: no-store` を付与
- `apps/web/tests/worker/api/articles.test.ts` にテスト 5 ケースを追加

## Test plan

- [x] `vp check` pass (lint/fmt/typecheck)
- [x] `vp test run` pass (176 tests)
- [ ] CI (build/test) 通過確認

Closes #123