### PR TITLE
feat(syndication): Atom 1.0 feed endpoints (closes #142)

### DIFF
--- a/apps/web/tests/worker/api/syndication.test.ts
+++ b/apps/web/tests/worker/api/syndication.test.ts
@@ -294,3 +294,116 @@ describe("/feeds/category/:cat.xml", () => {
     expect(second.status).toBe(304);
   });
 });
+
+describe("/feed.atom", () => {
+  it("returns 200 with Atom 1.0 feed and entries in desc order", async () => {
+    const res = await SELF.fetch("https://example.com/feed.atom");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("application/atom+xml");
+    const text = await res.text();
+    expect(text.startsWith("<?xml")).toBe(true);
+    expect(text).toContain('<feed xmlns="http://www.w3.org/2005/Atom">');
+    // XML エスケープが正しく行われること
+    expect(text).toContain("AI &lt;Article&gt; &amp; friends");
+    // 並び順: 最新が先 (bigtech: 2024-04-04 > jp: 2024-04-03 > ai: 2024-04-02)
+    const bigtech = text.indexOf("g-bigtech");
+    const jp = text.indexOf("g-jp");
+    const ai = text.indexOf("g-ai");
+    expect(bigtech).toBeLessThan(jp);
+    expect(jp).toBeLessThan(ai);
+    // JSON Feed の version 文字列が混入しないこと
+    expect(text).not.toContain("jsonfeed.org");
+  });
+
+  it("filters by category=ai", async () => {
+    const res = await SELF.fetch("https://example.com/feed.atom?category=ai");
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain("g-ai");
+    expect(text).not.toContain("g-jp");
+    expect(text).not.toContain("g-bigtech");
+  });
+});
+
+describe("/feeds/:id.atom (per-feed Atom)", () => {
+  it("returns 200 with only articles from the specified feed_id", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/openai-blog.atom");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("application/atom+xml");
+    const text = await res.text();
+    expect(text).toContain('<feed xmlns="http://www.w3.org/2005/Atom">');
+    expect(text).toContain("g-ai");
+    expect(text).not.toContain("g-jp");
+    // title には feeds.yaml の name が入る
+    expect(text).toContain("<title>OpenAI News</title>");
+    // summary が存在する場合 summary 要素が出力される
+    expect(text).toContain('<summary type="html">');
+  });
+
+  it("returns 404 for unknown feed_id", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/unknown-feed.atom");
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 304 on If-None-Match match (ETag round-trip)", async () => {
+    const res1 = await SELF.fetch("https://example.com/feeds/openai-blog.atom");
+    expect(res1.status).toBe(200);
+    const etag = res1.headers.get("ETag")!;
+    expect(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
+
+    const res2 = await SELF.fetch("https://example.com/feeds/openai-blog.atom", {
+      headers: { "If-None-Match": etag },
+    });
+    expect(res2.status).toBe(304);
+    expect(res2.headers.get("ETag")).toBe(etag);
+  });
+
+  it("omits summary element when article has no summary", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/cyberagent-developers.atom");
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain("g-jp");
+    // summary が null の場合 summary 要素が出力されないこと
+    expect(text).not.toContain("<summary");
+  });
+});
+
+describe("/feeds/category/:cat.atom", () => {
+  it("returns 200 with correct Content-Type for ai category", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/category/ai.atom");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("application/atom+xml");
+    const text = await res.text();
+    expect(text).toContain('<feed xmlns="http://www.w3.org/2005/Atom">');
+    expect(text).toContain("<title>Tech News Bot — AI Labs</title>");
+    expect(text).toContain("g-ai");
+    expect(text).not.toContain("g-jp");
+    expect(text).not.toContain("g-bigtech");
+  });
+
+  it("returns 200 and only jp articles for jp category", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/category/jp.atom");
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain("Tech News Bot — 国内エンジニアリング");
+    expect(text).toContain("g-jp");
+    expect(text).not.toContain("g-ai");
+    expect(text).not.toContain("g-bigtech");
+  });
+
+  it("returns 404 for invalid category", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/category/invalid.atom");
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 304 on ETag round-trip", async () => {
+    const first = await SELF.fetch("https://example.com/feeds/category/ai.atom");
+    const etag = first.headers.get("ETag");
+    expect(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
+
+    const second = await SELF.fetch("https://example.com/feeds/category/ai.atom", {
+      headers: { "If-None-Match": etag! },
+    });
+    expect(second.status).toBe(304);
+  });
+});

--- a/apps/web/worker/api/syndication.ts
+++ b/apps/web/worker/api/syndication.ts
@@ -120,6 +120,72 @@ async function buildJsonFeed(
   return c.body(JSON.stringify(json));
 }
 
+async function buildAtomFeed(
+  c: Context<{ Bindings: Env }>,
+  opts: BuildFeedOpts,
+): Promise<Response> {
+  const { feedId, category, lang, feedName, titleOverride } = opts;
+  const etag = await computeSyndicationEtag(c.env.DB, FEEDS_VERSION, { category, lang, feedId });
+  if (c.req.header("If-None-Match") === etag) {
+    c.header("ETag", etag);
+    c.header("Cache-Control", "public, max-age=60");
+    return c.body(null, 304);
+  }
+
+  const result = await listArticles(c.env.DB, {
+    category,
+    lang,
+    feedId,
+    limit: FEED_LIMIT,
+    cursor: null,
+  });
+  const origin = siteOrigin(c.req.url);
+  const feedUrl = new URL(c.req.url).toString();
+  const feedPath = new URL(c.req.url).pathname;
+  const hostname = new URL(c.req.url).hostname || "example.com";
+  const year = new Date().getFullYear();
+  const title = feedName ?? titleOverride ?? SITE_TITLE;
+  const description = feedName ? `${feedName} の最新記事` : SITE_DESCRIPTION;
+  const updated = result.articles[0]?.published_at ?? new Date().toISOString();
+
+  const entries = result.articles
+    .map((a) => {
+      const authorName = a.author ?? a.feed_name ?? "";
+      const parts = [
+        `<entry>`,
+        `<title>${escapeXml(a.title)}</title>`,
+        `<id>${escapeXml(a.guid)}</id>`,
+        `<link href="${escapeXml(a.url)}" rel="alternate"/>`,
+        `<updated>${a.published_at}</updated>`,
+        `<published>${a.published_at}</published>`,
+      ];
+      if (authorName) parts.push(`<author><name>${escapeXml(authorName)}</name></author>`);
+      parts.push(`<category term="${escapeXml(a.category)}"/>`);
+      if (a.summary) parts.push(`<summary type="html">${escapeXml(a.summary)}</summary>`);
+      parts.push(`</entry>`);
+      return parts.join("");
+    })
+    .join("");
+
+  const xml =
+    `<?xml version="1.0" encoding="utf-8"?>` +
+    `<feed xmlns="http://www.w3.org/2005/Atom">` +
+    `<title>${escapeXml(title)}</title>` +
+    `<subtitle>${escapeXml(description)}</subtitle>` +
+    `<link href="${escapeXml(origin)}/" rel="alternate"/>` +
+    `<link href="${escapeXml(feedUrl)}" rel="self"/>` +
+    `<id>tag:${escapeXml(hostname)},${year}:${escapeXml(feedPath)}</id>` +
+    `<updated>${updated}</updated>` +
+    `<generator uri="https://github.com/rikeda71/tech-news-bot">tech-news-bot</generator>` +
+    entries +
+    `</feed>`;
+
+  c.header("Content-Type", "application/atom+xml; charset=utf-8");
+  c.header("ETag", etag);
+  c.header("Cache-Control", "public, max-age=60");
+  return c.body(xml);
+}
+
 async function buildRssFeed(c: Context<{ Bindings: Env }>, opts: BuildFeedOpts): Promise<Response> {
   const { feedId, category, lang, feedName, titleOverride } = opts;
   const etag = await computeSyndicationEtag(c.env.DB, FEEDS_VERSION, { category, lang, feedId });
@@ -189,6 +255,11 @@ app.get("/feed.xml", async (c) => {
   return buildRssFeed(c, { category, lang });
 });
 
+app.get("/feed.atom", async (c) => {
+  const { category, lang } = parseFilters(c);
+  return buildAtomFeed(c, { category, lang });
+});
+
 // カテゴリ別 syndication エンドポイント
 // Hono の :param は非スラッシュ文字をすべて取り込むため、ワイルドカードで受け取り
 // 拡張子とカテゴリ名を手動で分離する。
@@ -198,7 +269,7 @@ app.get("/feeds/category/*", async (c) => {
   const basename = pathname.replace(/^.*\/feeds\/category\//, "");
 
   let cat: FeedCategory;
-  let format: "json" | "xml";
+  let format: "json" | "xml" | "atom";
 
   if (basename.endsWith(".json")) {
     cat = basename.slice(0, -5) as FeedCategory;
@@ -206,6 +277,9 @@ app.get("/feeds/category/*", async (c) => {
   } else if (basename.endsWith(".xml")) {
     cat = basename.slice(0, -4) as FeedCategory;
     format = "xml";
+  } else if (basename.endsWith(".atom")) {
+    cat = basename.slice(0, -5) as FeedCategory;
+    format = "atom";
   } else {
     return c.json({ error: "Not Found" }, 404);
   }
@@ -219,6 +293,9 @@ app.get("/feeds/category/*", async (c) => {
   if (format === "json") {
     return buildJsonFeed(c, { category: cat, titleOverride });
   }
+  if (format === "atom") {
+    return buildAtomFeed(c, { category: cat, titleOverride });
+  }
   return buildRssFeed(c, { category: cat, titleOverride });
 });
 
@@ -229,7 +306,7 @@ app.get("/feeds/category/*", async (c) => {
 app.get("/feeds/:filename", async (c) => {
   const filename = c.req.param("filename");
   let feedId: string;
-  let format: "xml" | "json";
+  let format: "xml" | "json" | "atom";
 
   if (filename.endsWith(".xml")) {
     feedId = filename.slice(0, -4);
@@ -237,6 +314,9 @@ app.get("/feeds/:filename", async (c) => {
   } else if (filename.endsWith(".json")) {
     feedId = filename.slice(0, -5);
     format = "json";
+  } else if (filename.endsWith(".atom")) {
+    feedId = filename.slice(0, -5);
+    format = "atom";
   } else {
     return c.notFound();
   }
@@ -246,6 +326,9 @@ app.get("/feeds/:filename", async (c) => {
 
   if (format === "xml") {
     return buildRssFeed(c, { feedId, feedName: feedConfig.name, lang: feedConfig.lang });
+  }
+  if (format === "atom") {
+    return buildAtomFeed(c, { feedId, feedName: feedConfig.name, lang: feedConfig.lang });
   }
   return buildJsonFeed(c, { feedId, feedName: feedConfig.name, lang: feedConfig.lang });
 });


### PR DESCRIPTION
## 概要

Atom 1.0 (RFC 4287) 形式のフィード配信エンドポイントを 3 つ追加。

## 変更内容

- `buildAtomFeed()` ヘルパを `worker/api/syndication.ts` に追加
- `GET /feed.atom` — 全件 Atom 1.0 (`?category=` / `?lang=` クエリ対応)
- `GET /feeds/:id.atom` — 個別フィード
- `GET /feeds/category/:cat.atom` — カテゴリ別
- `/feeds/:filename` と `/feeds/category/*` の拡張子分岐に `.atom` ケースを追加
- ETag / 304 は既存 RSS / JSON Feed と同一ロジックを再利用
- 新規テスト 10 件 (Atom 1.0 well-formed、entry 並び順、category/lang フィルタ、404、ETag round-trip)

## テスト

- [x] `vp run build` pass
- [x] `vp test run` pass (248/248)
- [x] `vp lint` clean (syndication への警告なし)
- [x] `vp fmt --check` pass

Closes #142