### PR TITLE
feat(syndication): add /feeds/category/:cat.{xml,json} endpoints

### DIFF
--- a/apps/web/tests/worker/api/syndication.test.ts
+++ b/apps/web/tests/worker/api/syndication.test.ts
@@ -23,6 +23,14 @@ const FEEDS: FeedConfig[] = [
     lang: "ja",
     enabled: true,
   },
+  {
+    id: "google-research",
+    name: "Google Research Blog",
+    url: "https://x.test/g",
+    category: "bigtech",
+    lang: "en",
+    enabled: true,
+  },
 ];
 
 beforeEach(async () => {
@@ -50,6 +58,17 @@ beforeEach(async () => {
       category: "jp",
       lang: "ja",
     },
+    {
+      guid: "g-bigtech",
+      feed_id: "google-research",
+      title: "Google Blog Post",
+      url: "https://x.test/g/1",
+      summary: null,
+      author: null,
+      published_at: "2024-04-04T00:00:00.000Z",
+      category: "bigtech",
+      lang: "en",
+    },
   ]);
 });
 
@@ -64,8 +83,8 @@ describe("/feed.json", () => {
       items: { id: string; title: string; url: string }[];
     };
     expect(body.version).toBe("https://jsonfeed.org/version/1.1");
-    expect(body.items.map((i) => i.id)).toEqual(["g-jp", "g-ai"]);
-    expect(body.items[1].title).toBe("AI <Article> & friends");
+    expect(body.items.map((i) => i.id)).toEqual(["g-bigtech", "g-jp", "g-ai"]);
+    expect(body.items[2].title).toBe("AI <Article> & friends");
   });
 
   it("filters by category", async () => {
@@ -77,7 +96,7 @@ describe("/feed.json", () => {
   it("filters by lang", async () => {
     const res = await SELF.fetch("https://example.com/feed.json?lang=en");
     const body = (await res.json()) as { items: { id: string }[] };
-    expect(body.items.map((i) => i.id)).toEqual(["g-ai"]);
+    expect(body.items.map((i) => i.id)).toEqual(["g-bigtech", "g-ai"]);
   });
 });
 
@@ -190,5 +209,88 @@ describe("/feeds/:id.json (per-feed JSON Feed)", () => {
   it("returns 404 for unknown feed_id", async () => {
     const res = await SELF.fetch("https://example.com/feeds/no-such-feed.json");
     expect(res.status).toBe(404);
+  });
+});
+
+describe("/feeds/category/:cat.json", () => {
+  it("returns 200 with correct Content-Type for ai category", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/category/ai.json");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("application/feed+json");
+    const body = (await res.json()) as {
+      version: string;
+      title: string;
+      items: { id: string }[];
+    };
+    expect(body.version).toBe("https://jsonfeed.org/version/1.1");
+    expect(body.title).toBe("Tech News Bot — AI Labs");
+    expect(body.items.map((i) => i.id)).toEqual(["g-ai"]);
+  });
+
+  it("returns 200 and only jp articles for jp category", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/category/jp.json");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { title: string; items: { id: string }[] };
+    expect(body.title).toBe("Tech News Bot — 国内エンジニアリング");
+    expect(body.items.map((i) => i.id)).toEqual(["g-jp"]);
+    // 別カテゴリの記事が混入しないこと
+    expect(body.items.find((i) => i.id === "g-ai")).toBeUndefined();
+    expect(body.items.find((i) => i.id === "g-bigtech")).toBeUndefined();
+  });
+
+  it("returns 404 for invalid category", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/category/invalid.json");
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 304 on ETag round-trip", async () => {
+    const first = await SELF.fetch("https://example.com/feeds/category/ai.json");
+    const etag = first.headers.get("ETag");
+    expect(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
+
+    const second = await SELF.fetch("https://example.com/feeds/category/ai.json", {
+      headers: { "If-None-Match": etag! },
+    });
+    expect(second.status).toBe(304);
+  });
+});
+
+describe("/feeds/category/:cat.xml", () => {
+  it("returns 200 with correct Content-Type for bigtech category", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/category/bigtech.xml");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("application/rss+xml");
+    const text = await res.text();
+    expect(text.startsWith("<?xml")).toBe(true);
+    expect(text).toContain('<rss version="2.0"');
+    expect(text).toContain("Tech News Bot — Big Tech");
+    expect(text).toContain("g-bigtech");
+  });
+
+  it("returns 200 and only ai articles for ai category", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/category/ai.xml");
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain("Tech News Bot — AI Labs");
+    expect(text).toContain("g-ai");
+    // 別カテゴリの記事が混入しないこと
+    expect(text).not.toContain("g-jp");
+    expect(text).not.toContain("g-bigtech");
+  });
+
+  it("returns 404 for invalid category", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/category/unknown.xml");
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 304 on ETag round-trip", async () => {
+    const first = await SELF.fetch("https://example.com/feeds/category/jp.xml");
+    const etag = first.headers.get("ETag");
+    expect(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
+
+    const second = await SELF.fetch("https://example.com/feeds/category/jp.xml", {
+      headers: { "If-None-Match": etag! },
+    });
+    expect(second.status).toBe(304);
   });
 });

--- a/apps/web/worker/api/syndication.ts
+++ b/apps/web/worker/api/syndication.ts
@@ -11,8 +11,16 @@ const FEEDS_VERSION = (feedsYaml as FeedsFile).version;
 const VALID_CATEGORIES: FeedCategory[] = ["bigtech", "ai", "jp", "zenn"];
 const VALID_LANGS: FeedLang[] = ["ja", "en"];
 const FEED_LIMIT = 50;
-const SITE_TITLE = "tech-news-bot";
+const SITE_TITLE = "Tech News Bot";
 const SITE_DESCRIPTION = "Big tech / AI / 日本企業の technical blog を集約した RSS / JSON Feed";
+
+// カテゴリごとの表示名 mapping
+const CATEGORY_DISPLAY_NAMES: Record<FeedCategory, string> = {
+  bigtech: "Big Tech",
+  ai: "AI Labs",
+  jp: "国内エンジニアリング",
+  zenn: "Zenn",
+};
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -58,13 +66,15 @@ interface BuildFeedOpts {
   lang?: FeedLang;
   /** feeds.yaml の name (per-feed 時に channel.title へ使用) */
   feedName?: string;
+  /** カテゴリフィード用タイトル上書き (feedName が指定される場合は無視) */
+  titleOverride?: string;
 }
 
 async function buildJsonFeed(
   c: Context<{ Bindings: Env }>,
   opts: BuildFeedOpts,
 ): Promise<Response> {
-  const { feedId, category, lang, feedName } = opts;
+  const { feedId, category, lang, feedName, titleOverride } = opts;
   const etag = await computeSyndicationEtag(c.env.DB, FEEDS_VERSION, { category, lang, feedId });
   if (c.req.header("If-None-Match") === etag) {
     c.header("ETag", etag);
@@ -81,7 +91,7 @@ async function buildJsonFeed(
   });
   const origin = siteOrigin(c.req.url);
   const feedUrl = new URL(c.req.url).toString();
-  const title = feedName ?? SITE_TITLE;
+  const title = feedName ?? titleOverride ?? SITE_TITLE;
   const description = feedName ? `${feedName} の最新記事` : SITE_DESCRIPTION;
 
   const json = {
@@ -111,7 +121,7 @@ async function buildJsonFeed(
 }
 
 async function buildRssFeed(c: Context<{ Bindings: Env }>, opts: BuildFeedOpts): Promise<Response> {
-  const { feedId, category, lang, feedName } = opts;
+  const { feedId, category, lang, feedName, titleOverride } = opts;
   const etag = await computeSyndicationEtag(c.env.DB, FEEDS_VERSION, { category, lang, feedId });
   if (c.req.header("If-None-Match") === etag) {
     c.header("ETag", etag);
@@ -129,7 +139,7 @@ async function buildRssFeed(c: Context<{ Bindings: Env }>, opts: BuildFeedOpts):
   const origin = siteOrigin(c.req.url);
   const feedUrl = new URL(c.req.url).toString();
   const lastBuild = result.articles[0]?.published_at ?? new Date().toISOString();
-  const title = feedName ?? SITE_TITLE;
+  const title = feedName ?? titleOverride ?? SITE_TITLE;
   const description = feedName ? `${feedName} の最新記事` : SITE_DESCRIPTION;
 
   const items = result.articles
@@ -177,6 +187,39 @@ app.get("/feed.json", async (c) => {
 app.get("/feed.xml", async (c) => {
   const { category, lang } = parseFilters(c);
   return buildRssFeed(c, { category, lang });
+});
+
+// カテゴリ別 syndication エンドポイント
+// Hono の :param は非スラッシュ文字をすべて取り込むため、ワイルドカードで受け取り
+// 拡張子とカテゴリ名を手動で分離する。
+// /feeds/category/* を /feeds/:filename より先に登録することで優先マッチさせる。
+app.get("/feeds/category/*", async (c) => {
+  const pathname = new URL(c.req.url).pathname;
+  const basename = pathname.replace(/^.*\/feeds\/category\//, "");
+
+  let cat: FeedCategory;
+  let format: "json" | "xml";
+
+  if (basename.endsWith(".json")) {
+    cat = basename.slice(0, -5) as FeedCategory;
+    format = "json";
+  } else if (basename.endsWith(".xml")) {
+    cat = basename.slice(0, -4) as FeedCategory;
+    format = "xml";
+  } else {
+    return c.json({ error: "Not Found" }, 404);
+  }
+
+  if (!(VALID_CATEGORIES as string[]).includes(cat)) {
+    return c.json({ error: "Not Found" }, 404);
+  }
+
+  const titleOverride = `${SITE_TITLE} — ${CATEGORY_DISPLAY_NAMES[cat]}`;
+
+  if (format === "json") {
+    return buildJsonFeed(c, { category: cat, titleOverride });
+  }
+  return buildRssFeed(c, { category: cat, titleOverride });
 });
 
 // per-feed エンドポイント: feeds.yaml に定義された id のみ受け付ける


### PR DESCRIPTION
## 概要

Issue #129 の実装。カテゴリ別の RSS / JSON Feed エンドポイントを追加する。

## 変更内容

- `GET /feeds/category/:cat.xml` — RSS 2.0 (カテゴリ別)
- `GET /feeds/category/:cat.json` — JSON Feed v1.1 (カテゴリ別)
- カテゴリ: `bigtech | ai | jp | zenn`
- タイトル: `"Tech News Bot — <表示名>"` (例: `Tech News Bot — AI Labs`)
- ETag / 304 対応済み (既存の `computeSyndicationEtag` を再利用)
- Hono の `:param` がドットを含むセグメントを正しく扱えないため、`/feeds/category/*` ワイルドカードで受け取り拡張子を手動で分離
- `/feeds/category/*` を `/feeds/:filename` より前に登録して優先マッチさせる
- 既存の `buildRssFeed` / `buildJsonFeed` helpers に `titleOverride` オプションを追加してコードを再利用

## テスト

- 8 件の新規テストを追加 (JSON Feed 4 件 + RSS 4 件)
- 全 204 テストパス

## 完了条件

- [x] vp check pass (lint 0 errors, fmt ok, typecheck ok)
- [x] vp test run pass (204/204)
- [x] 動作確認 (統合テスト経由)

Closes #129