### PR TITLE
feat(client): SPA フィルタ状態を URL クエリに同期

### DIFF
--- a/apps/web/client/App.tsx
+++ b/apps/web/client/App.tsx
@@ -16,6 +16,7 @@ import { useReadState } from "./hooks/useReadState";
 import { useStarredState } from "./hooks/useStarredState";
 import { useStats } from "./hooks/useStats";
 import { ToastContext, useToastState } from "./hooks/useToast";
+import { useUrlState } from "./hooks/useUrlState";
 import type { FeedCategory, FeedLang } from "./types/api";
 
 function formatRelative(iso: string): string {
@@ -32,10 +33,7 @@ function formatRelative(iso: string): string {
 }
 
 function readFromUrl(): {
-  category: FeedCategory | "";
-  lang: FeedLang | "";
   feedId: string;
-  q: string;
   dateFrom: string;
   dateTo: string;
   unreadOnly: boolean;
@@ -43,10 +41,7 @@ function readFromUrl(): {
 } {
   const params = new URLSearchParams(window.location.search);
   return {
-    category: (params.get("category") as FeedCategory | null) ?? "",
-    lang: (params.get("lang") as FeedLang | null) ?? "",
     feedId: params.get("feed_id") ?? "",
-    q: params.get("q") ?? "",
     dateFrom: params.get("date_from") ?? "",
     dateTo: params.get("date_to") ?? "",
     unreadOnly: params.get("unread") === "1",
@@ -63,6 +58,7 @@ function buildSearch(
   dateTo: string,
   unreadOnly: boolean,
   starredOnly: boolean,
+  bookmarksOnly: boolean,
 ): string {
   const params = new URLSearchParams();
   if (category) params.set("category", category);
@@ -74,20 +70,19 @@ function buildSearch(
   // true のときだけ付ける
   if (unreadOnly) params.set("unread", "1");
   if (starredOnly) params.set("starred", "1");
+  if (bookmarksOnly) params.set("bookmarks", "only");
   const s = params.toString();
   return s ? `?${s}` : window.location.pathname;
 }
 
 function AppInner() {
-  const [category, setCategory] = useState<FeedCategory | "">(() => readFromUrl().category);
-  const [lang, setLang] = useState<FeedLang | "">(() => readFromUrl().lang);
+  const [urlFilters, setUrlFilters] = useUrlState();
+  const { q, category, lang, bookmarksOnly: bookmarkedOnly } = urlFilters;
   const [feedId, setFeedId] = useState<string>(() => readFromUrl().feedId);
-  const [q, setQ] = useState<string>(() => readFromUrl().q);
   const [dateFrom, setDateFrom] = useState<string>(() => readFromUrl().dateFrom);
   const [dateTo, setDateTo] = useState<string>(() => readFromUrl().dateTo);
   const [unreadOnly, setUnreadOnly] = useState<boolean>(() => readFromUrl().unreadOnly);
   const [starredOnly, setStarredOnly] = useState<boolean>(() => readFromUrl().starredOnly);
-  const [bookmarkedOnly, setBookmarkedOnly] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(-1);
   const [helpOpen, setHelpOpen] = useState(false);
 
@@ -100,14 +95,12 @@ function AppInner() {
   const { bookmarks, toggle: toggleBookmark } = useBookmarks();
   const { presets, addPreset, removePreset } = usePresets();
 
-  // popstate でブラウザ戻る/進むに追従する
+  // popstate でブラウザ戻る/進むに追従する (useUrlState が q/category/lang/bookmarksOnly を処理、
+  // feedId/dateFrom/dateTo/unreadOnly/starredOnly はこちらで処理)
   useEffect(() => {
     const onPop = () => {
       const next = readFromUrl();
-      setCategory(next.category);
-      setLang(next.lang);
       setFeedId(next.feedId);
-      setQ(next.q);
       setDateFrom(next.dateFrom);
       setDateTo(next.dateTo);
       setUnreadOnly(next.unreadOnly);
@@ -118,6 +111,8 @@ function AppInner() {
   }, []);
 
   // フィルタ変更時は pushState で履歴に積む
+  // useUrlState が q/category/lang/bookmarksOnly の URL 同期を担うため、
+  // pushState 後に popstate を dispatch して useUrlState のキャッシュを更新する
   const pushFilter = useCallback(
     (
       nextCategory: FeedCategory | "",
@@ -138,6 +133,7 @@ function AppInner() {
         nextDateTo,
         nextUnreadOnly,
         nextStarredOnly,
+        bookmarkedOnly,
       );
       const current = buildSearch(
         category,
@@ -148,21 +144,20 @@ function AppInner() {
         dateTo,
         unreadOnly,
         starredOnly,
+        bookmarkedOnly,
       );
-      // 同じ URL なら重複履歴を作らない
       if (next !== current) {
         window.history.pushState(null, "", next);
+        // useUrlState の subscribe リスナー (popstate) を起動してキャッシュを無効化する
+        window.dispatchEvent(new PopStateEvent("popstate"));
       }
-      setCategory(nextCategory);
-      setLang(nextLang);
       setFeedId(nextFeedId);
-      setQ(nextQ);
       setDateFrom(nextDateFrom);
       setDateTo(nextDateTo);
       setUnreadOnly(nextUnreadOnly);
       setStarredOnly(nextStarredOnly);
     },
-    [category, lang, feedId, q, dateFrom, dateTo, unreadOnly, starredOnly],
+    [category, lang, feedId, q, dateFrom, dateTo, unreadOnly, starredOnly, bookmarkedOnly],
   );
 
   const handleCategoryChange = useCallback(
@@ -182,10 +177,7 @@ function AppInner() {
     [pushFilter, category, lang, q, dateFrom, dateTo, unreadOnly, starredOnly],
   );
 
-  const handleQChange = useCallback(
-    (v: string) => pushFilter(category, lang, feedId, v, dateFrom, dateTo, unreadOnly, starredOnly),
-    [pushFilter, category, lang, feedId, dateFrom, dateTo, unreadOnly, starredOnly],
-  );
+  const handleQChange = useCallback((v: string) => setUrlFilters({ q: v }), [setUrlFilters]);
 
   const handleDateFromChange = useCallback(
     (v: string) => pushFilter(category, lang, feedId, q, v, dateTo, unreadOnly, starredOnly),
@@ -208,8 +200,8 @@ function AppInner() {
   );
 
   const handleClear = useCallback(
-    () => pushFilter("", "", "", q, "", "", false, false),
-    [pushFilter, q],
+    () => pushFilter("", "", "", "", "", "", false, false),
+    [pushFilter],
   );
 
   const handleApplyPreset = useCallback(
@@ -236,6 +228,10 @@ function AppInner() {
     },
     [pushFilter],
   );
+
+  const handleBookmarkedOnlyToggle = useCallback(() => {
+    setUrlFilters({ bookmarksOnly: !bookmarkedOnly });
+  }, [setUrlFilters, bookmarkedOnly]);
 
   // カード上のバッジ/取得元クリックでフィルタを適用する
   const handleFilterByCategory = useCallback(
@@ -344,7 +340,7 @@ function AppInner() {
         <button
           type="button"
           className={`bookmarks-only-toggle${bookmarkedOnly ? " active" : ""}`}
-          onClick={() => setBookmarkedOnly((prev) => !prev)}
+          onClick={handleBookmarkedOnlyToggle}
           aria-pressed={bookmarkedOnly}
         >
           ★ {bookmarks.size} 件{bookmarkedOnly ? " (表示中)" : ""}

--- a/apps/web/client/hooks/useUrlState.ts
+++ b/apps/web/client/hooks/useUrlState.ts
@@ -1,0 +1,130 @@
+import { useCallback, useRef, useSyncExternalStore } from "react";
+import type { FeedCategory, FeedLang } from "../types/api";
+
+export type FilterState = {
+  q: string;
+  category: FeedCategory | "";
+  lang: FeedLang | "";
+  bookmarksOnly: boolean;
+};
+
+const VALID_CATEGORIES = new Set<string>(["bigtech", "ai", "jp", "zenn"]);
+const VALID_LANGS = new Set<string>(["ja", "en"]);
+
+const DEFAULT_STATE: FilterState = {
+  q: "",
+  category: "",
+  lang: "",
+  bookmarksOnly: false,
+};
+
+// parse はテストから直接使えるように export する
+export function parseSearch(search: string): FilterState {
+  const params = new URLSearchParams(search);
+  const category = params.get("category") ?? "";
+  const lang = params.get("lang") ?? "";
+  return {
+    q: params.get("q") ?? "",
+    category: VALID_CATEGORIES.has(category) ? (category as FeedCategory) : "",
+    lang: VALID_LANGS.has(lang) ? (lang as FeedLang) : "",
+    bookmarksOnly: params.get("bookmarks") === "only",
+  };
+}
+
+// 現在の URL の全パラメータを保持しつつ、管理対象の 4 つだけを上書きする
+export function serializeState(state: FilterState): string {
+  // 既存の URL パラメータ (feedId, dateFrom, etc.) を引き継ぐ
+  const params = new URLSearchParams(window.location.search);
+  if (state.q) {
+    params.set("q", state.q);
+  } else {
+    params.delete("q");
+  }
+  if (state.category) {
+    params.set("category", state.category);
+  } else {
+    params.delete("category");
+  }
+  if (state.lang) {
+    params.set("lang", state.lang);
+  } else {
+    params.delete("lang");
+  }
+  if (state.bookmarksOnly) {
+    params.set("bookmarks", "only");
+  } else {
+    params.delete("bookmarks");
+  }
+  const s = params.toString();
+  return s ? `?${s}` : window.location.pathname;
+}
+
+// useSyncExternalStore の getSnapshot は参照同一性を要求するため
+// search 文字列をキャッシュキーにして同一内容なら同じオブジェクト参照を返す
+let cachedSearch: string | null = null;
+let cachedState: FilterState = { ...DEFAULT_STATE };
+
+function getSnapshot(): FilterState {
+  const search = window.location.search;
+  if (search === cachedSearch) return cachedState;
+  cachedSearch = search;
+  cachedState = parseSearch(search);
+  return cachedState;
+}
+
+function getServerSnapshot(): FilterState {
+  return DEFAULT_STATE;
+}
+
+type Listener = () => void;
+const listeners = new Set<Listener>();
+
+function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  window.addEventListener("popstate", listener);
+  return () => {
+    listeners.delete(listener);
+    window.removeEventListener("popstate", listener);
+  };
+}
+
+function notify(): void {
+  for (const l of listeners) l();
+}
+
+const DEBOUNCE_MS = 300;
+
+export function useUrlState(): readonly [FilterState, (patch: Partial<FilterState>) => void] {
+  const state = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+  // debounce タイマーの ref
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // debounce 中に積み上げる patch をマージして保持する ref
+  const pendingRef = useRef<Partial<FilterState>>({});
+
+  const setFilters = useCallback((patch: Partial<FilterState>) => {
+    // 新しい patch を pending にマージ
+    pendingRef.current = { ...pendingRef.current, ...patch };
+
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+    }
+
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      const current = getSnapshot();
+      const next: FilterState = { ...current, ...pendingRef.current };
+      pendingRef.current = {};
+      const newSearch = serializeState(next);
+      const currentSearch = window.location.search || window.location.pathname;
+      // 内容が変わった時だけ replaceState を呼ぶ
+      if (newSearch !== currentSearch) {
+        window.history.replaceState(null, "", newSearch);
+      }
+      // キャッシュを無効化して再 subscribe
+      cachedSearch = null;
+      notify();
+    }, DEBOUNCE_MS);
+  }, []);
+
+  return [state, setFilters] as const;
+}

--- a/apps/web/tests/client/useUrlState.test.tsx
+++ b/apps/web/tests/client/useUrlState.test.tsx
@@ -1,0 +1,199 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+// useUrlState は useSyncExternalStore + window.location を使うため
+// テスト間で window.location.search と内部キャッシュを隔離する
+const { useUrlState, parseSearch } = await import("../../client/hooks/useUrlState");
+
+describe("parseSearch", () => {
+  it("parses q and category from search string", () => {
+    const state = parseSearch("?q=react&category=ai");
+    expect(state).toEqual({ q: "react", category: "ai", lang: "", bookmarksOnly: false });
+  });
+
+  it("returns empty defaults for empty search", () => {
+    expect(parseSearch("")).toEqual({ q: "", category: "", lang: "", bookmarksOnly: false });
+  });
+
+  it("returns empty category for invalid value", () => {
+    const state = parseSearch("?category=foo");
+    expect(state.category).toBe("");
+  });
+
+  it("returns empty lang for invalid value", () => {
+    const state = parseSearch("?lang=xx");
+    expect(state.lang).toBe("");
+  });
+
+  it("sets bookmarksOnly true when bookmarks=only", () => {
+    const state = parseSearch("?bookmarks=only");
+    expect(state.bookmarksOnly).toBe(true);
+  });
+
+  it("sets bookmarksOnly false when bookmarks has other value", () => {
+    const state = parseSearch("?bookmarks=1");
+    expect(state.bookmarksOnly).toBe(false);
+  });
+});
+
+describe("useUrlState", () => {
+  beforeEach(() => {
+    // window.location.search をリセットする
+    window.history.replaceState(null, "", "/");
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    window.history.replaceState(null, "", "/");
+  });
+
+  it("初期 URL ?q=react&category=ai で hook が正しい state を返す", () => {
+    window.history.replaceState(null, "", "/?q=react&category=ai");
+    const { result } = renderHook(() => useUrlState());
+    expect(result.current[0]).toEqual({
+      q: "react",
+      category: "ai",
+      lang: "",
+      bookmarksOnly: false,
+    });
+  });
+
+  it("setFilters({ category: 'jp' }) で URL に category=jp が反映される", () => {
+    window.history.replaceState(null, "", "/");
+    const { result } = renderHook(() => useUrlState());
+
+    act(() => {
+      result.current[1]({ category: "jp" });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(window.location.search).toContain("category=jp");
+    expect(result.current[0].category).toBe("jp");
+  });
+
+  it("setFilters({ category: '' }) で URL から category が消える", () => {
+    window.history.replaceState(null, "", "/?category=ai");
+    const { result } = renderHook(() => useUrlState());
+
+    act(() => {
+      result.current[1]({ category: "" });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(window.location.search).not.toContain("category");
+    expect(result.current[0].category).toBe("");
+  });
+
+  it("bookmarksOnly: true で URL に bookmarks=only が付く", () => {
+    window.history.replaceState(null, "", "/");
+    const { result } = renderHook(() => useUrlState());
+
+    act(() => {
+      result.current[1]({ bookmarksOnly: true });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(window.location.search).toContain("bookmarks=only");
+    expect(result.current[0].bookmarksOnly).toBe(true);
+  });
+
+  it("bookmarksOnly: false で URL から bookmarks が消える", () => {
+    window.history.replaceState(null, "", "/?bookmarks=only");
+    const { result } = renderHook(() => useUrlState());
+    expect(result.current[0].bookmarksOnly).toBe(true);
+
+    act(() => {
+      result.current[1]({ bookmarksOnly: false });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(window.location.search).not.toContain("bookmarks");
+    expect(result.current[0].bookmarksOnly).toBe(false);
+  });
+
+  it("popstate dispatch で state が更新される", () => {
+    window.history.replaceState(null, "", "/");
+    const { result } = renderHook(() => useUrlState());
+    expect(result.current[0].category).toBe("");
+
+    act(() => {
+      window.history.replaceState(null, "", "/?category=zenn");
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+
+    expect(result.current[0].category).toBe("zenn");
+  });
+
+  it("debounce: 連続 setFilters の URL 更新は 300ms 後の最後の値になる", () => {
+    window.history.replaceState(null, "", "/");
+    const { result } = renderHook(() => useUrlState());
+
+    act(() => {
+      result.current[1]({ q: "a" });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    // 100ms 経過後、まだ URL は更新されていない
+    expect(window.location.search).not.toContain("q=");
+
+    act(() => {
+      result.current[1]({ q: "ab" });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    // debounce が解消されて最後の値 "ab" が URL に反映される
+    expect(window.location.search).toContain("q=ab");
+    expect(result.current[0].q).toBe("ab");
+  });
+
+  it("不正な category 値は '' にフォールバックする", () => {
+    window.history.replaceState(null, "", "/?category=invalid_value");
+    const { result } = renderHook(() => useUrlState());
+    expect(result.current[0].category).toBe("");
+  });
+
+  it("すべてデフォルト値の場合は URL に query string が付かない", () => {
+    window.history.replaceState(null, "", "/");
+    const { result } = renderHook(() => useUrlState());
+
+    act(() => {
+      result.current[1]({ q: "test" });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(window.location.search).toContain("q=test");
+
+    act(() => {
+      result.current[1]({ q: "" });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    // すべてデフォルト → query string なし
+    expect(window.location.search).toBe("");
+  });
+});


### PR DESCRIPTION
Closes #145

## Summary

- useUrlState hook を新規実装: useSyncExternalStore + popstate イベントで URL query string と双方向同期
- q, category, lang, bookmarksOnly の 4 つのフィルタを URL に持続化
- debounce 300ms で検索 typing 中の高頻度 history.replaceState を抑制
- 不正な category/lang 値は '' にフォールバック
- bookmarksOnly: true で ?bookmarks=only、false で省略
- App.tsx でこれら 4 フィールドを useUrlState に移行

## Test plan

- [x] pnpm build pass
- [x] client tests pass (15 件の useUrlState テスト含む)
- [x] vp lint pass
- [x] vp fmt --check pass
- [x] pnpm -r typecheck pass