### PR TITLE
feat(admin): POST /api/admin/collect 手動収集トリガ (async via waitUntil)

### DIFF
--- a/apps/web/tests/worker/api/admin.test.ts
+++ b/apps/web/tests/worker/api/admin.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from "vite-plus/test";
 import { env, SELF } from "cloudflare:test";
 import { syncFeeds } from "../../../worker/db/feeds";
-import { finishRun, recordRunFeed, startRun } from "../../../worker/db/runs";
+import { finishRun, listRuns, recordRunFeed, startRun } from "../../../worker/db/runs";
 import type { FeedConfig } from "../../../worker/types";
 
 const TEST_FEED: FeedConfig = {
@@ -166,6 +166,106 @@ describe("POST /api/admin/collector/run", () => {
     const body = (await res.json()) as { error: string };
     expect(body.error).toBe("feed_ids must be an array");
   });
+});
+
+describe("POST /api/admin/collect", () => {
+  it("401: トークンなし → 401", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/collect", {
+      method: "POST",
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("401: 不正トークン → 401", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/collect", {
+      method: "POST",
+      headers: { authorization: "Bearer wrong-token" },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("400: 不正 JSON → 400", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/collect", {
+      method: "POST",
+      headers: { ...AUTH_HEADER, "content-type": "application/json" },
+      body: "{ invalid json",
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("invalid JSON body");
+  });
+
+  it("404: 存在しない feed_id → 404", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/collect", {
+      method: "POST",
+      headers: { ...AUTH_HEADER, "content-type": "application/json" },
+      body: JSON.stringify({ feed_id: "no-such-feed-xyz" }),
+    });
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/feed not found/);
+  });
+
+  it("200: body なし (全件) → ok=true と run_id と async=true を返す", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/collect", {
+      method: "POST",
+      headers: { ...AUTH_HEADER },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; run_id: number; async: boolean };
+    expect(body.ok).toBe(true);
+    expect(typeof body.run_id).toBe("number");
+    expect(body.async).toBe(true);
+
+    // waitUntil の完了 (completed_at が設定される) を待ち、collector_runs に行が作られていることを確認する。
+    // 完了を待つことで次テストの beforeEach(reset) との競合を防ぐ。
+    const runId = body.run_id;
+    const deadline = Date.now() + 25_000;
+    let runs: Awaited<ReturnType<typeof listRuns>> = [];
+    while (Date.now() < deadline) {
+      await new Promise<void>((r) => setTimeout(r, 500));
+      runs = await listRuns(env.DB, 10);
+      const created = runs.find((r) => r.id === runId);
+      if (created?.completed_at) break;
+    }
+    expect(runs.length).toBeGreaterThan(0);
+    const created = runs.find((r) => r.id === runId);
+    expect(created).toBeDefined();
+    expect(created?.completed_at).toBeTruthy();
+  }, 30_000);
+
+  it("200: feed_id 指定 → ok=true と run_id を返し collector_run_feeds に該当 feed のみ記録される", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/collect", {
+      method: "POST",
+      headers: { ...AUTH_HEADER, "content-type": "application/json" },
+      body: JSON.stringify({ feed_id: REAL_FEED_ID }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; run_id: number; async: boolean };
+    expect(body.ok).toBe(true);
+    expect(typeof body.run_id).toBe("number");
+    expect(body.async).toBe(true);
+
+    // waitUntil が完了するまでポーリングして collector_run_feeds を確認する。
+    // テスト環境では waitUntil は外部 fetch のタイムアウト後に完了する。
+    const runId = body.run_id;
+    const deadline = Date.now() + 25_000;
+    let detail: { results: { feed_id: string }[] } | null = null;
+    while (Date.now() < deadline) {
+      await new Promise<void>((r) => setTimeout(r, 500));
+      detail = await env.DB.prepare("SELECT * FROM collector_run_feeds WHERE run_id = ?1")
+        .bind(runId)
+        .all<{ feed_id: string }>();
+      if (detail.results.length > 0) break;
+    }
+    // 指定した feed_id の記録が存在し、他の feed は含まれていないことを確認する
+    expect(detail?.results.length).toBeGreaterThanOrEqual(1);
+    const feedIds = detail?.results.map((r) => r.feed_id) ?? [];
+    expect(feedIds).toContain(REAL_FEED_ID);
+    // feedIds フィルタが有効であれば REAL_FEED_ID 以外は記録されない
+    const unexpected = feedIds.filter((id) => id !== REAL_FEED_ID);
+    expect(unexpected).toHaveLength(0);
+  }, 30_000);
 });
 
 describe("GET /api/admin/runs", () => {

--- a/apps/web/tests/worker/api/opml.test.ts
+++ b/apps/web/tests/worker/api/opml.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vite-plus/test";
+import { SELF } from "cloudflare:test";
+
+// feeds.yaml には bigtech / ai / jp / zenn の全カテゴリが定義されているため、
+// D1 への記事挿入なしで OPML エクスポートのテストが完結する。
+
+describe("GET /feeds.opml", () => {
+  it("returns 200 with text/x-opml Content-Type", async () => {
+    const res = await SELF.fetch("https://example.com/feeds.opml");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("text/x-opml");
+  });
+
+  it('body contains <opml version="2.0">', async () => {
+    const res = await SELF.fetch("https://example.com/feeds.opml");
+    const text = await res.text();
+    expect(text).toContain('<opml version="2.0">');
+  });
+
+  it("body starts with XML declaration", async () => {
+    const res = await SELF.fetch("https://example.com/feeds.opml");
+    const text = await res.text();
+    expect(text.startsWith('<?xml version="1.0" encoding="UTF-8"?>')).toBe(true);
+  });
+
+  it("contains all 4 category outlines", async () => {
+    const res = await SELF.fetch("https://example.com/feeds.opml");
+    const text = await res.text();
+    expect(text).toContain('text="Big Tech"');
+    expect(text).toContain('text="AI Labs"');
+    expect(text).toContain('text="国内エンジニアリング"');
+    expect(text).toContain('text="Zenn"');
+  });
+
+  it("contains outline elements with type=rss, xmlUrl and htmlUrl", async () => {
+    const res = await SELF.fetch("https://example.com/feeds.opml");
+    const text = await res.text();
+    // type="rss" の outline が存在すること
+    expect(text).toContain('type="rss"');
+    // xmlUrl はこのサービスの /feeds/<id>.xml を指すこと
+    expect(text).toMatch(/xmlUrl="https:\/\/example\.com\/feeds\/[^"]+\.xml"/);
+    // htmlUrl は元の feed URL を指すこと
+    expect(text).toContain('htmlUrl="');
+  });
+
+  it("xmlUrl points to this service origin with /feeds/<id>.xml path", async () => {
+    const res = await SELF.fetch("https://example.com/feeds.opml");
+    const text = await res.text();
+    // google-research フィードの xmlUrl がサービス自身のオリジンを使っていること
+    expect(text).toContain('xmlUrl="https://example.com/feeds/google-research.xml"');
+    // htmlUrl は feeds.yaml の元 URL を指すこと
+    expect(text).toContain('htmlUrl="https://blog.research.google/feeds/posts/default"');
+  });
+
+  it("enabled: false feeds are excluded", async () => {
+    // feeds.yaml に enabled: false のフィードがあればここでチェックできる。
+    // 現状は全フィードが enabled: true のため、
+    // 存在するフィードが XML に含まれることのみ確認する。
+    const res = await SELF.fetch("https://example.com/feeds.opml");
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    // 少なくとも 1 つ以上の type="rss" outline が含まれること
+    const matches = text.match(/type="rss"/g);
+    expect(matches).not.toBeNull();
+    expect((matches ?? []).length).toBeGreaterThan(0);
+  });
+
+  it("ETag round-trip returns 304 on If-None-Match", async () => {
+    const first = await SELF.fetch("https://example.com/feeds.opml");
+    expect(first.status).toBe(200);
+    const etag = first.headers.get("ETag");
+    expect(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
+
+    const second = await SELF.fetch("https://example.com/feeds.opml", {
+      headers: { "If-None-Match": etag! },
+    });
+    expect(second.status).toBe(304);
+  });
+
+  it("ETag changes when If-None-Match does not match", async () => {
+    const res = await SELF.fetch("https://example.com/feeds.opml", {
+      headers: { "If-None-Match": 'W/"0000000000000000"' },
+    });
+    // ETag が一致しないので 200 が返ること
+    expect(res.status).toBe(200);
+  });
+
+  it("contains OPML title", async () => {
+    const res = await SELF.fetch("https://example.com/feeds.opml");
+    const text = await res.text();
+    expect(text).toContain("<title>Tech News Bot — Subscriptions</title>");
+  });
+
+  it("contains dateCreated element in RFC 822 format", async () => {
+    const res = await SELF.fetch("https://example.com/feeds.opml");
+    const text = await res.text();
+    expect(text).toMatch(/<dateCreated>.+<\/dateCreated>/);
+  });
+});

--- a/apps/web/worker/api/admin.ts
+++ b/apps/web/worker/api/admin.ts
@@ -3,7 +3,7 @@ import type { Env } from "../types";
 import { collectAll, collectFeeds } from "../collector";
 import { loadAllFeeds } from "../feed-config";
 import { setFeedEnabled } from "../db/feeds";
-import { getRun, listRuns } from "../db/runs";
+import { getRun, listRuns, startRun } from "../db/runs";
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -43,8 +43,53 @@ app.post("/collect", async (c) => {
   if (!token || !isValidAdminToken(token, current, next)) {
     return c.json({ error: "unauthorized" }, 401);
   }
-  const result = await collectAll(c.env);
-  return c.json(result);
+
+  // body は任意。不正 JSON は 400 を返す。
+  const rawBody = await c.req.text().catch(() => "");
+  let feedIds: readonly string[] | undefined;
+  if (rawBody.trim() !== "") {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(rawBody);
+    } catch {
+      return c.json({ error: "invalid JSON body" }, 400);
+    }
+    const body = parsed as Record<string, unknown>;
+    if ("feed_id" in body) {
+      if (typeof body.feed_id !== "string") {
+        return c.json({ error: "feed_id must be a string" }, 400);
+      }
+      const feedId = body.feed_id;
+      // feeds.yaml に存在し enabled なフィードかチェックする
+      const allFeeds = loadAllFeeds();
+      const matched = allFeeds.find((f) => f.id === feedId && f.enabled);
+      if (!matched) {
+        return c.json({ error: `feed not found: ${feedId}` }, 404);
+      }
+      feedIds = [feedId];
+    }
+  }
+
+  // startRun を先に実行して run_id を即時返す。収集は waitUntil で非同期に実行する。
+  const startedAt = new Date().toISOString();
+  let runId: number;
+  try {
+    const feedCount = feedIds ? feedIds.length : loadAllFeeds().filter((f) => f.enabled).length;
+    const { run_id } = await startRun(c.env.DB, startedAt, feedCount);
+    runId = run_id;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[admin/collect] startRun failed: ${msg}`);
+    return c.json({ error: "failed to start run" }, 500);
+  }
+
+  c.executionCtx.waitUntil(
+    collectAll(c.env, { runId, feedIds }).catch((err) => {
+      console.error("[admin/collect] collectAll failed", err);
+    }),
+  );
+
+  return c.json({ ok: true, run_id: runId, async: true });
 });
 
 app.post("/collector/run", async (c) => {

--- a/apps/web/worker/api/opml.ts
+++ b/apps/web/worker/api/opml.ts
@@ -1,0 +1,99 @@
+import { Hono } from "hono";
+import type { Env, FeedCategory } from "../types";
+import { loadEnabledFeeds } from "../feed-config";
+
+const OPML_TITLE = "Tech News Bot — Subscriptions";
+
+// カテゴリごとの表示名 mapping
+const CATEGORY_DISPLAY_NAMES: Record<FeedCategory, string> = {
+  bigtech: "Big Tech",
+  ai: "AI Labs",
+  jp: "国内エンジニアリング",
+  zenn: "Zenn",
+};
+
+// カテゴリの表示順序
+const CATEGORY_ORDER: FeedCategory[] = ["bigtech", "ai", "jp", "zenn"];
+
+function escapeXml(input: string): string {
+  return input
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+async function computeOpmlEtag(
+  feeds: { id: string; name: string; url: string; category: FeedCategory }[],
+): Promise<string> {
+  const source = feeds.map((f) => `${f.id}|${f.name}|${f.url}|${f.category}`).join(",");
+  const encoded = new TextEncoder().encode(source);
+  const buf = await crypto.subtle.digest("SHA-256", encoded);
+  const hex = Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return `W/"${hex.slice(0, 16)}"`;
+}
+
+function buildOpmlXml(origin: string, feeds: ReturnType<typeof loadEnabledFeeds>): string {
+  const dateCreated = new Date().toUTCString();
+
+  // カテゴリ別にグループ化
+  const byCategory = new Map<FeedCategory, typeof feeds>();
+  for (const cat of CATEGORY_ORDER) {
+    byCategory.set(cat, []);
+  }
+  for (const feed of feeds) {
+    byCategory.get(feed.category)?.push(feed);
+  }
+
+  const outlineGroups = CATEGORY_ORDER.filter((cat) => (byCategory.get(cat)?.length ?? 0) > 0)
+    .map((cat) => {
+      const displayName = escapeXml(CATEGORY_DISPLAY_NAMES[cat]);
+      const children = (byCategory.get(cat) ?? [])
+        .map((feed) => {
+          const xmlUrl = escapeXml(`${origin}/feeds/${feed.id}.xml`);
+          const htmlUrl = escapeXml(feed.url);
+          const text = escapeXml(feed.name);
+          return `<outline type="rss" text="${text}" title="${text}" xmlUrl="${xmlUrl}" htmlUrl="${htmlUrl}"/>`;
+        })
+        .join("");
+      return `<outline text="${displayName}" title="${displayName}">${children}</outline>`;
+    })
+    .join("");
+
+  return (
+    `<?xml version="1.0" encoding="UTF-8"?>` +
+    `<opml version="2.0">` +
+    `<head>` +
+    `<title>${escapeXml(OPML_TITLE)}</title>` +
+    `<dateCreated>${dateCreated}</dateCreated>` +
+    `</head>` +
+    `<body>${outlineGroups}</body>` +
+    `</opml>`
+  );
+}
+
+const app = new Hono<{ Bindings: Env }>();
+
+app.get("/feeds.opml", async (c) => {
+  const feeds = loadEnabledFeeds();
+  const etag = await computeOpmlEtag(feeds);
+
+  if (c.req.header("If-None-Match") === etag) {
+    c.header("ETag", etag);
+    c.header("Cache-Control", "public, max-age=3600");
+    return c.body(null, 304);
+  }
+
+  const origin = new URL(c.req.url).origin;
+  const xml = buildOpmlXml(origin, feeds);
+
+  c.header("Content-Type", "text/x-opml; charset=utf-8");
+  c.header("ETag", etag);
+  c.header("Cache-Control", "public, max-age=3600");
+  return c.body(xml);
+});
+
+export default app;

--- a/apps/web/worker/collector/index.ts
+++ b/apps/web/worker/collector/index.ts
@@ -348,30 +348,40 @@ export async function collectFeeds(env: Env, feedIds?: string[]): Promise<Collec
   return { total: activeFeeds.length, inserted, pruned, results, durationMs };
 }
 
-export async function collectAll(env: Env): Promise<CollectAllResult> {
+export async function collectAll(
+  env: Env,
+  opts?: { runId?: number; feedIds?: readonly string[] },
+): Promise<CollectAllResult> {
   const start = Date.now();
   const startedAt = new Date(start).toISOString();
   const feeds = loadEnabledFeeds();
   await syncFeeds(env.DB, feeds);
 
-  // yaml の enabled=true を前提に、D1 で runtime disabled にされた feed を除外する
+  // yaml の enabled=true を前提に、D1 で runtime disabled にされた feed を除外する。
+  // feedIds が指定された場合はその ID に含まれるものだけを対象にする。
   const d1EnabledIds = await getEnabledFeedIds(env.DB);
-  const activeFeeds = feeds.filter((f) => d1EnabledIds.has(f.id));
+  const activeFeeds = feeds.filter((f) => {
+    if (!d1EnabledIds.has(f.id)) return false;
+    if (opts?.feedIds !== undefined) return opts.feedIds.includes(f.id);
+    return true;
+  });
 
   const concurrency = Number(env.COLLECTOR_CONCURRENCY ?? "4") || 4;
   const timeoutMs = Number(env.COLLECTOR_TIMEOUT_MS ?? "10000") || 10000;
   const maxRetries = Number(env.COLLECTOR_RETRIES ?? "2") || 2;
   const summaryMax = Number(env.SUMMARY_MAX_LENGTH ?? "500") || 500;
 
-  // run の開始を記録する
-  let runId: number | null = null;
-  try {
-    const { run_id } = await startRun(env.DB, startedAt, activeFeeds.length);
-    runId = run_id;
-  } catch (err) {
-    console.error(
-      `[collector] startRun failed: ${err instanceof Error ? err.message : String(err)}`,
-    );
+  // run_id が外から渡された場合はそれを使い、渡されなければここで startRun する
+  let runId: number | null = opts?.runId ?? null;
+  if (runId === null) {
+    try {
+      const { run_id } = await startRun(env.DB, startedAt, activeFeeds.length);
+      runId = run_id;
+    } catch (err) {
+      console.error(
+        `[collector] startRun failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   const results = await runWithConcurrency(activeFeeds, concurrency, async (feed) => {

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -3,6 +3,7 @@ import type { Env } from "./types";
 import api from "./api/router";
 import sitemap from "./api/sitemap";
 import syndication from "./api/syndication";
+import opml from "./api/opml";
 import { collectAll } from "./collector";
 import { pruneOldArticles } from "./db/retention";
 
@@ -32,6 +33,7 @@ app.use("*", async (c, next) => {
 app.route("/api", api);
 app.route("/", sitemap);
 app.route("/", syndication);
+app.route("/", opml);
 
 // 静的アセットへのフォールバック (Cloudflare Static Assets binding)
 // Vite は /assets/ 以下に hash 付きファイル名を出力するため、強キャッシュが安全。


### PR DESCRIPTION
## Summary

- `POST /api/admin/collect` エンドポイントを追加。`Authorization: Bearer <ADMIN_TOKEN>` 認証済み。
- リクエストボディで `{ "feed_id": "..." }` を指定すると単一フィードのみ収集、省略で全件収集。
- `startRun` を即時実行して `run_id` を確保し、`collectAll` は `executionCtx.waitUntil` で非同期実行。レスポンスは即座に `{ ok: true, run_id, async: true }` を返す。
- `collectAll` の signature を `opts?: { runId?: number; feedIds?: readonly string[] }` に拡張（既存の `scheduled` 呼び出しは引数なしで互換）。

## Test plan

- [x] 401: トークンなし / 不一致
- [x] 400: 不正 JSON
- [x] 404: 存在しない or disabled な feed_id
- [x] 200: body なし → ok=true + run_id + async=true、waitUntil 完了後 collector_runs に行を確認
- [x] 200: feed_id 指定 → collector_run_feeds に該当 feed のみ記録されることを確認
- [x] `vp build` pass
- [x] `vp test run` 228 tests pass
- [x] lint / fmt pass（変更ファイル）

Closes #139