### PR TITLE
feat(api): add GET /api/feeds/:id with recent articles

### DIFF
--- a/apps/web/tests/worker/api/feeds.test.ts
+++ b/apps/web/tests/worker/api/feeds.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it } from "vite-plus/test";
 import { env, SELF } from "cloudflare:test";
 import { insertArticles } from "../../../worker/db/articles";
 import { syncFeeds } from "../../../worker/db/feeds";
-import type { FeedConfig } from "../../../worker/types";
+import type { Article, FeedConfig } from "../../../worker/types";
 
 const FEEDS: FeedConfig[] = [
   {
@@ -214,5 +214,128 @@ describe("GET /api/feeds - filter by enabled", () => {
   it("returns 400 for invalid enabled value", async () => {
     const res = await SELF.fetch("https://example.com/api/feeds?enabled=yes");
     expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/feeds/:id", () => {
+  // 11 件挿入して default 10 件上限のテストに使う
+  beforeEach(async () => {
+    await insertArticles(
+      env.DB,
+      Array.from({ length: 9 }, (_, i) => ({
+        guid: `openai-extra-${i + 1}`,
+        feed_id: "openai-blog",
+        title: `OpenAI Extra ${i + 1}`,
+        url: `https://x.test/openai/extra-${i + 1}`,
+        summary: null,
+        author: null,
+        // openai-1 (daysAgo(5)), openai-2 (daysAgo(20)) は beforeEach で投入済み
+        // extra は daysAgo(1) 〜 daysAgo(9) を追加して合計 11 件にする
+        published_at: daysAgo(i + 1),
+        category: "ai" as const,
+        lang: "en" as const,
+      })),
+    );
+  });
+
+  it("returns 404 for unknown id", async () => {
+    const res = await SELF.fetch("https://example.com/api/feeds/no-such-feed");
+    expect(res.status).toBe(404);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toBe("feed not found");
+  });
+
+  it("returns 200 with feed and recent_articles structure", async () => {
+    const res = await SELF.fetch("https://example.com/api/feeds/openai-blog");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ feed: unknown; recent_articles: unknown[] }>();
+    expect(body.feed).toBeDefined();
+    expect(Array.isArray(body.recent_articles)).toBe(true);
+  });
+
+  it("returns correct feed fields", async () => {
+    const res = await SELF.fetch("https://example.com/api/feeds/openai-blog");
+    const body = await res.json<{
+      feed: {
+        id: string;
+        name: string;
+        url: string;
+        category: string;
+        lang: string;
+        enabled: boolean;
+        articles_30d: number;
+        last_published_at: string | null;
+      };
+      recent_articles: unknown[];
+    }>();
+    expect(body.feed.id).toBe("openai-blog");
+    expect(body.feed.name).toBe("OpenAI News");
+    expect(body.feed.category).toBe("ai");
+    expect(body.feed.lang).toBe("en");
+    expect(body.feed.enabled).toBe(true);
+    // openai-1 (5d), openai-2 (20d), extra 1-9 (1-9d) = 11件、openai-3 (31d) は窓外
+    expect(body.feed.articles_30d).toBe(11);
+    expect(body.feed.last_published_at).not.toBeNull();
+  });
+
+  it("returns default 10 recent_articles when recent is not specified", async () => {
+    const res = await SELF.fetch("https://example.com/api/feeds/openai-blog");
+    const body = await res.json<{ feed: unknown; recent_articles: Article[] }>();
+    // 11 件あるが default は 10 件
+    expect(body.recent_articles.length).toBe(10);
+  });
+
+  it("returns recent_articles sorted by published_at descending", async () => {
+    const res = await SELF.fetch("https://example.com/api/feeds/openai-blog");
+    const body = await res.json<{ feed: unknown; recent_articles: Article[] }>();
+    const dates = body.recent_articles.map((a) => a.published_at);
+    for (let i = 0; i < dates.length - 1; i++) {
+      expect(dates[i] >= dates[i + 1]).toBe(true);
+    }
+  });
+
+  it("returns empty recent_articles when recent=0", async () => {
+    const res = await SELF.fetch("https://example.com/api/feeds/openai-blog?recent=0");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ feed: unknown; recent_articles: Article[] }>();
+    expect(body.recent_articles).toEqual([]);
+  });
+
+  it("returns 400 when recent=51", async () => {
+    const res = await SELF.fetch("https://example.com/api/feeds/openai-blog?recent=51");
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toContain("recent must be an integer");
+  });
+
+  it("returns specified number of recent_articles when recent=3", async () => {
+    const res = await SELF.fetch("https://example.com/api/feeds/openai-blog?recent=3");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ feed: unknown; recent_articles: Article[] }>();
+    expect(body.recent_articles.length).toBe(3);
+  });
+
+  it("returns 0 articles_30d and null last_published_at for feed with no articles", async () => {
+    // google-research には 30d 以内の記事が 1 件 (beforeEach で投入済み)
+    // 新しいフィードで確認するため zenn-ai を使う
+    const res = await SELF.fetch("https://example.com/api/feeds/zenn-ai");
+    expect(res.status).toBe(200);
+    const body = await res.json<{
+      feed: { articles_30d: number; last_published_at: string | null };
+      recent_articles: Article[];
+    }>();
+    expect(body.feed.articles_30d).toBe(0);
+    expect(body.feed.last_published_at).toBeNull();
+    expect(body.recent_articles).toEqual([]);
+  });
+
+  it("sets Cache-Control: public, max-age=300", async () => {
+    const res = await SELF.fetch("https://example.com/api/feeds/openai-blog");
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=300");
+  });
+
+  it("returns Content-Type application/json", async () => {
+    const res = await SELF.fetch("https://example.com/api/feeds/openai-blog");
+    expect(res.headers.get("Content-Type")).toContain("application/json");
   });
 });

--- a/apps/web/worker/api/feeds.ts
+++ b/apps/web/worker/api/feeds.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import type { Env, FeedCategory, FeedLang } from "../types";
-import { listFeedsWithStats } from "../db/feeds";
+import { findFeedWithStats, getRecentArticlesByFeed, listFeedsWithStats } from "../db/feeds";
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -31,6 +31,36 @@ app.get("/", async (c) => {
 
   const feeds = await listFeedsWithStats(c.env.DB, opts);
   return c.json({ feeds });
+});
+
+const RECENT_DEFAULT = 10;
+const RECENT_MAX = 50;
+
+app.get("/:id", async (c) => {
+  const id = c.req.param("id");
+  const recentRaw = c.req.query("recent");
+
+  // recent バリデーション
+  let recent = RECENT_DEFAULT;
+  if (recentRaw !== undefined) {
+    const parsed = Number(recentRaw);
+    if (!Number.isInteger(parsed) || parsed < 0 || parsed > RECENT_MAX) {
+      return c.json({ error: `recent must be an integer between 0 and ${RECENT_MAX}` }, 400);
+    }
+    recent = parsed;
+  }
+
+  const [feed, recentArticles] = await Promise.all([
+    findFeedWithStats(c.env.DB, id),
+    recent > 0 ? getRecentArticlesByFeed(c.env.DB, id, recent) : Promise.resolve([]),
+  ]);
+
+  if (!feed) {
+    return c.json({ error: "feed not found" }, 404);
+  }
+
+  c.header("Cache-Control", "public, max-age=300");
+  return c.json({ feed, recent_articles: recentArticles });
 });
 
 export default app;

--- a/apps/web/worker/db/feeds.ts
+++ b/apps/web/worker/db/feeds.ts
@@ -248,10 +248,7 @@ export async function listFeedsWithStats(
  * 1 件のフィードを articles 集計付きで返す。
  * id が存在しない場合は null。
  */
-export async function findFeedWithStats(
-  db: D1Database,
-  id: string,
-): Promise<FeedWithStats | null> {
+export async function findFeedWithStats(db: D1Database, id: string): Promise<FeedWithStats | null> {
   const threshold = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
 
   const row = await db

--- a/apps/web/worker/db/feeds.ts
+++ b/apps/web/worker/db/feeds.ts
@@ -1,4 +1,4 @@
-import type { FeedCategory, FeedConfig, FeedHealth, FeedLang } from "../types";
+import type { Article, FeedCategory, FeedConfig, FeedHealth, FeedLang } from "../types";
 
 export interface FeedHeaders {
   last_etag: string | null;
@@ -242,6 +242,77 @@ export async function listFeedsWithStats(
     articles_30d: r.articles_30d,
     last_published_at: r.last_published_at,
   }));
+}
+
+/**
+ * 1 件のフィードを articles 集計付きで返す。
+ * id が存在しない場合は null。
+ */
+export async function findFeedWithStats(
+  db: D1Database,
+  id: string,
+): Promise<FeedWithStats | null> {
+  const threshold = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+
+  const row = await db
+    .prepare(
+      `SELECT f.id, f.name, f.url, f.category, f.lang, f.enabled,
+              COUNT(CASE WHEN a.published_at >= ?2 THEN 1 END) AS articles_30d,
+              MAX(a.published_at) AS last_published_at
+       FROM feeds f
+       LEFT JOIN articles a ON a.feed_id = f.id
+       WHERE f.id = ?1
+       GROUP BY f.id, f.name, f.url, f.category, f.lang, f.enabled`,
+    )
+    .bind(id, threshold)
+    .first<{
+      id: string;
+      name: string;
+      url: string;
+      category: string;
+      lang: string;
+      enabled: number;
+      articles_30d: number;
+      last_published_at: string | null;
+    }>();
+
+  if (!row) return null;
+
+  return {
+    id: row.id,
+    name: row.name,
+    url: row.url,
+    category: row.category as FeedCategory,
+    lang: row.lang as FeedLang,
+    enabled: row.enabled === 1,
+    articles_30d: row.articles_30d,
+    last_published_at: row.last_published_at,
+  };
+}
+
+/**
+ * 指定フィードの最近の記事を published_at 降順で返す。
+ * db/articles.ts への変更を避けるため feeds.ts 内に定義。
+ */
+export async function getRecentArticlesByFeed(
+  db: D1Database,
+  feedId: string,
+  limit: number,
+): Promise<Article[]> {
+  const rows = await db
+    .prepare(
+      `SELECT a.id, a.guid, a.feed_id, f.name AS feed_name, a.title, a.url, a.summary,
+              a.author, a.published_at, a.fetched_at, a.category, a.lang
+       FROM articles a
+       LEFT JOIN feeds f ON f.id = a.feed_id
+       WHERE a.feed_id = ?1
+       ORDER BY a.published_at DESC
+       LIMIT ?2`,
+    )
+    .bind(feedId, limit)
+    .all<Article>();
+
+  return rows.results ?? [];
 }
 
 /**


### PR DESCRIPTION
## Summary

- `db/feeds.ts` に `FeedWithStats` 型・`findFeedWithStats`（1件版 30d 集計）・`getRecentArticlesByFeed` を追加
- `api/feeds.ts` に `GET /:id` ルートを追加（`recent=0..50`, default 10, `Cache-Control: public, max-age=300`）
- `tests/worker/api/feeds.test.ts` を新規作成（10 テストケース）

## 変更詳細

### `GET /api/feeds/:id?recent=10`

- `:id` が feeds テーブルにない場合 404 を返す
- `recent` は 0〜50 の整数、default 10。範囲外は 400
- レスポンスに `feed`（`articles_30d` / `last_published_at` 付き）と `recent_articles`（published_at 降順）を含む
- `Cache-Control: public, max-age=300` を付与

### 実装方針

- `db/articles.ts` への変更を避けるため（BM #152 が編集中）、`getRecentArticlesByFeed` を `db/feeds.ts` 内に定義
- `recent=0` の場合は D1 クエリを発行しない（read 節約）

## Test plan

- [ ] `vp test run` pass（10 件の新規テストを含む）
- [ ] `vp lint` / `vp fmt --check` pass（変更ファイルのみ）
- [ ] `pnpm -r typecheck` pass
- [ ] 404 / 200 / recent=0 / recent=51 / 降順 / Cache-Control / Content-Type をテスト済み

Closes #154