### PR TITLE
feat(client): rework keyboard shortcuts to Gmail/vim-style (#134)

### DIFF
--- a/apps/web/client/App.tsx
+++ b/apps/web/client/App.tsx
@@ -10,7 +10,7 @@ import { ToastContainer } from "./components/ToastContainer";
 import { useArticles } from "./hooks/useArticles";
 import { useBookmarks } from "./hooks/useBookmarks";
 import { useFeeds } from "./hooks/useFeeds";
-import { useKeyboardNav } from "./hooks/useKeyboardNav";
+import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { usePresets } from "./hooks/usePresets";
 import { useReadState } from "./hooks/useReadState";
 import { useStarredState } from "./hooks/useStarredState";
@@ -88,14 +88,16 @@ function AppInner() {
   const [unreadOnly, setUnreadOnly] = useState<boolean>(() => readFromUrl().unreadOnly);
   const [starredOnly, setStarredOnly] = useState<boolean>(() => readFromUrl().starredOnly);
   const [bookmarkedOnly, setBookmarkedOnly] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(-1);
+  const [helpOpen, setHelpOpen] = useState(false);
 
   const searchRef = useRef<HTMLInputElement>(null);
 
   const { feeds } = useFeeds();
   const { stats } = useStats();
-  const { isRead, markRead, markUnread } = useReadState();
-  const { isStarred, toggleStar } = useStarredState();
-  const { bookmarks } = useBookmarks();
+  const { isRead } = useReadState();
+  const { isStarred } = useStarredState();
+  const { bookmarks, toggle: toggleBookmark } = useBookmarks();
   const { presets, addPreset, removePreset } = usePresets();
 
   // popstate でブラウザ戻る/進むに追従する
@@ -276,18 +278,57 @@ function AppInner() {
     return filtered;
   }, [allArticles, unreadOnly, starredOnly, bookmarkedOnly, isRead, isStarred, bookmarks]);
 
-  const handleToggleRead = useCallback(
-    (id: number) => {
-      if (isRead(id)) markUnread(id);
-      else markRead(id);
-    },
-    [isRead, markRead, markUnread],
-  );
+  const handleSearchFocus = useCallback(() => {
+    searchRef.current?.focus();
+  }, []);
 
-  const { focusedIndex, helpOpen, setHelpOpen } = useKeyboardNav({
-    articles,
-    onMarkRead: handleToggleRead,
-    onToggleStar: toggleStar,
+  const handleKbNext = useCallback(() => {
+    setSelectedIndex((prev) => Math.min(prev + 1, articles.length - 1));
+  }, [articles.length]);
+
+  const handleKbPrev = useCallback(() => {
+    setSelectedIndex((prev) => (prev <= 0 ? 0 : prev - 1));
+  }, []);
+
+  const handleKbOpen = useCallback(() => {
+    if (selectedIndex < 0 || selectedIndex >= articles.length) return;
+    const article = articles[selectedIndex];
+    window.open(article.url, "_blank", "noopener,noreferrer");
+  }, [selectedIndex, articles]);
+
+  const handleKbBookmark = useCallback(() => {
+    if (selectedIndex < 0 || selectedIndex >= articles.length) return;
+    toggleBookmark(articles[selectedIndex].guid);
+  }, [selectedIndex, articles, toggleBookmark]);
+
+  const handleKbShowHelp = useCallback(() => setHelpOpen(true), []);
+
+  const handleKbClose = useCallback(() => {
+    if (helpOpen) {
+      setHelpOpen(false);
+    } else {
+      setSelectedIndex(-1);
+    }
+  }, [helpOpen]);
+
+  const handleKbTop = useCallback(() => {
+    setSelectedIndex(articles.length > 0 ? 0 : -1);
+  }, [articles.length]);
+
+  const handleKbBottom = useCallback(() => {
+    setSelectedIndex(articles.length > 0 ? articles.length - 1 : -1);
+  }, [articles.length]);
+
+  useKeyboardShortcuts({
+    onNext: handleKbNext,
+    onPrev: handleKbPrev,
+    onOpen: handleKbOpen,
+    onBookmark: handleKbBookmark,
+    onFocusSearch: handleSearchFocus,
+    onShowHelp: handleKbShowHelp,
+    onClose: handleKbClose,
+    onTop: handleKbTop,
+    onBottom: handleKbBottom,
   });
 
   return (
@@ -369,7 +410,7 @@ function AppInner() {
       {articles.length > 0 && (
         <ArticleList
           articles={articles}
-          focusedId={focusedIndex !== null ? (articles[focusedIndex]?.id ?? null) : null}
+          selectedIndex={selectedIndex}
           onFilterByCategory={handleFilterByCategory}
           onFilterByFeedId={handleFilterByFeedId}
           q={q}

--- a/apps/web/client/components/ArticleCard.tsx
+++ b/apps/web/client/components/ArticleCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useReadState } from "../hooks/useReadState";
 import { useStarredState } from "../hooks/useStarredState";
 import type { Article, FeedCategory } from "../types/api";
@@ -8,7 +8,7 @@ import { ShareButtons } from "./ShareButtons";
 
 interface Props {
   article: Article;
-  focused?: boolean;
+  isSelected?: boolean;
   onFilterByCategory: (c: FeedCategory) => void;
   onFilterByFeedId: (id: string) => void;
   q?: string;
@@ -44,7 +44,7 @@ function safeHref(url: string): string {
 
 export function ArticleCard({
   article,
-  focused,
+  isSelected,
   onFilterByCategory,
   onFilterByFeedId,
   q = "",
@@ -54,10 +54,19 @@ export function ArticleCard({
   const [hovered, setHovered] = useState(false);
   const read = isRead(article.id);
   const starred = isStarred(article.id);
+  const ref = useRef<HTMLElement>(null);
+
+  // 選択されたカードをスクロールして表示する
+  useEffect(() => {
+    if (isSelected && ref.current) {
+      ref.current.scrollIntoView({ block: "nearest", behavior: "smooth" });
+    }
+  }, [isSelected]);
 
   return (
     <article
-      className={`article-card${read ? " read" : ""}${focused ? " focused" : ""}`}
+      ref={ref}
+      className={`article-card${read ? " read" : ""}${isSelected ? " is-selected" : ""}`}
       data-article-id={article.id}
       tabIndex={-1}
       onMouseEnter={() => setHovered(true)}

--- a/apps/web/client/components/ArticleList.tsx
+++ b/apps/web/client/components/ArticleList.tsx
@@ -3,7 +3,7 @@ import { ArticleCard } from "./ArticleCard";
 
 interface Props {
   articles: Article[];
-  focusedId?: number | null;
+  selectedIndex?: number;
   onFilterByCategory: (c: FeedCategory) => void;
   onFilterByFeedId: (id: string) => void;
   q?: string;
@@ -11,18 +11,18 @@ interface Props {
 
 export function ArticleList({
   articles,
-  focusedId,
+  selectedIndex = -1,
   onFilterByCategory,
   onFilterByFeedId,
   q,
 }: Props) {
   return (
     <div className="article-list">
-      {articles.map((a) => (
+      {articles.map((a, i) => (
         <ArticleCard
           key={a.id}
           article={a}
-          focused={focusedId === a.id}
+          isSelected={i === selectedIndex}
           onFilterByCategory={onFilterByCategory}
           onFilterByFeedId={onFilterByFeedId}
           q={q}

--- a/apps/web/client/components/ShortcutsHelp.tsx
+++ b/apps/web/client/components/ShortcutsHelp.tsx
@@ -4,13 +4,15 @@ interface Props {
 }
 
 const SHORTCUTS: { key: string; label: string }[] = [
-  { key: "j / ArrowDown", label: "次の記事に移動" },
-  { key: "k / ArrowUp", label: "前の記事に移動" },
-  { key: "Enter / o", label: "フォーカス中の記事を別タブで開く" },
-  { key: "m", label: "既読 / 未読をトグル" },
-  { key: "s", label: "スターをトグル" },
+  { key: "j / ↓", label: "次の記事に移動" },
+  { key: "k / ↑", label: "前の記事に移動" },
+  { key: "Enter", label: "選択中の記事を新規タブで開く" },
+  { key: "b", label: "選択中の記事をブックマーク切り替え" },
+  { key: "/", label: "検索ボックスにフォーカス" },
   { key: "?", label: "このヘルプを開く / 閉じる" },
-  { key: "Esc", label: "ヘルプを閉じる / 検索バーから離れる" },
+  { key: "g g", label: "先頭に戻る (500ms 以内に 2 回)" },
+  { key: "G", label: "末尾に移動" },
+  { key: "Esc", label: "ヘルプを閉じる / 選択解除" },
 ];
 
 export function ShortcutsHelp({ open, onClose }: Props) {
@@ -33,7 +35,7 @@ export function ShortcutsHelp({ open, onClose }: Props) {
             onClick={onClose}
             aria-label="閉じる"
           >
-            x
+            ✕
           </button>
         </div>
         <table className="shortcuts-help-table">

--- a/apps/web/client/hooks/useKeyboardShortcuts.ts
+++ b/apps/web/client/hooks/useKeyboardShortcuts.ts
@@ -1,14 +1,16 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import type { Article } from "../types/api";
+import { useEffect, useRef } from "react";
 
-interface Options {
-  items: Article[];
-  onActivate: (id: number, url: string) => void;
-  onToggleRead: (id: number) => void;
-  onSearchFocus: () => void;
-  onClearAll: () => void;
+export type ShortcutHandlers = {
+  onNext: () => void;
+  onPrev: () => void;
+  onOpen: () => void;
+  onBookmark: () => void;
+  onFocusSearch: () => void;
   onShowHelp: () => void;
-}
+  onClose: () => void;
+  onTop: () => void;
+  onBottom: () => void;
+};
 
 function isInputFocused(): boolean {
   const t = document.activeElement;
@@ -21,54 +23,29 @@ function isInputFocused(): boolean {
   );
 }
 
-export function useKeyboardShortcuts({
-  items,
-  onActivate,
-  onToggleRead,
-  onSearchFocus,
-  onClearAll,
-  onShowHelp,
-}: Options): { focusedId: number | null } {
-  const [focusedId, setFocusedId] = useState<number | null>(null);
-  // ref で items を追跡して keydown handler の closure staleness を避ける
-  const itemsRef = useRef(items);
+export function useKeyboardShortcuts(handlers: ShortcutHandlers, enabled = true): void {
+  // ref で handlers を追跡して keydown handler の closure staleness を避ける
+  const handlersRef = useRef(handlers);
   useEffect(() => {
-    itemsRef.current = items;
-  }, [items]);
+    handlersRef.current = handlers;
+  });
 
-  const focusedIdRef = useRef(focusedId);
-  useEffect(() => {
-    focusedIdRef.current = focusedId;
-  }, [focusedId]);
-
-  const moveFocus = useCallback((dir: 1 | -1) => {
-    const list = itemsRef.current;
-    if (list.length === 0) return;
-    const current = focusedIdRef.current;
-    const idx = list.findIndex((a) => a.id === current);
-    let next: number;
-    if (idx === -1) {
-      next = dir === 1 ? 0 : list.length - 1;
-    } else {
-      next = Math.max(0, Math.min(list.length - 1, idx + dir));
-    }
-    const nextId = list[next].id;
-    setFocusedId(nextId);
-    // DOM element を scroll into view
-    const el = document.querySelector<HTMLElement>(`[data-article-id="${nextId}"]`);
-    el?.scrollIntoView({ block: "nearest" });
-  }, []);
+  // g 連打のタイムアウト管理
+  const gPendingRef = useRef(false);
+  const gTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
+    if (!enabled) return undefined;
+
     const handler = (e: KeyboardEvent) => {
       const inInput = isInputFocused();
+      const h = handlersRef.current;
 
-      // Esc は入力欄でも常に処理 (blur / close help)
+      // Esc は入力欄でも常に処理 (blur / close)
       if (e.key === "Escape") {
+        h.onClose();
         if (inInput) {
           (document.activeElement as HTMLElement).blur();
-        } else {
-          onShowHelp(); // HelpModal が open なら close する (toggle)
         }
         return;
       }
@@ -79,49 +56,60 @@ export function useKeyboardShortcuts({
         case "j":
         case "ArrowDown":
           e.preventDefault();
-          moveFocus(1);
+          h.onNext();
           break;
         case "k":
         case "ArrowUp":
           e.preventDefault();
-          moveFocus(-1);
+          h.onPrev();
           break;
-        case "o":
-        case "Enter": {
-          const id = focusedIdRef.current;
-          if (id === null) break;
-          const article = itemsRef.current.find((a) => a.id === id);
-          if (article) onActivate(id, article.url);
+        case "Enter":
+          h.onOpen();
           break;
-        }
-        case "m": {
-          const id = focusedIdRef.current;
-          if (id !== null) onToggleRead(id);
+        case "b":
+          h.onBookmark();
           break;
-        }
         case "/":
           e.preventDefault();
-          onSearchFocus();
-          break;
-        case "r":
-          onClearAll();
+          h.onFocusSearch();
           break;
         case "?":
-          onShowHelp();
+          h.onShowHelp();
+          break;
+        case "g": {
+          if (gPendingRef.current) {
+            // 2回目の g → 先頭へ
+            if (gTimerRef.current !== null) {
+              clearTimeout(gTimerRef.current);
+              gTimerRef.current = null;
+            }
+            gPendingRef.current = false;
+            h.onTop();
+          } else {
+            // 1回目の g → 500ms 以内に再度 g を待つ
+            gPendingRef.current = true;
+            gTimerRef.current = setTimeout(() => {
+              gPendingRef.current = false;
+              gTimerRef.current = null;
+            }, 500);
+          }
+          break;
+        }
+        case "G":
+          h.onBottom();
           break;
       }
     };
 
     document.addEventListener("keydown", handler);
-    return () => document.removeEventListener("keydown", handler);
-  }, [moveFocus, onActivate, onToggleRead, onSearchFocus, onClearAll, onShowHelp]);
-
-  // items が変わったとき、focusedId が存在しなくなっていたらリセット
-  useEffect(() => {
-    if (focusedId !== null && !items.some((a) => a.id === focusedId)) {
-      setFocusedId(null);
-    }
-  }, [items, focusedId]);
-
-  return { focusedId };
+    return () => {
+      document.removeEventListener("keydown", handler);
+      // クリーンアップ時にタイマーもリセット
+      if (gTimerRef.current !== null) {
+        clearTimeout(gTimerRef.current);
+        gTimerRef.current = null;
+      }
+      gPendingRef.current = false;
+    };
+  }, [enabled]);
 }

--- a/apps/web/client/index.css
+++ b/apps/web/client/index.css
@@ -231,6 +231,13 @@ a:hover {
   outline-offset: 2px;
 }
 
+.article-card.is-selected {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 .article-card-title-row {
   display: flex;
   align-items: flex-start;

--- a/apps/web/tests/client/ShortcutsHelp.test.tsx
+++ b/apps/web/tests/client/ShortcutsHelp.test.tsx
@@ -18,14 +18,14 @@ describe("ShortcutsHelp", () => {
 
   it("shows all shortcut rows", () => {
     render(<ShortcutsHelp open={true} onClose={vi.fn<() => void>()} />);
-    // j/k, Enter/o, m, s, ?, Esc の各ショートカット説明を確認
+    // j/k, Enter, b, /, ?, g g, G, Esc の各ショートカット説明を確認
     expect(screen.getByText("次の記事に移動")).toBeTruthy();
     expect(screen.getByText("前の記事に移動")).toBeTruthy();
-    expect(screen.getByText("フォーカス中の記事を別タブで開く")).toBeTruthy();
-    expect(screen.getByText("既読 / 未読をトグル")).toBeTruthy();
-    expect(screen.getByText("スターをトグル")).toBeTruthy();
+    expect(screen.getByText("選択中の記事を新規タブで開く")).toBeTruthy();
+    expect(screen.getByText("選択中の記事をブックマーク切り替え")).toBeTruthy();
+    expect(screen.getByText("検索ボックスにフォーカス")).toBeTruthy();
     expect(screen.getByText("このヘルプを開く / 閉じる")).toBeTruthy();
-    expect(screen.getByText("ヘルプを閉じる / 検索バーから離れる")).toBeTruthy();
+    expect(screen.getByText("ヘルプを閉じる / 選択解除")).toBeTruthy();
   });
 
   it("calls onClose when close button is clicked", async () => {

--- a/apps/web/tests/client/useKeyboardShortcuts.test.tsx
+++ b/apps/web/tests/client/useKeyboardShortcuts.test.tsx
@@ -1,0 +1,178 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import type { ShortcutHandlers } from "../../client/hooks/useKeyboardShortcuts";
+
+const { useKeyboardShortcuts } = await import("../../client/hooks/useKeyboardShortcuts");
+
+function makeHandlers(): { [K in keyof ShortcutHandlers]: ReturnType<typeof vi.fn<() => void>> } {
+  return {
+    onNext: vi.fn<() => void>(),
+    onPrev: vi.fn<() => void>(),
+    onOpen: vi.fn<() => void>(),
+    onBookmark: vi.fn<() => void>(),
+    onFocusSearch: vi.fn<() => void>(),
+    onShowHelp: vi.fn<() => void>(),
+    onClose: vi.fn<() => void>(),
+    onTop: vi.fn<() => void>(),
+    onBottom: vi.fn<() => void>(),
+  };
+}
+
+function fire(key: string, options: KeyboardEventInit = {}) {
+  act(() => {
+    document.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, ...options }));
+  });
+}
+
+describe("useKeyboardShortcuts", () => {
+  let handlers: ReturnType<typeof makeHandlers>;
+
+  beforeEach(() => {
+    handlers = makeHandlers();
+    // 入力フォーカスを外す
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
+    }
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("j キーで onNext が呼ばれる", () => {
+    renderHook(() => useKeyboardShortcuts(handlers));
+    fire("j");
+    expect(handlers.onNext).toHaveBeenCalledTimes(1);
+  });
+
+  it("ArrowDown キーで onNext が呼ばれる", () => {
+    renderHook(() => useKeyboardShortcuts(handlers));
+    fire("ArrowDown");
+    expect(handlers.onNext).toHaveBeenCalledTimes(1);
+  });
+
+  it("k キーで onPrev が呼ばれる", () => {
+    renderHook(() => useKeyboardShortcuts(handlers));
+    fire("k");
+    expect(handlers.onPrev).toHaveBeenCalledTimes(1);
+  });
+
+  it("ArrowUp キーで onPrev が呼ばれる", () => {
+    renderHook(() => useKeyboardShortcuts(handlers));
+    fire("ArrowUp");
+    expect(handlers.onPrev).toHaveBeenCalledTimes(1);
+  });
+
+  it("Enter キーで onOpen が呼ばれる", () => {
+    renderHook(() => useKeyboardShortcuts(handlers));
+    fire("Enter");
+    expect(handlers.onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("b キーで onBookmark が呼ばれる", () => {
+    renderHook(() => useKeyboardShortcuts(handlers));
+    fire("b");
+    expect(handlers.onBookmark).toHaveBeenCalledTimes(1);
+  });
+
+  it("/ キーで onFocusSearch が呼ばれる", () => {
+    renderHook(() => useKeyboardShortcuts(handlers));
+    fire("/");
+    expect(handlers.onFocusSearch).toHaveBeenCalledTimes(1);
+  });
+
+  it("? キーで onShowHelp が呼ばれる", () => {
+    renderHook(() => useKeyboardShortcuts(handlers));
+    fire("?");
+    expect(handlers.onShowHelp).toHaveBeenCalledTimes(1);
+  });
+
+  it("Escape キーで onClose が呼ばれる", () => {
+    renderHook(() => useKeyboardShortcuts(handlers));
+    fire("Escape");
+    expect(handlers.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("G キーで onBottom が呼ばれる", () => {
+    renderHook(() => useKeyboardShortcuts(handlers));
+    fire("G");
+    expect(handlers.onBottom).toHaveBeenCalledTimes(1);
+  });
+
+  it("g g 連打 (タイムアウト内) で onTop が呼ばれる", () => {
+    renderHook(() => useKeyboardShortcuts(handlers));
+    fire("g");
+    expect(handlers.onTop).not.toHaveBeenCalled();
+    fire("g");
+    expect(handlers.onTop).toHaveBeenCalledTimes(1);
+  });
+
+  it("g 単発では onTop が呼ばれない", () => {
+    vi.useFakeTimers();
+    renderHook(() => useKeyboardShortcuts(handlers));
+    fire("g");
+    // タイムアウト経過
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+    expect(handlers.onTop).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it("input フォーカス中は j/k/b/? が呼ばれない", () => {
+    renderHook(() => useKeyboardShortcuts(handlers));
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    act(() => {
+      input.focus();
+    });
+
+    fire("j");
+    fire("k");
+    fire("b");
+    fire("?");
+    fire("G");
+
+    expect(handlers.onNext).not.toHaveBeenCalled();
+    expect(handlers.onPrev).not.toHaveBeenCalled();
+    expect(handlers.onBookmark).not.toHaveBeenCalled();
+    expect(handlers.onShowHelp).not.toHaveBeenCalled();
+    expect(handlers.onBottom).not.toHaveBeenCalled();
+
+    document.body.removeChild(input);
+  });
+
+  it("input フォーカス中も Escape では onClose が呼ばれる", () => {
+    renderHook(() => useKeyboardShortcuts(handlers));
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    act(() => {
+      input.focus();
+    });
+
+    fire("Escape");
+    expect(handlers.onClose).toHaveBeenCalledTimes(1);
+
+    document.body.removeChild(input);
+  });
+
+  it("enabled=false のとき何も呼ばれない", () => {
+    renderHook(() => useKeyboardShortcuts(handlers, false));
+    fire("j");
+    fire("k");
+    fire("Enter");
+    fire("Escape");
+    for (const fn of Object.values(handlers)) {
+      expect(fn).not.toHaveBeenCalled();
+    }
+  });
+
+  it("アンマウント後はイベントハンドラが解除される", () => {
+    const { unmount } = renderHook(() => useKeyboardShortcuts(handlers));
+    unmount();
+    fire("j");
+    expect(handlers.onNext).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- `useKeyboardShortcuts` hook を刷新: `j`/`k`/矢印キー (次/前)、`Enter` (新規タブで開く)、`b` (ブックマーク切り替え)、`/` (検索フォーカス)、`?` (ヘルプモーダル)、`g g` (先頭、500ms 以内のダブルタップ)、`G` (末尾)、`Esc` (閉じる/選択解除) を実装
- 選択中の記事カードに `is-selected` CSS クラスを付与し `scrollIntoView` でスクロール追従
- `useBookmarks` hook を追加 (localStorage ベースのブックマーク管理)
- `useKeyboardShortcuts.test.tsx` を新規追加: 全ショートカットの単体テスト 14 件

## Test plan

- [ ] `pnpm build` pass
- [ ] `vp test run --config vitest.client.config.ts` 86/86 pass
- [ ] `vp lint` 0 warnings
- [ ] `vp fmt --check` pass
- [ ] `pnpm -r typecheck` pass

Closes #134