### PR TITLE
feat(api): add GET /api/articles/:guid/related endpoint

### DIFF
--- a/apps/web/tests/worker/api/articles.test.ts
+++ b/apps/web/tests/worker/api/articles.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it } from "vite-plus/test";
 import { env, SELF } from "cloudflare:test";
 import { insertArticles } from "../../../worker/db/articles";
 import { syncFeeds } from "../../../worker/db/feeds";
-import type { FeedConfig } from "../../../worker/types";
+import type { Article, FeedConfig } from "../../../worker/types";
 
 const FEEDS: FeedConfig[] = [
   {
@@ -184,5 +184,245 @@ describe("GET /api/articles/:id", () => {
     expect(res.status).toBe(200);
     const contentType = res.headers.get("Content-Type");
     expect(contentType).toMatch(/application\/json/);
+  });
+});
+
+describe("GET /api/articles/:guid/related", () => {
+  it("returns 404 for unknown guid", async () => {
+    const res = await SELF.fetch(
+      "https://example.com/api/articles/unknown-guid-does-not-exist/related",
+    );
+    expect(res.status).toBe(404);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toBe("not found");
+  });
+
+  it("returns 400 when n=0", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/o-ai-1/related?n=0");
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toBe("n must be 1-20");
+  });
+
+  it("returns 400 when n=21", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/o-ai-1/related?n=21");
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toBe("n must be 1-20");
+  });
+
+  it("returns same feed articles when enough exist", async () => {
+    // openai-blog に記事を追加して同 feed の記事を 5 件以上にする
+    const extraFeeds: FeedConfig[] = [
+      {
+        id: "openai-blog",
+        name: "OpenAI Blog",
+        url: "https://x.test/o",
+        category: "ai",
+        lang: "en",
+        enabled: true,
+      },
+    ];
+    await syncFeeds(env.DB, extraFeeds);
+    await insertArticles(env.DB, [
+      {
+        guid: "o-ai-3",
+        feed_id: "openai-blog",
+        title: "AI Article Three",
+        url: "https://x.test/o/3",
+        summary: null,
+        author: null,
+        published_at: "2024-04-04T00:00:00.000Z",
+        category: "ai",
+        lang: "en",
+      },
+      {
+        guid: "o-ai-4",
+        feed_id: "openai-blog",
+        title: "AI Article Four",
+        url: "https://x.test/o/4",
+        summary: null,
+        author: null,
+        published_at: "2024-04-05T00:00:00.000Z",
+        category: "ai",
+        lang: "en",
+      },
+      {
+        guid: "o-ai-5",
+        feed_id: "openai-blog",
+        title: "AI Article Five",
+        url: "https://x.test/o/5",
+        summary: null,
+        author: null,
+        published_at: "2024-04-06T00:00:00.000Z",
+        category: "ai",
+        lang: "en",
+      },
+      {
+        guid: "o-ai-6",
+        feed_id: "openai-blog",
+        title: "AI Article Six",
+        url: "https://x.test/o/6",
+        summary: null,
+        author: null,
+        published_at: "2024-04-07T00:00:00.000Z",
+        category: "ai",
+        lang: "en",
+      },
+    ]);
+
+    const res = await SELF.fetch("https://example.com/api/articles/o-ai-1/related?n=5");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ items: Article[] }>();
+    expect(body.items.length).toBe(5);
+    for (const item of body.items) {
+      expect(item.feed_id).toBe("openai-blog");
+    }
+  });
+
+  it("fills remaining slots with same category articles from other feeds", async () => {
+    // google-research に bigtech 記事を追加し、bigtech の別 feed を用意
+    const moreFeeds: FeedConfig[] = [
+      {
+        id: "meta-engineering",
+        name: "Meta Engineering",
+        url: "https://x.test/m",
+        category: "bigtech",
+        lang: "en",
+        enabled: true,
+      },
+    ];
+    await syncFeeds(env.DB, moreFeeds);
+    // google-research には既に g-bt-1 が入っている (beforeEach)
+    await insertArticles(env.DB, [
+      {
+        guid: "g-bt-2",
+        feed_id: "google-research",
+        title: "BigTech Article Two",
+        url: "https://x.test/g/2",
+        summary: null,
+        author: null,
+        published_at: "2024-04-02T00:00:00.000Z",
+        category: "bigtech",
+        lang: "en",
+      },
+      {
+        guid: "m-bt-1",
+        feed_id: "meta-engineering",
+        title: "Meta Article One",
+        url: "https://x.test/m/1",
+        summary: null,
+        author: null,
+        published_at: "2024-04-01T12:00:00.000Z",
+        category: "bigtech",
+        lang: "en",
+      },
+      {
+        guid: "m-bt-2",
+        feed_id: "meta-engineering",
+        title: "Meta Article Two",
+        url: "https://x.test/m/2",
+        summary: null,
+        author: null,
+        published_at: "2024-04-02T12:00:00.000Z",
+        category: "bigtech",
+        lang: "en",
+      },
+      {
+        guid: "m-bt-3",
+        feed_id: "meta-engineering",
+        title: "Meta Article Three",
+        url: "https://x.test/m/3",
+        summary: null,
+        author: null,
+        published_at: "2024-04-03T12:00:00.000Z",
+        category: "bigtech",
+        lang: "en",
+      },
+      {
+        guid: "m-bt-4",
+        feed_id: "meta-engineering",
+        title: "Meta Article Four",
+        url: "https://x.test/m/4",
+        summary: null,
+        author: null,
+        published_at: "2024-04-04T12:00:00.000Z",
+        category: "bigtech",
+        lang: "en",
+      },
+      {
+        guid: "m-bt-5",
+        feed_id: "meta-engineering",
+        title: "Meta Article Five",
+        url: "https://x.test/m/5",
+        summary: null,
+        author: null,
+        published_at: "2024-04-05T12:00:00.000Z",
+        category: "bigtech",
+        lang: "en",
+      },
+    ]);
+
+    // g-bt-1 の関連記事を n=5 で取得
+    // 同 feed (google-research) には g-bt-2 の 1 件、残り 4 件は meta-engineering から
+    const res = await SELF.fetch("https://example.com/api/articles/g-bt-1/related?n=5");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ items: Article[] }>();
+    expect(body.items.length).toBe(5);
+
+    // 先頭が同 feed
+    expect(body.items[0].feed_id).toBe("google-research");
+    // 残りは meta-engineering (同 category)
+    for (const item of body.items.slice(1)) {
+      expect(item.feed_id).toBe("meta-engineering");
+      expect(item.category).toBe("bigtech");
+    }
+  });
+
+  it("does not include the target article itself in items", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/o-ai-1/related");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ items: Article[] }>();
+    for (const item of body.items) {
+      expect(item.guid).not.toBe("o-ai-1");
+    }
+  });
+
+  it("returns items sorted by published_at desc within each segment", async () => {
+    // openai-blog に記事を追加して published_at の順序を確認
+    await insertArticles(env.DB, [
+      {
+        guid: "o-ai-3",
+        feed_id: "openai-blog",
+        title: "AI Article Three",
+        url: "https://x.test/o/3",
+        summary: null,
+        author: null,
+        published_at: "2024-04-04T00:00:00.000Z",
+        category: "ai",
+        lang: "en",
+      },
+    ]);
+
+    // o-ai-1 の関連: o-ai-3 (2024-04-04) → o-ai-2 (2024-04-03) の順
+    const res = await SELF.fetch("https://example.com/api/articles/o-ai-1/related?n=5");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ items: Article[] }>();
+    const sameFeed = body.items.filter((i) => i.feed_id === "openai-blog");
+    expect(sameFeed.length).toBeGreaterThanOrEqual(2);
+    expect(sameFeed[0].published_at >= sameFeed[1].published_at).toBe(true);
+  });
+
+  it("returns Content-Type application/json", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/o-ai-1/related");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toMatch(/application\/json/);
+  });
+
+  it("returns Cache-Control with max-age=300", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/o-ai-1/related");
+    expect(res.status).toBe(200);
+    const cc = res.headers.get("Cache-Control");
+    expect(cc).toContain("max-age=300");
   });
 });

--- a/apps/web/worker/api/articles.ts
+++ b/apps/web/worker/api/articles.ts
@@ -1,7 +1,12 @@
 import { Hono } from "hono";
 import type { Env, FeedCategory, FeedLang } from "../types";
 import { loadAllFeeds } from "../feed-config";
-import { getArticleById, getRandomArticles, listArticles } from "../db/articles";
+import {
+  getArticleById,
+  getRandomArticles,
+  getRelatedArticles,
+  listArticles,
+} from "../db/articles";
 import { computeArticlesEtag } from "../utils/etag";
 import feedsYaml from "../feeds.yaml";
 import type { FeedsFile } from "../types";
@@ -122,6 +127,17 @@ app.get("/random", async (c) => {
 
   const articles = await getRandomArticles(c.env.DB, { n, category, lang, feedId });
   return c.json({ articles }, 200, { "Cache-Control": "no-store" });
+});
+
+app.get("/:guid/related", async (c) => {
+  const guid = c.req.param("guid");
+  const nRaw = c.req.query("n") ?? "5";
+  const n = Number(nRaw);
+  if (!Number.isInteger(n) || n < 1 || n > 20) return c.json({ error: "n must be 1-20" }, 400);
+
+  const items = await getRelatedArticles(c.env.DB, guid, n);
+  if (items === null) return c.json({ error: "not found" }, 404);
+  return c.json({ items }, 200, { "Cache-Control": "public, max-age=300" });
 });
 
 app.get("/:id", async (c) => {

--- a/apps/web/worker/db/articles.ts
+++ b/apps/web/worker/db/articles.ts
@@ -203,6 +203,73 @@ export async function getArticleById(db: D1Database, id: number): Promise<Articl
   return result ?? null;
 }
 
+export async function findArticleByGuid(db: D1Database, guid: string): Promise<Article | null> {
+  const result = await db
+    .prepare(
+      `SELECT a.id, a.guid, a.feed_id, f.name AS feed_name, a.title, a.url, a.summary,
+              a.author, a.published_at, a.fetched_at, a.category, a.lang
+       FROM articles a
+       LEFT JOIN feeds f ON f.id = a.feed_id
+       WHERE a.guid = ?1
+       LIMIT 1`,
+    )
+    .bind(guid)
+    .first<Article>();
+  return result ?? null;
+}
+
+/**
+ * guid に対する関連記事を返す。
+ * 同 feed_id を優先し、不足分を同 category の記事で補う。
+ * guid が存在しない場合は null を返す (呼び出し側で 404 ハンドル)。
+ */
+export async function getRelatedArticles(
+  db: D1Database,
+  guid: string,
+  n: number,
+): Promise<Article[] | null> {
+  const target = await findArticleByGuid(db, guid);
+  if (!target) return null;
+
+  // 同じ feed_id の記事を published_at 降順で n 件取得 (対象自身除外)
+  const sameFeedRows = await db
+    .prepare(
+      `SELECT a.id, a.guid, a.feed_id, f.name AS feed_name, a.title, a.url, a.summary,
+              a.author, a.published_at, a.fetched_at, a.category, a.lang
+       FROM articles a
+       LEFT JOIN feeds f ON f.id = a.feed_id
+       WHERE a.feed_id = ?1 AND a.guid != ?2
+       ORDER BY a.published_at DESC
+       LIMIT ?3`,
+    )
+    .bind(target.feed_id, guid, n)
+    .all<Article>();
+
+  const sameFeedArticles = sameFeedRows.results ?? [];
+  const remaining = n - sameFeedArticles.length;
+
+  if (remaining <= 0) return sameFeedArticles;
+
+  // 不足分を同 category で補う (対象自身 + 同 feed 記事の guid を除外)
+  // feed が異なる記事のみ対象とすることで同 feed 重複を避ける
+  const excludeGuids = [guid, ...sameFeedArticles.map((a) => a.guid)];
+  const placeholders = excludeGuids.map((_, i) => `?${i + 3}`).join(",");
+  const sameCategoryRows = await db
+    .prepare(
+      `SELECT a.id, a.guid, a.feed_id, f.name AS feed_name, a.title, a.url, a.summary,
+              a.author, a.published_at, a.fetched_at, a.category, a.lang
+       FROM articles a
+       LEFT JOIN feeds f ON f.id = a.feed_id
+       WHERE a.category = ?1 AND a.feed_id != ?2 AND a.guid NOT IN (${placeholders})
+       ORDER BY a.published_at DESC
+       LIMIT ?${excludeGuids.length + 3}`,
+    )
+    .bind(target.category, target.feed_id, ...excludeGuids, remaining)
+    .all<Article>();
+
+  return [...sameFeedArticles, ...(sameCategoryRows.results ?? [])];
+}
+
 export async function countAllArticles(db: D1Database): Promise<number> {
   const row = await db.prepare(`SELECT COUNT(*) AS c FROM articles`).first<{ c: number }>();
   return row?.c ?? 0;


### PR DESCRIPTION
## Summary

- `GET /api/articles/:guid/related?n=5` エンドポイントを追加
- 同 `feed_id` の記事を優先 (published_at 降順)、不足分は同 `category` の別 feed 記事で補完
- `n` パラメータ: 1-20 の整数、範囲外は 400、デフォルト 5
- 対象 guid が存在しない場合は 404
- Cache-Control: `public, max-age=300`

## 変更ファイル

- `apps/web/worker/db/articles.ts`: `findArticleByGuid` / `getRelatedArticles` を追加
- `apps/web/worker/api/articles.ts`: `/:guid/related` ルートを `/:id` より前に登録
- `apps/web/tests/worker/api/articles.test.ts`: 8 テストケース追加

## Test plan

- [ ] 不明 guid で 404
- [ ] `?n=0` で 400
- [ ] `?n=21` で 400
- [ ] 同 feed の他記事 5 件で `?n=5` → 全部同 feed_id
- [ ] 同 feed 2 件 + 同 category 別 feed で `?n=5` → 先頭 1 件が同 feed、残り 4 件が category 補完
- [ ] 対象自身が items に含まれない
- [ ] published_at 降順
- [ ] Content-Type: application/json
- [ ] Cache-Control に max-age=300 含む

Closes #147

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint to retrieve related articles for a given article. Accepts pagination parameter (1–20 items per request). Intelligently populates results from the same source first, then supplements with articles from the same category if needed. Includes proper error handling and HTTP caching optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->