### PR TITLE
feat(articles): add GET /api/articles/archive monthly archive endpoint

### DIFF
--- a/apps/web/tests/worker/api/articles.test.ts
+++ b/apps/web/tests/worker/api/articles.test.ts
@@ -106,6 +106,207 @@ describe("GET /api/articles/random", () => {
   });
 });
 
+describe("GET /api/articles/archive", () => {
+  it("returns 400 when year is missing", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/archive?month=4");
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when month is missing", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/archive?year=2024");
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when year=1999 (out of range)", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/archive?year=1999&month=4");
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when year=2101 (out of range)", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/archive?year=2101&month=4");
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when month=0 (out of range)", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/archive?year=2024&month=0");
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when month=13 (out of range)", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/archive?year=2024&month=13");
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid category", async () => {
+    const res = await SELF.fetch(
+      "https://example.com/api/articles/archive?year=2024&month=4&category=invalid",
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid lang", async () => {
+    const res = await SELF.fetch(
+      "https://example.com/api/articles/archive?year=2024&month=4&lang=fr",
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for limit=0", async () => {
+    const res = await SELF.fetch(
+      "https://example.com/api/articles/archive?year=2024&month=4&limit=0",
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for limit=501", async () => {
+    const res = await SELF.fetch(
+      "https://example.com/api/articles/archive?year=2024&month=4&limit=501",
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns only articles from the specified month, excluding prev/next months", async () => {
+    // beforeEach で 2024-04 の記事が 3 件入っている
+    // 前月・翌月の記事を追加
+    await insertArticles(env.DB, [
+      {
+        guid: "prev-month",
+        feed_id: "google-research",
+        title: "March Article",
+        url: "https://x.test/g/march",
+        summary: null,
+        author: null,
+        published_at: "2024-03-31T23:59:59.000Z",
+        category: "bigtech",
+        lang: "en",
+      },
+      {
+        guid: "next-month",
+        feed_id: "google-research",
+        title: "May Article",
+        url: "https://x.test/g/may",
+        summary: null,
+        author: null,
+        published_at: "2024-05-01T00:00:00.000Z",
+        category: "bigtech",
+        lang: "en",
+      },
+    ]);
+
+    const res = await SELF.fetch("https://example.com/api/articles/archive?year=2024&month=4");
+    expect(res.status).toBe(200);
+    const body = await res.json<{
+      year: number;
+      month: number;
+      items: { published_at: string }[];
+      total: number;
+    }>();
+    expect(body.year).toBe(2024);
+    expect(body.month).toBe(4);
+    expect(body.total).toBe(3);
+    expect(body.items.length).toBe(3);
+    for (const item of body.items) {
+      expect(item.published_at >= "2024-04-01T00:00:00.000Z").toBe(true);
+      expect(item.published_at < "2024-05-01T00:00:00.000Z").toBe(true);
+    }
+  });
+
+  it("returns items in published_at descending order", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/archive?year=2024&month=4");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ items: { published_at: string }[] }>();
+    const dates = body.items.map((a) => a.published_at);
+    const sorted = dates.toSorted((a, b) => b.localeCompare(a));
+    expect(dates).toEqual(sorted);
+  });
+
+  it("returns limited items but total reflects full count (total > limit)", async () => {
+    // 追加で 12 件挿入 (beforeEach の 3 件と合わせて 15 件)
+    const extra = Array.from({ length: 12 }, (_, i) => ({
+      guid: `extra-${i}`,
+      feed_id: "openai-blog",
+      title: `Extra ${i}`,
+      url: `https://x.test/o/extra-${i}`,
+      summary: null,
+      author: null,
+      published_at: `2024-04-10T${String(i).padStart(2, "0")}:00:00.000Z`,
+      category: "ai" as const,
+      lang: "en" as const,
+    }));
+    await insertArticles(env.DB, extra);
+
+    const res = await SELF.fetch(
+      "https://example.com/api/articles/archive?year=2024&month=4&limit=10",
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json<{ items: unknown[]; total: number }>();
+    expect(body.items.length).toBe(10);
+    expect(body.total).toBe(15);
+  });
+
+  it("correctly handles December to January year wrap (2025-12)", async () => {
+    await insertArticles(env.DB, [
+      {
+        guid: "dec-article",
+        feed_id: "google-research",
+        title: "December Article",
+        url: "https://x.test/g/dec",
+        summary: null,
+        author: null,
+        published_at: "2025-12-15T12:00:00.000Z",
+        category: "bigtech",
+        lang: "en",
+      },
+      {
+        guid: "jan-next-article",
+        feed_id: "google-research",
+        title: "January Next Article",
+        url: "https://x.test/g/jan-next",
+        summary: null,
+        author: null,
+        published_at: "2026-01-01T00:00:00.000Z",
+        category: "bigtech",
+        lang: "en",
+      },
+    ]);
+
+    const res = await SELF.fetch("https://example.com/api/articles/archive?year=2025&month=12");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ items: { published_at: string }[]; total: number }>();
+    expect(body.total).toBe(1);
+    expect(body.items.length).toBe(1);
+    expect(body.items[0].published_at).toBe("2025-12-15T12:00:00.000Z");
+  });
+
+  it("returns Cache-Control: public, max-age=600", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/archive?year=2024&month=4");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=600");
+  });
+
+  it("returns Content-Type application/json", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/archive?year=2024&month=4");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toMatch(/application\/json/);
+  });
+
+  it("filters by year + month + category simultaneously", async () => {
+    const res = await SELF.fetch(
+      "https://example.com/api/articles/archive?year=2024&month=4&category=ai",
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json<{
+      items: { category: string; published_at: string }[];
+      total: number;
+    }>();
+    // 2024-04 に ai が 2 件 (o-ai-1, o-ai-2)
+    expect(body.total).toBe(2);
+    for (const item of body.items) {
+      expect(item.category).toBe("ai");
+    }
+  });
+});
+
 describe("GET /api/articles/:id", () => {
   it("returns 200 with full article fields for existing article", async () => {
     // 挿入した記事の id を D1 から取得

--- a/apps/web/worker/api/articles.ts
+++ b/apps/web/worker/api/articles.ts
@@ -2,7 +2,9 @@ import { Hono } from "hono";
 import type { Env, FeedCategory, FeedLang } from "../types";
 import { loadAllFeeds } from "../feed-config";
 import {
+  countArticlesByMonth,
   getArticleById,
+  getArticlesByMonth,
   getRandomArticles,
   getRelatedArticles,
   listArticles,
@@ -138,6 +140,48 @@ app.get("/:guid/related", async (c) => {
   const items = await getRelatedArticles(c.env.DB, guid, n);
   if (items === null) return c.json({ error: "not found" }, 404);
   return c.json({ items }, 200, { "Cache-Control": "public, max-age=300" });
+});
+
+app.get("/archive", async (c) => {
+  const yearRaw = c.req.query("year") ?? "";
+  const monthRaw = c.req.query("month") ?? "";
+
+  const year = parseInt(yearRaw, 10);
+  if (isNaN(year) || year < 2000 || year > 2100) {
+    return c.json({ error: "year must be an integer between 2000 and 2100" }, 400);
+  }
+
+  const month = parseInt(monthRaw, 10);
+  if (isNaN(month) || month < 1 || month > 12) {
+    return c.json({ error: "month must be an integer between 1 and 12" }, 400);
+  }
+
+  const categoryRaw = c.req.query("category");
+  if (categoryRaw !== undefined && !(VALID_CATEGORIES as string[]).includes(categoryRaw)) {
+    return c.json({ error: "invalid category" }, 400);
+  }
+  const category = categoryRaw as FeedCategory | undefined;
+
+  const langRaw = c.req.query("lang");
+  if (langRaw !== undefined && !(VALID_LANGS as string[]).includes(langRaw)) {
+    return c.json({ error: "invalid lang" }, 400);
+  }
+  const lang = langRaw as FeedLang | undefined;
+
+  const limitRaw = c.req.query("limit") ?? "200";
+  const limit = parseInt(limitRaw, 10);
+  if (isNaN(limit) || limit < 1 || limit > 500) {
+    return c.json({ error: "limit must be an integer between 1 and 500" }, 400);
+  }
+
+  const [items, total] = await Promise.all([
+    getArticlesByMonth(c.env.DB, year, month, { category, lang, limit }),
+    countArticlesByMonth(c.env.DB, year, month, { category, lang }),
+  ]);
+
+  return c.json({ year, month, items, total }, 200, {
+    "Cache-Control": "public, max-age=600",
+  });
 });
 
 app.get("/:id", async (c) => {

--- a/apps/web/worker/db/articles.ts
+++ b/apps/web/worker/db/articles.ts
@@ -438,6 +438,91 @@ export async function getByLang30d(db: D1Database): Promise<ByLang30d> {
   return result;
 }
 
+export interface GetArticlesByMonthParams {
+  category?: FeedCategory;
+  lang?: FeedLang;
+  limit?: number;
+}
+
+export async function getArticlesByMonth(
+  db: D1Database,
+  year: number,
+  month: number,
+  opts?: GetArticlesByMonthParams,
+): Promise<Article[]> {
+  const start = new Date(Date.UTC(year, month - 1, 1)).toISOString();
+  const end = new Date(Date.UTC(year, month, 1)).toISOString();
+  const limit = Math.min(Math.max(opts?.limit ?? 200, 1), 500);
+
+  const conds: string[] = [`a.published_at >= ?1`, `a.published_at < ?2`];
+  const binds: unknown[] = [start, end];
+
+  if (opts?.category) {
+    conds.push(`a.category = ?${binds.length + 1}`);
+    binds.push(opts.category);
+  }
+  if (opts?.lang) {
+    conds.push(`a.lang = ?${binds.length + 1}`);
+    binds.push(opts.lang);
+  }
+
+  const where = `WHERE ${conds.join(" AND ")}`;
+  const sql = `
+    SELECT a.id, a.guid, a.feed_id, f.name AS feed_name, a.title, a.url, a.summary,
+           a.author, a.published_at, a.fetched_at, a.category, a.lang
+    FROM articles a
+    LEFT JOIN feeds f ON f.id = a.feed_id
+    ${where}
+    ORDER BY a.published_at DESC, a.id DESC
+    LIMIT ?${binds.length + 1}
+  `;
+  binds.push(limit);
+
+  const result = await db
+    .prepare(sql)
+    .bind(...binds)
+    .all<Article>();
+
+  return result.results ?? [];
+}
+
+export interface CountArticlesByMonthParams {
+  category?: FeedCategory;
+  lang?: FeedLang;
+}
+
+export async function countArticlesByMonth(
+  db: D1Database,
+  year: number,
+  month: number,
+  opts?: CountArticlesByMonthParams,
+): Promise<number> {
+  const start = new Date(Date.UTC(year, month - 1, 1)).toISOString();
+  const end = new Date(Date.UTC(year, month, 1)).toISOString();
+
+  const conds: string[] = [`published_at >= ?1`, `published_at < ?2`];
+  const binds: unknown[] = [start, end];
+
+  if (opts?.category) {
+    conds.push(`category = ?${binds.length + 1}`);
+    binds.push(opts.category);
+  }
+  if (opts?.lang) {
+    conds.push(`lang = ?${binds.length + 1}`);
+    binds.push(opts.lang);
+  }
+
+  const where = `WHERE ${conds.join(" AND ")}`;
+  const sql = `SELECT COUNT(*) AS c FROM articles ${where}`;
+
+  const row = await db
+    .prepare(sql)
+    .bind(...binds)
+    .first<{ c: number }>();
+
+  return row?.c ?? 0;
+}
+
 function escapeFtsQuery(input: string): string {
   // FTS5 で安全に扱うため、特殊記号を除去して各単語をフレーズ扱いにする
   const tokens = input


### PR DESCRIPTION
## Summary

- `db/articles.ts` に `getArticlesByMonth` / `countArticlesByMonth` を追加
- `api/articles.ts` に `GET /archive` ルートを `/random` → `/archive` → `/:id` の順で登録
- year/month/category/lang/limit の厳密バリデーション (400 return)
- `Date.UTC` による UTC 境界計算（12月→翌年1月の年またぎも正常動作）
- `Promise.all` で items と total を並列取得
- `Cache-Control: public, max-age=600`
- 17件の統合テスト追加

Closes #152

## Test plan

- [ ] `vp build` pass
- [ ] `vp test run` pass (17件の archive テスト含む全249件)
- [ ] `vp lint` 0 warnings 0 errors
- [ ] `vp fmt --check` pass
- [ ] `pnpm -r typecheck` pass
- [ ] CI 緑化確認