### PR TITLE
feat: add OPML 2.0 export endpoint GET /feeds.opml

### DIFF
--- a/apps/web/tests/worker/api/opml.test.ts
+++ b/apps/web/tests/worker/api/opml.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vite-plus/test";
+import { SELF } from "cloudflare:test";
+
+// feeds.yaml には bigtech / ai / jp / zenn の全カテゴリが定義されているため、
+// D1 への記事挿入なしで OPML エクスポートのテストが完結する。
+
+describe("GET /feeds.opml", () => {
+  it("returns 200 with text/x-opml Content-Type", async () => {
+    const res = await SELF.fetch("https://example.com/feeds.opml");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("text/x-opml");
+  });
+
+  it('body contains <opml version="2.0">', async () => {
+    const res = await SELF.fetch("https://example.com/feeds.opml");
+    const text = await res.text();
+    expect(text).toContain('<opml version="2.0">');
+  });
+
+  it("body starts with XML declaration", async () => {
+    const res = await SELF.fetch("https://example.com/feeds.opml");
+    const text = await res.text();
+    expect(text.startsWith('<?xml version="1.0" encoding="UTF-8"?>')).toBe(true);
+  });
+
+  it("contains all 4 category outlines", async () => {
+    const res = await SELF.fetch("https://example.com/feeds.opml");
+    const text = await res.text();
+    expect(text).toContain('text="Big Tech"');
+    expect(text).toContain('text="AI Labs"');
+    expect(text).toContain('text="国内エンジニアリング"');
+    expect(text).toContain('text="Zenn"');
+  });
+
+  it("contains outline elements with type=rss, xmlUrl and htmlUrl", async () => {
+    const res = await SELF.fetch("https://example.com/feeds.opml");
+    const text = await res.text();
+    // type="rss" の outline が存在すること
+    expect(text).toContain('type="rss"');
+    // xmlUrl はこのサービスの /feeds/<id>.xml を指すこと
+    expect(text).toMatch(/xmlUrl="https:\/\/example\.com\/feeds\/[^"]+\.xml"/);
+    // htmlUrl は元の feed URL を指すこと
+    expect(text).toContain('htmlUrl="');
+  });
+
+  it("xmlUrl points to this service origin with /feeds/<id>.xml path", async () => {
+    const res = await SELF.fetch("https://example.com/feeds.opml");
+    const text = await res.text();
+    // google-research フィードの xmlUrl がサービス自身のオリジンを使っていること
+    expect(text).toContain('xmlUrl="https://example.com/feeds/google-research.xml"');
+    // htmlUrl は feeds.yaml の元 URL を指すこと
+    expect(text).toContain('htmlUrl="https://blog.research.google/feeds/posts/default"');
+  });
+
+  it("enabled: false feeds are excluded", async () => {
+    // feeds.yaml に enabled: false のフィードがあればここでチェックできる。
+    // 現状は全フィードが enabled: true のため、
+    // 存在するフィードが XML に含まれることのみ確認する。
+    const res = await SELF.fetch("https://example.com/feeds.opml");
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    // 少なくとも 1 つ以上の type="rss" outline が含まれること
+    const matches = text.match(/type="rss"/g);
+    expect(matches).not.toBeNull();
+    expect((matches ?? []).length).toBeGreaterThan(0);
+  });
+
+  it("ETag round-trip returns 304 on If-None-Match", async () => {
+    const first = await SELF.fetch("https://example.com/feeds.opml");
+    expect(first.status).toBe(200);
+    const etag = first.headers.get("ETag");
+    expect(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
+
+    const second = await SELF.fetch("https://example.com/feeds.opml", {
+      headers: { "If-None-Match": etag! },
+    });
+    expect(second.status).toBe(304);
+  });
+
+  it("ETag changes when If-None-Match does not match", async () => {
+    const res = await SELF.fetch("https://example.com/feeds.opml", {
+      headers: { "If-None-Match": 'W/"0000000000000000"' },
+    });
+    // ETag が一致しないので 200 が返ること
+    expect(res.status).toBe(200);
+  });
+
+  it("contains OPML title", async () => {
+    const res = await SELF.fetch("https://example.com/feeds.opml");
+    const text = await res.text();
+    expect(text).toContain("<title>Tech News Bot — Subscriptions</title>");
+  });
+
+  it("contains dateCreated element in RFC 822 format", async () => {
+    const res = await SELF.fetch("https://example.com/feeds.opml");
+    const text = await res.text();
+    expect(text).toMatch(/<dateCreated>.+<\/dateCreated>/);
+  });
+});

--- a/apps/web/worker/api/opml.ts
+++ b/apps/web/worker/api/opml.ts
@@ -1,0 +1,99 @@
+import { Hono } from "hono";
+import type { Env, FeedCategory } from "../types";
+import { loadEnabledFeeds } from "../feed-config";
+
+const OPML_TITLE = "Tech News Bot — Subscriptions";
+
+// カテゴリごとの表示名 mapping
+const CATEGORY_DISPLAY_NAMES: Record<FeedCategory, string> = {
+  bigtech: "Big Tech",
+  ai: "AI Labs",
+  jp: "国内エンジニアリング",
+  zenn: "Zenn",
+};
+
+// カテゴリの表示順序
+const CATEGORY_ORDER: FeedCategory[] = ["bigtech", "ai", "jp", "zenn"];
+
+function escapeXml(input: string): string {
+  return input
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+async function computeOpmlEtag(
+  feeds: { id: string; name: string; url: string; category: FeedCategory }[],
+): Promise<string> {
+  const source = feeds.map((f) => `${f.id}|${f.name}|${f.url}|${f.category}`).join(",");
+  const encoded = new TextEncoder().encode(source);
+  const buf = await crypto.subtle.digest("SHA-256", encoded);
+  const hex = Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return `W/"${hex.slice(0, 16)}"`;
+}
+
+function buildOpmlXml(origin: string, feeds: ReturnType<typeof loadEnabledFeeds>): string {
+  const dateCreated = new Date().toUTCString();
+
+  // カテゴリ別にグループ化
+  const byCategory = new Map<FeedCategory, typeof feeds>();
+  for (const cat of CATEGORY_ORDER) {
+    byCategory.set(cat, []);
+  }
+  for (const feed of feeds) {
+    byCategory.get(feed.category)?.push(feed);
+  }
+
+  const outlineGroups = CATEGORY_ORDER.filter((cat) => (byCategory.get(cat)?.length ?? 0) > 0)
+    .map((cat) => {
+      const displayName = escapeXml(CATEGORY_DISPLAY_NAMES[cat]);
+      const children = (byCategory.get(cat) ?? [])
+        .map((feed) => {
+          const xmlUrl = escapeXml(`${origin}/feeds/${feed.id}.xml`);
+          const htmlUrl = escapeXml(feed.url);
+          const text = escapeXml(feed.name);
+          return `<outline type="rss" text="${text}" title="${text}" xmlUrl="${xmlUrl}" htmlUrl="${htmlUrl}"/>`;
+        })
+        .join("");
+      return `<outline text="${displayName}" title="${displayName}">${children}</outline>`;
+    })
+    .join("");
+
+  return (
+    `<?xml version="1.0" encoding="UTF-8"?>` +
+    `<opml version="2.0">` +
+    `<head>` +
+    `<title>${escapeXml(OPML_TITLE)}</title>` +
+    `<dateCreated>${dateCreated}</dateCreated>` +
+    `</head>` +
+    `<body>${outlineGroups}</body>` +
+    `</opml>`
+  );
+}
+
+const app = new Hono<{ Bindings: Env }>();
+
+app.get("/feeds.opml", async (c) => {
+  const feeds = loadEnabledFeeds();
+  const etag = await computeOpmlEtag(feeds);
+
+  if (c.req.header("If-None-Match") === etag) {
+    c.header("ETag", etag);
+    c.header("Cache-Control", "public, max-age=3600");
+    return c.body(null, 304);
+  }
+
+  const origin = new URL(c.req.url).origin;
+  const xml = buildOpmlXml(origin, feeds);
+
+  c.header("Content-Type", "text/x-opml; charset=utf-8");
+  c.header("ETag", etag);
+  c.header("Cache-Control", "public, max-age=3600");
+  return c.body(xml);
+});
+
+export default app;

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -3,6 +3,7 @@ import type { Env } from "./types";
 import api from "./api/router";
 import sitemap from "./api/sitemap";
 import syndication from "./api/syndication";
+import opml from "./api/opml";
 import { collectAll } from "./collector";
 import { pruneOldArticles } from "./db/retention";
 
@@ -32,6 +33,7 @@ app.use("*", async (c, next) => {
 app.route("/api", api);
 app.route("/", sitemap);
 app.route("/", syndication);
+app.route("/", opml);
 
 // 静的アセットへのフォールバック (Cloudflare Static Assets binding)
 // Vite は /assets/ 以下に hash 付きファイル名を出力するため、強キャッシュが安全。


### PR DESCRIPTION
Closes #132

## Summary
- GET /feeds.opml エンドポイントを追加 (OPML 2.0, text/x-opml; charset=utf-8)
- feeds.yaml の enabled: true フィードをカテゴリ別グループ (Big Tech / AI Labs / 国内エンジニアリング / Zenn) に分類して出力
- xmlUrl にはこのサービスの /feeds/<id>.xml を、htmlUrl には元フィード URL を設定
- ETag は id+name+url+category の SHA-256 hex 16 文字。If-None-Match で 304 対応
- 新規ファイル: apps/web/worker/api/opml.ts、apps/web/tests/worker/api/opml.test.ts
- apps/web/worker/index.ts に app.route('/', opml) を追加 (最小変更)

## Test plan
- [x] pnpm build pass
- [x] pnpm test pass (207 tests including 10 new opml tests)
- [x] pnpm lint 0 errors
- [x] pnpm -r typecheck pass
- [x] pnpm format 適用済み