### PR TITLE
feat(collector): add run metrics to D1 and /api/admin/runs endpoint

### DIFF
--- a/apps/web/tests/worker/api/admin.test.ts
+++ b/apps/web/tests/worker/api/admin.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vite-plus/test";
 import { env, SELF } from "cloudflare:test";
 import { syncFeeds } from "../../../worker/db/feeds";
+import { finishRun, recordRunFeed, startRun } from "../../../worker/db/runs";
 import type { FeedConfig } from "../../../worker/types";
 
 const TEST_FEED: FeedConfig = {
@@ -164,5 +165,85 @@ describe("POST /api/admin/collector/run", () => {
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
     expect(body.error).toBe("feed_ids must be an array");
+  });
+});
+
+describe("GET /api/admin/runs", () => {
+  it("200: returns empty runs array when no runs exist", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/runs", {
+      headers: AUTH_HEADER,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { runs: unknown[] };
+    expect(Array.isArray(body.runs)).toBe(true);
+    expect(body.runs).toHaveLength(0);
+  });
+
+  it("200: returns runs list", async () => {
+    const { run_id } = await startRun(env.DB, "2024-04-01T00:00:00.000Z", 3);
+    await finishRun(env.DB, run_id, "2024-04-01T00:00:10.000Z", 2, 1, 15);
+
+    const res = await SELF.fetch("https://example.com/api/admin/runs", {
+      headers: AUTH_HEADER,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { runs: { id: number; feeds_ok: number }[] };
+    expect(body.runs).toHaveLength(1);
+    expect(body.runs[0].id).toBe(run_id);
+    expect(body.runs[0].feeds_ok).toBe(2);
+  });
+
+  it("200: clamps limit to max 100", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/runs?limit=9999", {
+      headers: AUTH_HEADER,
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("401: rejects unauthenticated request", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/runs");
+    expect(res.status).toBe(401);
+  });
+
+  it("401: rejects invalid token", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/runs", {
+      headers: { authorization: "Bearer wrong-token" },
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /api/admin/runs/:id", () => {
+  it("200: returns run detail with feeds", async () => {
+    const { run_id } = await startRun(env.DB, "2024-04-05T00:00:00.000Z", 2);
+    await recordRunFeed(env.DB, run_id, "feed-a", "ok", 10, 800);
+    await recordRunFeed(env.DB, run_id, "feed-b", "failed", 0, 200, "HTTP 500");
+    await finishRun(env.DB, run_id, "2024-04-05T00:00:05.000Z", 1, 1, 10);
+
+    const res = await SELF.fetch(`https://example.com/api/admin/runs/${run_id}`, {
+      headers: AUTH_HEADER,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      run: { id: number; feeds_ok: number };
+      feeds: { feed_id: string; status: string }[];
+    };
+    expect(body.run.id).toBe(run_id);
+    expect(body.run.feeds_ok).toBe(1);
+    expect(body.feeds).toHaveLength(2);
+    const feedA = body.feeds.find((f) => f.feed_id === "feed-a");
+    expect(feedA!.status).toBe("ok");
+  });
+
+  it("404: returns not found for unknown id", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/runs/99999", {
+      headers: AUTH_HEADER,
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("401: rejects unauthenticated request", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/runs/1");
+    expect(res.status).toBe(401);
   });
 });

--- a/apps/web/tests/worker/db/runs.test.ts
+++ b/apps/web/tests/worker/db/runs.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vite-plus/test";
+import { env } from "cloudflare:test";
+import { finishRun, getRun, listRuns, recordRunFeed, startRun } from "../../../worker/db/runs";
+
+describe("runs db", () => {
+  it("startRun returns a run_id", async () => {
+    const { run_id } = await startRun(env.DB, "2024-04-01T00:00:00.000Z", 5);
+    expect(typeof run_id).toBe("number");
+    expect(run_id).toBeGreaterThan(0);
+  });
+
+  it("listRuns returns empty array when no runs exist", async () => {
+    const runs = await listRuns(env.DB);
+    expect(runs).toHaveLength(0);
+  });
+
+  it("startRun → finishRun → listRuns round-trip", async () => {
+    const startedAt = "2024-04-01T00:00:00.000Z";
+    const completedAt = "2024-04-01T00:00:10.000Z";
+
+    const { run_id } = await startRun(env.DB, startedAt, 10);
+    await finishRun(env.DB, run_id, completedAt, 8, 2, 42);
+
+    const runs = await listRuns(env.DB);
+    expect(runs).toHaveLength(1);
+    expect(runs[0].id).toBe(run_id);
+    expect(runs[0].started_at).toBe(startedAt);
+    expect(runs[0].completed_at).toBe(completedAt);
+    expect(runs[0].feeds_total).toBe(10);
+    expect(runs[0].feeds_ok).toBe(8);
+    expect(runs[0].feeds_failed).toBe(2);
+    expect(runs[0].articles_inserted).toBe(42);
+    expect(runs[0].error).toBeNull();
+  });
+
+  it("startRun → recordRunFeed → getRun round-trip", async () => {
+    const startedAt = "2024-04-02T00:00:00.000Z";
+    const completedAt = "2024-04-02T00:00:15.000Z";
+
+    const { run_id } = await startRun(env.DB, startedAt, 3);
+    await recordRunFeed(env.DB, run_id, "feed-a", "ok", 5, 1200);
+    await recordRunFeed(env.DB, run_id, "feed-b", "failed", 0, 500, "HTTP 503 error");
+    await recordRunFeed(env.DB, run_id, "feed-c", "skipped", 0, 300);
+    await finishRun(env.DB, run_id, completedAt, 2, 1, 5);
+
+    const detail = await getRun(env.DB, run_id);
+    expect(detail).not.toBeNull();
+    expect(detail!.run.id).toBe(run_id);
+    expect(detail!.feeds).toHaveLength(3);
+
+    const feedA = detail!.feeds.find((f) => f.feed_id === "feed-a");
+    expect(feedA).not.toBeUndefined();
+    expect(feedA!.status).toBe("ok");
+    expect(feedA!.articles_inserted).toBe(5);
+    expect(feedA!.duration_ms).toBe(1200);
+    expect(feedA!.error).toBeNull();
+
+    const feedB = detail!.feeds.find((f) => f.feed_id === "feed-b");
+    expect(feedB).not.toBeUndefined();
+    expect(feedB!.status).toBe("failed");
+    expect(feedB!.error).toBe("HTTP 503 error");
+  });
+
+  it("getRun returns null for unknown id", async () => {
+    const detail = await getRun(env.DB, 99999);
+    expect(detail).toBeNull();
+  });
+
+  it("listRuns respects limit parameter", async () => {
+    for (let i = 0; i < 5; i++) {
+      await startRun(env.DB, `2024-04-0${i + 1}T00:00:00.000Z`, 1);
+    }
+    const runs = await listRuns(env.DB, 3);
+    expect(runs).toHaveLength(3);
+  });
+
+  it("listRuns orders by started_at desc", async () => {
+    await startRun(env.DB, "2024-04-01T00:00:00.000Z", 1);
+    await startRun(env.DB, "2024-04-03T00:00:00.000Z", 1);
+    await startRun(env.DB, "2024-04-02T00:00:00.000Z", 1);
+
+    const runs = await listRuns(env.DB);
+    expect(runs[0].started_at).toBe("2024-04-03T00:00:00.000Z");
+    expect(runs[1].started_at).toBe("2024-04-02T00:00:00.000Z");
+    expect(runs[2].started_at).toBe("2024-04-01T00:00:00.000Z");
+  });
+
+  it("error field is truncated to 200 characters", async () => {
+    const { run_id } = await startRun(env.DB, "2024-04-10T00:00:00.000Z", 1);
+    const longError = "E".repeat(300);
+    await recordRunFeed(env.DB, run_id, "feed-x", "failed", 0, 100, longError);
+
+    const detail = await getRun(env.DB, run_id);
+    expect(detail!.feeds[0].error).toHaveLength(200);
+  });
+
+  it("CASCADE DELETE removes run feeds when run is deleted", async () => {
+    const { run_id } = await startRun(env.DB, "2024-04-11T00:00:00.000Z", 1);
+    await recordRunFeed(env.DB, run_id, "feed-y", "ok", 1, 100);
+
+    await env.DB.prepare("DELETE FROM collector_runs WHERE id = ?1").bind(run_id).run();
+
+    const result = await env.DB.prepare(
+      "SELECT COUNT(*) AS cnt FROM collector_run_feeds WHERE run_id = ?1",
+    )
+      .bind(run_id)
+      .first<{ cnt: number }>();
+    expect(result!.cnt).toBe(0);
+  });
+});

--- a/apps/web/worker/api/admin.ts
+++ b/apps/web/worker/api/admin.ts
@@ -3,6 +3,7 @@ import type { Env } from "../types";
 import { collectAll, collectFeeds } from "../collector";
 import { loadAllFeeds } from "../feed-config";
 import { setFeedEnabled } from "../db/feeds";
+import { getRun, listRuns } from "../db/runs";
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -150,6 +151,47 @@ app.post("/feeds/:id/enabled", async (c) => {
     return c.json({ error: "feed not found" }, 404);
   }
   return c.json({ id, enabled });
+});
+
+app.get("/runs", async (c) => {
+  const current = c.env.ADMIN_TOKEN;
+  const next = c.env.ADMIN_TOKEN_NEXT;
+  if (!current) {
+    return c.json({ error: "ADMIN_TOKEN is not configured" }, 503);
+  }
+  const auth = c.req.header("authorization") ?? "";
+  const token = auth.replace(/^Bearer\s+/i, "");
+  if (!token || !isValidAdminToken(token, current, next)) {
+    return c.json({ error: "unauthorized" }, 401);
+  }
+
+  const limitParam = Number(c.req.query("limit") ?? "20");
+  const limit = Number.isFinite(limitParam) ? Math.min(Math.max(limitParam, 1), 100) : 20;
+  const runs = await listRuns(c.env.DB, limit);
+  return c.json({ runs });
+});
+
+app.get("/runs/:id", async (c) => {
+  const current = c.env.ADMIN_TOKEN;
+  const next = c.env.ADMIN_TOKEN_NEXT;
+  if (!current) {
+    return c.json({ error: "ADMIN_TOKEN is not configured" }, 503);
+  }
+  const auth = c.req.header("authorization") ?? "";
+  const token = auth.replace(/^Bearer\s+/i, "");
+  if (!token || !isValidAdminToken(token, current, next)) {
+    return c.json({ error: "unauthorized" }, 401);
+  }
+
+  const idParam = Number(c.req.param("id"));
+  if (!Number.isFinite(idParam) || idParam <= 0) {
+    return c.json({ error: "invalid id" }, 400);
+  }
+  const detail = await getRun(c.env.DB, idParam);
+  if (!detail) {
+    return c.json({ error: "not found" }, 404);
+  }
+  return c.json(detail);
 });
 
 export default app;

--- a/apps/web/worker/collector/index.ts
+++ b/apps/web/worker/collector/index.ts
@@ -14,6 +14,7 @@ import {
   syncFeeds,
   updateFeedHeaders,
 } from "../db/feeds";
+import { finishRun, recordRunFeed, startRun } from "../db/runs";
 
 const MAX_FEED_BYTES = 4 * 1024 * 1024; // 4MB
 const MAX_ITEMS_PER_FEED = 50;
@@ -349,6 +350,7 @@ export async function collectFeeds(env: Env, feedIds?: string[]): Promise<Collec
 
 export async function collectAll(env: Env): Promise<CollectAllResult> {
   const start = Date.now();
+  const startedAt = new Date(start).toISOString();
   const feeds = loadEnabledFeeds();
   await syncFeeds(env.DB, feeds);
 
@@ -361,12 +363,50 @@ export async function collectAll(env: Env): Promise<CollectAllResult> {
   const maxRetries = Number(env.COLLECTOR_RETRIES ?? "2") || 2;
   const summaryMax = Number(env.SUMMARY_MAX_LENGTH ?? "500") || 500;
 
-  const results = await runWithConcurrency(activeFeeds, concurrency, (feed) =>
-    collectFeed(env, feed, summaryMax, timeoutMs, maxRetries),
-  );
+  // run の開始を記録する
+  let runId: number | null = null;
+  try {
+    const { run_id } = await startRun(env.DB, startedAt, activeFeeds.length);
+    runId = run_id;
+  } catch (err) {
+    console.error(
+      `[collector] startRun failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const results = await runWithConcurrency(activeFeeds, concurrency, async (feed) => {
+    const feedStart = Date.now();
+    const result = await collectFeed(env, feed, summaryMax, timeoutMs, maxRetries);
+    const durationMs = Date.now() - feedStart;
+
+    // 各フィードの結果を記録する。失敗しても collectFeed の結果は返す。
+    if (runId !== null) {
+      const status =
+        result.status === "error" ? "failed" : result.status === "not_modified" ? "skipped" : "ok";
+      try {
+        await recordRunFeed(
+          env.DB,
+          runId,
+          feed.id,
+          status,
+          result.inserted,
+          durationMs,
+          result.error,
+        );
+      } catch (err) {
+        console.error(
+          `[collector] recordRunFeed(${feed.id}) failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
+    return result;
+  });
 
   const inserted = results.reduce((acc, r) => acc + r.inserted, 0);
   const skipped304 = results.filter((r) => r.status === "not_modified").length;
+  const feedsOk = results.filter((r) => r.status === "ok" || r.status === "not_modified").length;
+  const feedsFailed = results.filter((r) => r.status === "error").length;
 
   const retentionDays = Number(env.RETENTION_DAYS ?? "90") || 90;
   let pruned = 0;
@@ -379,6 +419,19 @@ export async function collectAll(env: Env): Promise<CollectAllResult> {
   }
 
   const durationMs = Date.now() - start;
+  const completedAt = new Date(Date.now()).toISOString();
+
+  // run の完了を記録する
+  if (runId !== null) {
+    try {
+      await finishRun(env.DB, runId, completedAt, feedsOk, feedsFailed, inserted);
+    } catch (err) {
+      console.error(
+        `[collector] finishRun failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
   console.log(
     `[collector] feeds=${activeFeeds.length} skipped304=${skipped304} inserted=${inserted} pruned=${pruned} retentionDays=${retentionDays} duration=${durationMs}ms`,
   );

--- a/apps/web/worker/db/runs.ts
+++ b/apps/web/worker/db/runs.ts
@@ -1,0 +1,122 @@
+export interface RunRow {
+  id: number;
+  started_at: string;
+  completed_at: string | null;
+  feeds_total: number | null;
+  feeds_ok: number | null;
+  feeds_failed: number | null;
+  articles_inserted: number | null;
+  error: string | null;
+}
+
+export interface RunFeedRow {
+  run_id: number;
+  feed_id: string;
+  status: "ok" | "failed" | "skipped";
+  articles_inserted: number;
+  duration_ms: number;
+  error: string | null;
+}
+
+export async function startRun(
+  db: D1Database,
+  started_at: string,
+  feeds_total: number,
+): Promise<{ run_id: number }> {
+  const result = await db
+    .prepare(
+      `INSERT INTO collector_runs (started_at, feeds_total)
+       VALUES (?1, ?2)`,
+    )
+    .bind(started_at, feeds_total)
+    .run();
+  const run_id = result.meta.last_row_id as number;
+  return { run_id };
+}
+
+export async function recordRunFeed(
+  db: D1Database,
+  run_id: number,
+  feed_id: string,
+  status: "ok" | "failed" | "skipped",
+  articles_inserted: number,
+  duration_ms: number,
+  error?: string,
+): Promise<void> {
+  // 200 文字で切り詰め。長いスタックトレースを D1 に書かないため。
+  const errorTruncated = error ? error.slice(0, 200) : null;
+  await db
+    .prepare(
+      `INSERT INTO collector_run_feeds (run_id, feed_id, status, articles_inserted, duration_ms, error)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6)`,
+    )
+    .bind(run_id, feed_id, status, articles_inserted, duration_ms, errorTruncated)
+    .run();
+}
+
+export async function finishRun(
+  db: D1Database,
+  run_id: number,
+  completed_at: string,
+  feeds_ok: number,
+  feeds_failed: number,
+  articles_inserted: number,
+  error?: string,
+): Promise<void> {
+  const errorTruncated = error ? error.slice(0, 200) : null;
+  await db
+    .prepare(
+      `UPDATE collector_runs
+       SET completed_at = ?1,
+           feeds_ok = ?2,
+           feeds_failed = ?3,
+           articles_inserted = ?4,
+           error = ?5
+       WHERE id = ?6`,
+    )
+    .bind(completed_at, feeds_ok, feeds_failed, articles_inserted, errorTruncated, run_id)
+    .run();
+}
+
+export async function listRuns(db: D1Database, limit = 20): Promise<RunRow[]> {
+  const safeLimit = Math.min(Math.max(limit, 1), 100);
+  const result = await db
+    .prepare(
+      `SELECT id, started_at, completed_at, feeds_total, feeds_ok, feeds_failed,
+              articles_inserted, error
+       FROM collector_runs
+       ORDER BY started_at DESC
+       LIMIT ?1`,
+    )
+    .bind(safeLimit)
+    .all<RunRow>();
+  return result.results ?? [];
+}
+
+export async function getRun(
+  db: D1Database,
+  run_id: number,
+): Promise<{ run: RunRow; feeds: RunFeedRow[] } | null> {
+  const run = await db
+    .prepare(
+      `SELECT id, started_at, completed_at, feeds_total, feeds_ok, feeds_failed,
+              articles_inserted, error
+       FROM collector_runs
+       WHERE id = ?1`,
+    )
+    .bind(run_id)
+    .first<RunRow>();
+  if (!run) return null;
+
+  const feedsResult = await db
+    .prepare(
+      `SELECT run_id, feed_id, status, articles_inserted, duration_ms, error
+       FROM collector_run_feeds
+       WHERE run_id = ?1
+       ORDER BY feed_id ASC`,
+    )
+    .bind(run_id)
+    .all<RunFeedRow>();
+
+  return { run, feeds: feedsResult.results ?? [] };
+}

--- a/migrations/0008_collector_runs.sql
+++ b/migrations/0008_collector_runs.sql
@@ -1,0 +1,24 @@
+-- collector_runs: cron の 1 回分の実行を記録するテーブル
+CREATE TABLE IF NOT EXISTS collector_runs (
+  id                INTEGER PRIMARY KEY AUTOINCREMENT,
+  started_at        TEXT NOT NULL,
+  completed_at      TEXT,
+  feeds_total       INTEGER,
+  feeds_ok          INTEGER,
+  feeds_failed      INTEGER,
+  articles_inserted INTEGER,
+  error             TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_collector_runs_started_desc ON collector_runs (started_at DESC);
+
+-- collector_run_feeds: run ごとの各フィードの結果を記録するテーブル
+CREATE TABLE IF NOT EXISTS collector_run_feeds (
+  run_id            INTEGER NOT NULL REFERENCES collector_runs(id) ON DELETE CASCADE,
+  feed_id           TEXT NOT NULL,
+  status            TEXT NOT NULL CHECK (status IN ('ok', 'failed', 'skipped')),
+  articles_inserted INTEGER NOT NULL DEFAULT 0,
+  duration_ms       INTEGER NOT NULL DEFAULT 0,
+  error             TEXT,
+  PRIMARY KEY (run_id, feed_id)
+);


### PR DESCRIPTION
## Summary

- D1 に `collector_runs` / `collector_run_feeds` テーブルを追加し、`collectAll()` の各実行を記録する
- `GET /api/admin/runs?limit=N` と `GET /api/admin/runs/:id` エンドポイントを追加（ADMIN_TOKEN 認証）
- `db/runs.ts` を新規作成（`startRun` / `recordRunFeed` / `finishRun` / `listRuns` / `getRun`）
- 新規テスト: `tests/worker/db/runs.test.ts` (8 件) + `admin.test.ts` に runs エンドポイントテスト (8 件)

## Changes

- `migrations/0008_collector_runs.sql`: `collector_runs` + `collector_run_feeds` テーブル定義、cascade delete、インデックス
- `apps/web/worker/db/runs.ts`: D1 アクセス層（新規）
- `apps/web/worker/collector/index.ts`: `collectAll` に startRun / recordRunFeed / finishRun を組み込み
- `apps/web/worker/api/admin.ts`: `/api/admin/runs` + `/api/admin/runs/:id` ルート追加
- `apps/web/tests/worker/db/runs.test.ts`: 往復テスト（新規）
- `apps/web/tests/worker/api/admin.test.ts`: runs エンドポイントテスト追加

## Test plan

- [ ] `pnpm build` pass
- [ ] `pnpm test` pass (18 files, 188 tests)
- [ ] `pnpm check` pass (lint/fmt/typecheck)
- [ ] CI green

Closes #127