### PR TITLE
feat(client): add article bookmark feature

### DIFF
--- a/apps/web/client/App.tsx
+++ b/apps/web/client/App.tsx
@@ -8,6 +8,7 @@ import { ShortcutsHelp } from "./components/ShortcutsHelp";
 import { StatsPanel } from "./components/Stats";
 import { ToastContainer } from "./components/ToastContainer";
 import { useArticles } from "./hooks/useArticles";
+import { useBookmarks } from "./hooks/useBookmarks";
 import { useFeeds } from "./hooks/useFeeds";
 import { useKeyboardNav } from "./hooks/useKeyboardNav";
 import { usePresets } from "./hooks/usePresets";
@@ -86,6 +87,7 @@ function AppInner() {
   const [dateTo, setDateTo] = useState<string>(() => readFromUrl().dateTo);
   const [unreadOnly, setUnreadOnly] = useState<boolean>(() => readFromUrl().unreadOnly);
   const [starredOnly, setStarredOnly] = useState<boolean>(() => readFromUrl().starredOnly);
+  const [bookmarkedOnly, setBookmarkedOnly] = useState(false);
 
   const searchRef = useRef<HTMLInputElement>(null);
 
@@ -93,6 +95,7 @@ function AppInner() {
   const { stats } = useStats();
   const { isRead, markRead, markUnread } = useReadState();
   const { isStarred, toggleStar } = useStarredState();
+  const { bookmarks } = useBookmarks();
   const { presets, addPreset, removePreset } = usePresets();
 
   // popstate でブラウザ戻る/進むに追従する
@@ -264,13 +267,14 @@ function AppInner() {
     loadMore,
   } = useArticles(query);
 
-  // 未読・スターフィルタはクライアントサイドで適用 (サーバー API は既読/スターを知らないため)
+  // 未読・スター・ブックマークフィルタはクライアントサイドで適用 (サーバー API はこれらを知らないため)
   const articles = useMemo(() => {
     let filtered = allArticles;
     if (unreadOnly) filtered = filtered.filter((a) => !isRead(a.id));
     if (starredOnly) filtered = filtered.filter((a) => isStarred(a.id));
+    if (bookmarkedOnly) filtered = filtered.filter((a) => bookmarks.has(a.guid));
     return filtered;
-  }, [allArticles, unreadOnly, starredOnly, isRead, isStarred]);
+  }, [allArticles, unreadOnly, starredOnly, bookmarkedOnly, isRead, isStarred, bookmarks]);
 
   const handleToggleRead = useCallback(
     (id: number) => {
@@ -296,6 +300,14 @@ function AppInner() {
           {feeds.length > 0 ? ` · ${feeds.length} sources` : ""}
           {stats?.last_fetched_at ? ` · 最終更新 ${formatRelative(stats.last_fetched_at)}` : ""}
         </span>
+        <button
+          type="button"
+          className={`bookmarks-only-toggle${bookmarkedOnly ? " active" : ""}`}
+          onClick={() => setBookmarkedOnly((prev) => !prev)}
+          aria-pressed={bookmarkedOnly}
+        >
+          ★ {bookmarks.size} 件{bookmarkedOnly ? " (表示中)" : ""}
+        </button>
         {stats && stats.stale_feeds.length > 0 && (
           <details className="stale-warning">
             <summary>⚠ {stats.stale_feeds.length} 件の収集に問題があります</summary>
@@ -347,7 +359,10 @@ function AppInner() {
 
       {loading && <div className="loader">読み込み中…</div>}
       {error && !loading && <div className="error">取得エラー: {error}</div>}
-      {!loading && !error && articles.length === 0 && (
+      {!loading && !error && articles.length === 0 && bookmarkedOnly && (
+        <div className="empty">ブックマークがありません</div>
+      )}
+      {!loading && !error && articles.length === 0 && !bookmarkedOnly && (
         <div className="empty">記事はまだありません。Cron 実行をお待ちください。</div>
       )}
 

--- a/apps/web/client/components/ArticleCard.tsx
+++ b/apps/web/client/components/ArticleCard.tsx
@@ -3,6 +3,7 @@ import { useReadState } from "../hooks/useReadState";
 import { useStarredState } from "../hooks/useStarredState";
 import type { Article, FeedCategory } from "../types/api";
 import { highlight } from "../utils/highlight";
+import { BookmarkButton } from "./BookmarkButton";
 import { ShareButtons } from "./ShareButtons";
 
 interface Props {
@@ -81,6 +82,7 @@ export function ArticleCard({
         >
           {starred ? "★" : "☆"}
         </button>
+        <BookmarkButton guid={article.guid} />
         {/* hover 時に既読 / 未読切り替えボタンを薄く表示 */}
         {hovered && (
           <button

--- a/apps/web/client/components/BookmarkButton.tsx
+++ b/apps/web/client/components/BookmarkButton.tsx
@@ -1,0 +1,22 @@
+import { useBookmarks } from "../hooks/useBookmarks";
+
+interface Props {
+  guid: string;
+}
+
+export function BookmarkButton({ guid }: Props) {
+  const { isBookmarked, toggle } = useBookmarks();
+  const bookmarked = isBookmarked(guid);
+
+  return (
+    <button
+      type="button"
+      className="bookmark-button"
+      onClick={() => toggle(guid)}
+      aria-label={bookmarked ? "ブックマークから削除" : "ブックマークに追加"}
+      aria-pressed={bookmarked}
+    >
+      {bookmarked ? "★" : "☆"}
+    </button>
+  );
+}

--- a/apps/web/client/hooks/useBookmarks.ts
+++ b/apps/web/client/hooks/useBookmarks.ts
@@ -1,0 +1,91 @@
+import { useCallback, useSyncExternalStore } from "react";
+
+const STORAGE_KEY = "tnb:bookmarks:v1";
+const MAX_IDS = 1000;
+
+function parse(raw: string | null): Set<string> {
+  if (!raw) return new Set();
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter((v): v is string => typeof v === "string"));
+  } catch {
+    return new Set();
+  }
+}
+
+function writeStorage(ids: string[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(ids));
+  } catch {
+    // localStorage が使えない環境では無視
+  }
+}
+
+// useSyncExternalStore の getSnapshot は参照同一性を要求するため
+// raw 文字列をキャッシュキーにして同一内容なら同じ Set 参照を返す
+let cachedRaw: string | null = null;
+let cachedSet: ReadonlySet<string> = new Set();
+
+function getSnapshot(): ReadonlySet<string> {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (raw === cachedRaw) return cachedSet;
+  cachedRaw = raw;
+  cachedSet = parse(raw);
+  return cachedSet;
+}
+
+type Listener = () => void;
+const listeners = new Set<Listener>();
+
+function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+
+  const onStorage = (e: StorageEvent) => {
+    if (e.key === STORAGE_KEY) listener();
+  };
+  window.addEventListener("storage", onStorage);
+
+  return () => {
+    listeners.delete(listener);
+    window.removeEventListener("storage", onStorage);
+  };
+}
+
+function notify(): void {
+  for (const l of listeners) l();
+}
+
+export interface BookmarksAPI {
+  bookmarks: ReadonlySet<string>;
+  isBookmarked: (guid: string) => boolean;
+  toggle: (guid: string) => void;
+  clear: () => void;
+}
+
+export function useBookmarks(): BookmarksAPI {
+  const bookmarks = useSyncExternalStore(subscribe, getSnapshot, () => new Set<string>());
+
+  const isBookmarked = useCallback((guid: string) => bookmarks.has(guid), [bookmarks]);
+
+  const toggle = useCallback((guid: string) => {
+    const current = getSnapshot();
+    if (current.has(guid)) {
+      writeStorage(Array.from(current).filter((v) => v !== guid));
+    } else {
+      // 新規追加は先頭に、上限超過分は破棄
+      writeStorage([guid, ...Array.from(current).filter((v) => v !== guid)].slice(0, MAX_IDS));
+    }
+    // キャッシュを無効化して次の getSnapshot で再読み込みさせる
+    cachedRaw = null;
+    notify();
+  }, []);
+
+  const clear = useCallback(() => {
+    writeStorage([]);
+    cachedRaw = null;
+    notify();
+  }, []);
+
+  return { bookmarks, isBookmarked, toggle, clear };
+}

--- a/apps/web/client/index.css
+++ b/apps/web/client/index.css
@@ -867,3 +867,47 @@ kbd {
   opacity: 1;
   color: var(--fg);
 }
+
+.bookmark-button {
+  flex-shrink: 0;
+  padding: 2px 6px;
+  background: none;
+  color: var(--fg-muted);
+  border: none;
+  font-size: 1rem;
+  font-family: inherit;
+  cursor: pointer;
+  line-height: 1;
+  opacity: 0.5;
+}
+
+.bookmark-button:hover,
+.bookmark-button[aria-pressed="true"] {
+  opacity: 1;
+  color: var(--accent);
+}
+
+.bookmarks-only-toggle {
+  padding: 4px 10px;
+  background: var(--bg-elev);
+  color: var(--fg-muted);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-family: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.bookmarks-only-toggle:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.bookmarks-only-toggle.active {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+  color: var(--accent);
+  font-weight: 600;
+}

--- a/apps/web/tests/client/useBookmarks.test.tsx
+++ b/apps/web/tests/client/useBookmarks.test.tsx
@@ -1,0 +1,98 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vite-plus/test";
+
+const { useBookmarks } = await import("../../client/hooks/useBookmarks");
+
+const STORAGE_KEY = "tnb:bookmarks:v1";
+
+describe("useBookmarks", () => {
+  beforeEach(() => {
+    // テスト間の localStorage 状態を隔離する
+    localStorage.clear();
+  });
+
+  it("initially returns an empty bookmarks set", () => {
+    const { result } = renderHook(() => useBookmarks());
+    expect(result.current.isBookmarked("guid-1")).toBe(false);
+    expect(result.current.bookmarks.size).toBe(0);
+  });
+
+  it("toggle adds an article to bookmarks", () => {
+    const { result } = renderHook(() => useBookmarks());
+    act(() => {
+      result.current.toggle("guid-abc");
+    });
+    expect(result.current.isBookmarked("guid-abc")).toBe(true);
+  });
+
+  it("toggle removes an already bookmarked article", () => {
+    const { result } = renderHook(() => useBookmarks());
+    act(() => {
+      result.current.toggle("guid-abc");
+    });
+    expect(result.current.isBookmarked("guid-abc")).toBe(true);
+    act(() => {
+      result.current.toggle("guid-abc");
+    });
+    expect(result.current.isBookmarked("guid-abc")).toBe(false);
+  });
+
+  it("persists bookmarks to localStorage", () => {
+    const { result } = renderHook(() => useBookmarks());
+    act(() => {
+      result.current.toggle("guid-xyz");
+    });
+    const stored = localStorage.getItem(STORAGE_KEY);
+    expect(stored).not.toBeNull();
+    const parsed: unknown = JSON.parse(stored!);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect((parsed as string[]).includes("guid-xyz")).toBe(true);
+  });
+
+  it("isBookmarked returns false for unknown guid", () => {
+    const { result } = renderHook(() => useBookmarks());
+    expect(result.current.isBookmarked("unknown-guid")).toBe(false);
+  });
+
+  it("clear() removes all bookmarks", () => {
+    const { result } = renderHook(() => useBookmarks());
+    act(() => {
+      result.current.toggle("guid-1");
+      result.current.toggle("guid-2");
+    });
+    expect(result.current.bookmarks.size).toBe(2);
+    act(() => {
+      result.current.clear();
+    });
+    expect(result.current.bookmarks.size).toBe(0);
+    expect(result.current.isBookmarked("guid-1")).toBe(false);
+    expect(result.current.isBookmarked("guid-2")).toBe(false);
+  });
+
+  it("returns the same Set reference when raw is unchanged", () => {
+    // raw が変わっていなければ getSnapshot が同じ参照を返すことを確認する
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(["guid-a", "guid-b"]));
+    const { result } = renderHook(() => useBookmarks());
+    expect(result.current.isBookmarked("guid-a")).toBe(true);
+    expect(result.current.isBookmarked("guid-b")).toBe(true);
+    expect(result.current.isBookmarked("guid-c")).toBe(false);
+  });
+
+  it("syncs via StorageEvent (cross-tab simulation)", () => {
+    const { result } = renderHook(() => useBookmarks());
+    expect(result.current.isBookmarked("guid-remote")).toBe(false);
+
+    act(() => {
+      // 別タブから localStorage が変更されたことをシミュレート
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(["guid-remote"]));
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: STORAGE_KEY,
+          newValue: JSON.stringify(["guid-remote"]),
+        }),
+      );
+    });
+
+    expect(result.current.isBookmarked("guid-remote")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- `useBookmarks` hook: localStorage (`tnb:bookmarks:v1`) に GUID 配列を保存。useSyncExternalStore + raw string キャッシュで参照安定化 (usePresets.ts と同パターン)。StorageEvent でクロスタブ同期
- `BookmarkButton` コンポーネント: ☆/★ トグル、aria-label / aria-pressed 対応
- `ArticleCard` に BookmarkButton を埋め込み (star-button の隣)
- `App.tsx` ヘッダーに「★ N 件」トグルボタンを追加。ON 時にブックマーク済み記事のみ表示、0 件時は "ブックマークがありません" を表示
- `index.css` に `.bookmark-button` / `.bookmarks-only-toggle` スタイルを追加

## Test plan

- [x] `useBookmarks.test.tsx` 新規追加 (8 テスト)
  - localStorage 永続化
  - toggle で add / remove
  - isBookmarked
  - clear()
  - StorageEvent による クロスタブ同期シミュレーション
  - 参照安定性 (同一 raw なら同一 Set 参照)
- [x] `pnpm build` pass
- [x] `pnpm test` 136/136 pass
- [x] `pnpm lint` エラー 0 件
- [x] `pnpm -r typecheck` pass

Closes #128