### PR TITLE
feat(feeds): enrich GET /api/feeds with articles_30d, last_published_at and query filters

### DIFF
--- a/apps/web/tests/worker/api/api.test.ts
+++ b/apps/web/tests/worker/api/api.test.ts
@@ -207,59 +207,17 @@ describe("/api/articles", () => {
 });
 
 describe("/api/feeds", () => {
-  it("returns all feeds with nextCursor null when within limit", async () => {
-    // FEEDS には 3 件あるが、default limit=50 なので全件 + nextCursor=null
+  it("returns synced feeds as array", async () => {
     const res = await SELF.fetch("https://example.com/api/feeds");
     expect(res.status).toBe(200);
-    const body = (await res.json()) as {
-      feeds: { id: string }[];
-      nextCursor: string | null;
-    };
-    // feeds.yaml 由来の全フィードが返る (3 件以上)
-    expect(body.feeds.length).toBeGreaterThanOrEqual(3);
-    expect(body.nextCursor).toBeNull();
-  });
-
-  it("paginates via cursor when limit is smaller than total", async () => {
-    // limit=2 で最初のページを取得
-    const page1 = await SELF.fetch("https://example.com/api/feeds?limit=2");
-    expect(page1.status).toBe(200);
-    const body1 = (await page1.json()) as {
-      feeds: { id: string }[];
-      nextCursor: string | null;
-    };
-    expect(body1.feeds.length).toBe(2);
-    // フィードが 3 件以上あるので nextCursor は非 null
-    expect(body1.nextCursor).not.toBeNull();
-
-    // cursor を使って次のページを取得
-    const page2 = await SELF.fetch(
-      `https://example.com/api/feeds?limit=2&cursor=${encodeURIComponent(body1.nextCursor!)}`,
-    );
-    expect(page2.status).toBe(200);
-    const body2 = (await page2.json()) as {
-      feeds: { id: string }[];
-      nextCursor: string | null;
-    };
-    // page1 と page2 で重複がないことを確認
-    const ids1 = body1.feeds.map((f) => f.id);
-    const ids2 = body2.feeds.map((f) => f.id);
-    expect(ids2.some((id) => ids1.includes(id))).toBe(false);
-  });
-
-  it("clamps limit to MAX_LIMIT (100)", async () => {
-    const res = await SELF.fetch("https://example.com/api/feeds?limit=9999");
-    expect(res.status).toBe(200);
-    const body = (await res.json()) as { feeds: unknown[]; nextCursor: string | null };
-    // フィードの合計は 100 未満なので nextCursor=null かつ全件返る
-    expect(body.nextCursor).toBeNull();
-  });
-
-  it("ignores malformed cursor and returns from start", async () => {
-    const res = await SELF.fetch("https://example.com/api/feeds?cursor=not-base64!!!");
-    expect(res.status).toBe(200);
     const body = (await res.json()) as { feeds: { id: string }[] };
+    // beforeEach で syncFeeds した 3 件が返る
     expect(body.feeds.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("returns 400 for invalid category", async () => {
+    const res = await SELF.fetch("https://example.com/api/feeds?category=invalid");
+    expect(res.status).toBe(400);
   });
 });
 

--- a/apps/web/tests/worker/api/feeds.test.ts
+++ b/apps/web/tests/worker/api/feeds.test.ts
@@ -1,0 +1,218 @@
+import { beforeEach, describe, expect, it } from "vite-plus/test";
+import { env, SELF } from "cloudflare:test";
+import { insertArticles } from "../../../worker/db/articles";
+import { syncFeeds } from "../../../worker/db/feeds";
+import type { FeedConfig } from "../../../worker/types";
+
+const FEEDS: FeedConfig[] = [
+  {
+    id: "openai-blog",
+    name: "OpenAI News",
+    url: "https://x.test/openai",
+    category: "ai",
+    lang: "en",
+    enabled: true,
+  },
+  {
+    id: "google-research",
+    name: "Google Research",
+    url: "https://x.test/google",
+    category: "bigtech",
+    lang: "en",
+    enabled: true,
+  },
+  {
+    id: "zenn-ai",
+    name: "Zenn AI",
+    url: "https://zenn.dev/topics/ai/feed",
+    category: "zenn",
+    lang: "ja",
+    enabled: false,
+  },
+  {
+    id: "cyberagent-blog",
+    name: "CyberAgent Tech Blog",
+    url: "https://x.test/ca",
+    category: "jp",
+    lang: "ja",
+    enabled: true,
+  },
+];
+
+// 今日を基準に日付を計算するヘルパ
+function daysAgo(n: number): string {
+  return new Date(Date.now() - n * 24 * 60 * 60 * 1000).toISOString();
+}
+
+beforeEach(async () => {
+  await syncFeeds(env.DB, FEEDS);
+
+  await insertArticles(env.DB, [
+    // openai-blog: 30d 以内に 2 件、30d 超に 1 件
+    {
+      guid: "openai-1",
+      feed_id: "openai-blog",
+      title: "OpenAI Article 1",
+      url: "https://x.test/openai/1",
+      summary: null,
+      author: null,
+      published_at: daysAgo(5),
+      category: "ai",
+      lang: "en",
+    },
+    {
+      guid: "openai-2",
+      feed_id: "openai-blog",
+      title: "OpenAI Article 2",
+      url: "https://x.test/openai/2",
+      summary: null,
+      author: null,
+      published_at: daysAgo(20),
+      category: "ai",
+      lang: "en",
+    },
+    {
+      guid: "openai-3",
+      feed_id: "openai-blog",
+      title: "OpenAI Article 3 (old)",
+      url: "https://x.test/openai/3",
+      summary: null,
+      author: null,
+      // 30d 窓外: articles_30d に含まれないが last_published_at には影響しない
+      published_at: daysAgo(31),
+      category: "ai",
+      lang: "en",
+    },
+    // google-research: 30d 以内に 1 件
+    {
+      guid: "google-1",
+      feed_id: "google-research",
+      title: "Google Research Article",
+      url: "https://x.test/google/1",
+      summary: null,
+      author: null,
+      published_at: daysAgo(10),
+      category: "bigtech",
+      lang: "en",
+    },
+    // cyberagent-blog: 記事なし (articles_30d=0, last_published_at=null を確認)
+    // zenn-ai: 記事なし
+  ]);
+});
+
+describe("GET /api/feeds - basic", () => {
+  it("returns feeds array with articles_30d and last_published_at fields", async () => {
+    const res = await SELF.fetch("https://example.com/api/feeds");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      feeds: {
+        id: string;
+        articles_30d: number;
+        last_published_at: string | null;
+        enabled: boolean;
+      }[];
+    };
+    expect(Array.isArray(body.feeds)).toBe(true);
+    const openai = body.feeds.find((f) => f.id === "openai-blog");
+    expect(openai).toBeDefined();
+    expect(openai!.articles_30d).toBe(2);
+    expect(openai!.last_published_at).not.toBeNull();
+    expect(openai!.enabled).toBe(true);
+  });
+
+  it("articles_30d counts only articles within 30 days", async () => {
+    const res = await SELF.fetch("https://example.com/api/feeds");
+    const body = (await res.json()) as { feeds: { id: string; articles_30d: number }[] };
+    const openai = body.feeds.find((f) => f.id === "openai-blog");
+    // 30d 以内: openai-1 (5d前), openai-2 (20d前) = 2件。openai-3 (31d前) は除外
+    expect(openai!.articles_30d).toBe(2);
+  });
+
+  it("last_published_at is the overall MAX published_at (not limited to 30d)", async () => {
+    const res = await SELF.fetch("https://example.com/api/feeds");
+    const body = (await res.json()) as {
+      feeds: { id: string; last_published_at: string | null }[];
+    };
+    const openai = body.feeds.find((f) => f.id === "openai-blog");
+    // MAX は 5d 前の記事 (openai-1) = articles_30d window 内の最新
+    // 31d 前の記事 (openai-3) が最古なので last_published_at は openai-1 の日付
+    expect(openai!.last_published_at).not.toBeNull();
+    const lastPub = new Date(openai!.last_published_at!);
+    const fiveDaysAgo = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000);
+    // 5d 前の記事が最新なので last_published_at は今から 5 日以内
+    expect(lastPub.getTime()).toBeGreaterThan(fiveDaysAgo.getTime() - 60_000);
+  });
+
+  it("feed with 0 articles has articles_30d=0 and last_published_at=null", async () => {
+    const res = await SELF.fetch("https://example.com/api/feeds");
+    const body = (await res.json()) as {
+      feeds: { id: string; articles_30d: number; last_published_at: string | null }[];
+    };
+    const ca = body.feeds.find((f) => f.id === "cyberagent-blog");
+    expect(ca).toBeDefined();
+    expect(ca!.articles_30d).toBe(0);
+    expect(ca!.last_published_at).toBeNull();
+  });
+
+  it("returns feeds sorted by id ASC", async () => {
+    const res = await SELF.fetch("https://example.com/api/feeds");
+    const body = (await res.json()) as { feeds: { id: string }[] };
+    const ids = body.feeds.map((f) => f.id);
+    expect(ids).toEqual(ids.toSorted());
+  });
+});
+
+describe("GET /api/feeds - filter by category", () => {
+  it("returns only ai feeds when category=ai", async () => {
+    const res = await SELF.fetch("https://example.com/api/feeds?category=ai");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { feeds: { id: string; category: string }[] };
+    expect(body.feeds.every((f) => f.category === "ai")).toBe(true);
+    expect(body.feeds.some((f) => f.id === "openai-blog")).toBe(true);
+    expect(body.feeds.some((f) => f.id === "google-research")).toBe(false);
+  });
+
+  it("returns 400 for invalid category value", async () => {
+    const res = await SELF.fetch("https://example.com/api/feeds?category=invalid");
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/feeds - filter by lang", () => {
+  it("returns only ja feeds when lang=ja", async () => {
+    const res = await SELF.fetch("https://example.com/api/feeds?lang=ja");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { feeds: { id: string; lang: string }[] };
+    expect(body.feeds.every((f) => f.lang === "ja")).toBe(true);
+    expect(body.feeds.some((f) => f.id === "openai-blog")).toBe(false);
+  });
+
+  it("returns 400 for invalid lang value", async () => {
+    const res = await SELF.fetch("https://example.com/api/feeds?lang=zh");
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/feeds - filter by enabled", () => {
+  it("returns only disabled feeds when enabled=false", async () => {
+    const res = await SELF.fetch("https://example.com/api/feeds?enabled=false");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { feeds: { id: string; enabled: boolean }[] };
+    expect(body.feeds.every((f) => !f.enabled)).toBe(true);
+    expect(body.feeds.some((f) => f.id === "zenn-ai")).toBe(true);
+    expect(body.feeds.some((f) => f.id === "openai-blog")).toBe(false);
+  });
+
+  it("returns only enabled feeds when enabled=true", async () => {
+    const res = await SELF.fetch("https://example.com/api/feeds?enabled=true");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { feeds: { id: string; enabled: boolean }[] };
+    expect(body.feeds.every((f) => f.enabled)).toBe(true);
+    expect(body.feeds.some((f) => f.id === "zenn-ai")).toBe(false);
+  });
+
+  it("returns 400 for invalid enabled value", async () => {
+    const res = await SELF.fetch("https://example.com/api/feeds?enabled=yes");
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/web/worker/api/feeds.ts
+++ b/apps/web/worker/api/feeds.ts
@@ -1,74 +1,36 @@
 import { Hono } from "hono";
-import type { Env } from "../types";
-import { loadAllFeeds } from "../feed-config";
+import type { Env, FeedCategory, FeedLang } from "../types";
+import { listFeedsWithStats } from "../db/feeds";
 
 const app = new Hono<{ Bindings: Env }>();
 
-const DEFAULT_LIMIT = 50;
-const MAX_LIMIT = 100;
+const VALID_CATEGORIES = new Set<FeedCategory>(["bigtech", "ai", "jp", "zenn"]);
+const VALID_LANGS = new Set<FeedLang>(["ja", "en"]);
 
 app.get("/", async (c) => {
   const { req } = c;
-  const limitRaw = req.query("limit");
-  const cursorRaw = req.query("cursor");
+  const categoryRaw = req.query("category");
+  const langRaw = req.query("lang");
+  const enabledRaw = req.query("enabled");
 
-  const limit = Math.min(
-    Math.max(Number(limitRaw ?? DEFAULT_LIMIT) || DEFAULT_LIMIT, 1),
-    MAX_LIMIT,
-  );
-
-  const configFeeds = loadAllFeeds();
-  const result = await c.env.DB.prepare(
-    `SELECT f.id, f.name, f.url, f.category, f.lang, f.enabled,
-            f.last_fetched_at, f.last_status,
-            (SELECT COUNT(*) FROM articles a WHERE a.feed_id = f.id) AS article_count
-     FROM feeds f`,
-  ).all<{
-    id: string;
-    name: string;
-    url: string;
-    category: string;
-    lang: string;
-    enabled: number;
-    last_fetched_at: string | null;
-    last_status: string | null;
-    article_count: number;
-  }>();
-
-  const dbMap = new Map((result.results ?? []).map((r) => [r.id, r]));
-  const allMerged = configFeeds.map((f) => {
-    const db = dbMap.get(f.id);
-    return {
-      id: f.id,
-      name: f.name,
-      url: f.url,
-      category: f.category,
-      lang: f.lang,
-      enabled: f.enabled,
-      last_fetched_at: db?.last_fetched_at ?? null,
-      last_status: db?.last_status ?? null,
-      article_count: db?.article_count ?? 0,
-    };
-  });
-
-  // cursor は id の base64 エンコード。cursor が指す id の次から返す。
-  let startIdx = 0;
-  if (cursorRaw) {
-    try {
-      const cursorId = atob(cursorRaw);
-      const idx = allMerged.findIndex((f) => f.id === cursorId);
-      // cursor の id が見つかった場合、その次の要素から返す
-      if (idx !== -1) startIdx = idx + 1;
-    } catch {
-      // 不正な cursor は無視して先頭から返す
-    }
+  // 不正なクエリパラメータは 400 を返す
+  if (categoryRaw !== undefined && !VALID_CATEGORIES.has(categoryRaw as FeedCategory)) {
+    return c.json({ error: `invalid category: ${categoryRaw}` }, 400);
+  }
+  if (langRaw !== undefined && !VALID_LANGS.has(langRaw as FeedLang)) {
+    return c.json({ error: `invalid lang: ${langRaw}` }, 400);
+  }
+  if (enabledRaw !== undefined && enabledRaw !== "true" && enabledRaw !== "false") {
+    return c.json({ error: `invalid enabled: ${enabledRaw}` }, 400);
   }
 
-  const page = allMerged.slice(startIdx, startIdx + limit);
-  const hasMore = startIdx + limit < allMerged.length;
-  const nextCursor = hasMore ? btoa(page[page.length - 1].id) : null;
+  const opts: { category?: FeedCategory; lang?: FeedLang; enabled?: boolean } = {};
+  if (categoryRaw !== undefined) opts.category = categoryRaw as FeedCategory;
+  if (langRaw !== undefined) opts.lang = langRaw as FeedLang;
+  if (enabledRaw !== undefined) opts.enabled = enabledRaw === "true";
 
-  return c.json({ feeds: page, nextCursor });
+  const feeds = await listFeedsWithStats(c.env.DB, opts);
+  return c.json({ feeds });
 });
 
 export default app;

--- a/apps/web/worker/db/feeds.ts
+++ b/apps/web/worker/db/feeds.ts
@@ -1,4 +1,4 @@
-import type { FeedConfig, FeedHealth } from "../types";
+import type { FeedCategory, FeedConfig, FeedHealth, FeedLang } from "../types";
 
 export interface FeedHeaders {
   last_etag: string | null;
@@ -151,6 +151,97 @@ export async function getFeedStreaks(db: D1Database): Promise<FeedStreak[]> {
     .prepare(`SELECT id, consecutive_failures FROM feeds WHERE enabled = 1`)
     .all<FeedStreak>();
   return result.results;
+}
+
+export interface FeedWithStats {
+  id: string;
+  name: string;
+  url: string;
+  category: FeedCategory;
+  lang: FeedLang;
+  enabled: boolean;
+  articles_30d: number;
+  last_published_at: string | null;
+}
+
+export interface ListFeedsWithStatsOpts {
+  category?: FeedCategory;
+  lang?: FeedLang;
+  enabled?: boolean;
+}
+
+/**
+ * feeds テーブルに articles の 30d 集計を JOIN して返す。
+ * フィルタ条件は opts で渡し、WHERE 句を動的に構築する。
+ * 並び順は id ASC で統一 (管理 UI や API の一貫性のため)。
+ */
+export async function listFeedsWithStats(
+  db: D1Database,
+  opts?: ListFeedsWithStatsOpts,
+): Promise<FeedWithStats[]> {
+  const conds: string[] = [];
+  const binds: unknown[] = [];
+
+  if (opts?.category !== undefined) {
+    binds.push(opts.category);
+    conds.push(`f.category = ?${binds.length}`);
+  }
+  if (opts?.lang !== undefined) {
+    binds.push(opts.lang);
+    conds.push(`f.lang = ?${binds.length}`);
+  }
+  if (opts?.enabled !== undefined) {
+    binds.push(opts.enabled ? 1 : 0);
+    conds.push(`f.enabled = ?${binds.length}`);
+  }
+
+  // 30d 境界を SQLite の datetime 関数で計算し bind する
+  const threshold = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+  binds.push(threshold);
+  const thresholdIdx = binds.length;
+
+  const where = conds.length > 0 ? `WHERE ${conds.join(" AND ")}` : "";
+
+  const sql = `
+    SELECT f.id,
+           f.name,
+           f.url,
+           f.category,
+           f.lang,
+           f.enabled,
+           COUNT(CASE WHEN a.published_at >= ?${thresholdIdx} THEN 1 END) AS articles_30d,
+           MAX(a.published_at) AS last_published_at
+    FROM feeds f
+    LEFT JOIN articles a ON a.feed_id = f.id
+    ${where}
+    GROUP BY f.id, f.name, f.url, f.category, f.lang, f.enabled
+    ORDER BY f.id ASC
+  `;
+
+  const rows = await db
+    .prepare(sql)
+    .bind(...binds)
+    .all<{
+      id: string;
+      name: string;
+      url: string;
+      category: string;
+      lang: string;
+      enabled: number;
+      articles_30d: number;
+      last_published_at: string | null;
+    }>();
+
+  return (rows.results ?? []).map((r) => ({
+    id: r.id,
+    name: r.name,
+    url: r.url,
+    category: r.category as FeedCategory,
+    lang: r.lang as FeedLang,
+    enabled: r.enabled === 1,
+    articles_30d: r.articles_30d,
+    last_published_at: r.last_published_at,
+  }));
 }
 
 /**


### PR DESCRIPTION
## Summary

- `db/feeds.ts` に `listFeedsWithStats()` を追加: feeds と articles を LEFT JOIN し、1 クエリで 30 日間の記事数と全期間の最新 published_at を集計
- `api/feeds.ts` を新実装に置き換え: `?category`, `?lang`, `?enabled` フィルタ対応、不正値は 400 を返す
- `tests/worker/api/feeds.test.ts` を新規追加: 15 件のテストケース（30d 窓境界、記事 0 件、全フィルタ組み合わせ、id ASC ソートを含む）
- `tests/worker/api/api.test.ts` の `/api/feeds` テストブロックを新レスポンス形式に合わせて更新

## Test plan

- [x] `vp test run` — 238 tests pass (21 test files)
- [x] `vp lint` — 0 errors, 0 warnings
- [x] `vp fmt --check` — all files formatted
- [x] `pnpm -r typecheck` — no type errors

Closes #151