### PR TITLE
feat(api): add GET /api/articles/:guid/neighbors endpoint

### DIFF
--- a/apps/web/tests/worker/api/articles.test.ts
+++ b/apps/web/tests/worker/api/articles.test.ts
@@ -627,3 +627,131 @@ describe("GET /api/articles/:guid/related", () => {
     expect(cc).toContain("max-age=300");
   });
 });
+
+describe("GET /api/articles/:guid/neighbors", () => {
+  // beforeEach で挿入される記事:
+  //   g-bt-1 (google-research, 2024-04-01)
+  //   o-ai-1 (openai-blog,     2024-04-02)
+  //   o-ai-2 (openai-blog,     2024-04-03)
+
+  it("returns 404 for unknown guid", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/unknown-guid-xyz/neighbors");
+    expect(res.status).toBe(404);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toBe("not found");
+  });
+
+  it("returns prev and next both non-null for a middle article", async () => {
+    // openai-blog: o-ai-1 (04-02) < o-ai-2 (04-03) < o-ai-3 (04-04)
+    await insertArticles(env.DB, [
+      {
+        guid: "o-ai-3",
+        feed_id: "openai-blog",
+        title: "AI Article Three",
+        url: "https://x.test/o/3",
+        summary: null,
+        author: null,
+        published_at: "2024-04-04T00:00:00.000Z",
+        category: "ai",
+        lang: "en",
+      },
+    ]);
+
+    const res = await SELF.fetch("https://example.com/api/articles/o-ai-2/neighbors");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ prev: Article; next: Article }>();
+    expect(body.prev).not.toBeNull();
+    expect(body.next).not.toBeNull();
+    expect(body.prev.guid).toBe("o-ai-1");
+    expect(body.next.guid).toBe("o-ai-3");
+  });
+
+  it("returns prev=null for the oldest article in feed", async () => {
+    // o-ai-1 は openai-blog で最も古い
+    const res = await SELF.fetch("https://example.com/api/articles/o-ai-1/neighbors");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ prev: Article | null; next: Article | null }>();
+    expect(body.prev).toBeNull();
+    expect(body.next).not.toBeNull();
+    expect(body.next!.guid).toBe("o-ai-2");
+  });
+
+  it("returns next=null for the newest article in feed", async () => {
+    // o-ai-2 は openai-blog で最も新しい
+    const res = await SELF.fetch("https://example.com/api/articles/o-ai-2/neighbors");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ prev: Article | null; next: Article | null }>();
+    expect(body.next).toBeNull();
+    expect(body.prev).not.toBeNull();
+    expect(body.prev!.guid).toBe("o-ai-1");
+  });
+
+  it("tie-breaks by guid lexicographic order when published_at is identical", async () => {
+    // 同一 published_at の記事を 3 件追加 (guid: tie-a, tie-b, tie-c)
+    // 辞書順: tie-a < tie-b < tie-c → tie-b の prev=tie-a, next=tie-c
+    const TIE_AT = "2024-05-01T00:00:00.000Z";
+    await insertArticles(env.DB, [
+      {
+        guid: "tie-a",
+        feed_id: "openai-blog",
+        title: "Tie A",
+        url: "https://x.test/o/tie-a",
+        summary: null,
+        author: null,
+        published_at: TIE_AT,
+        category: "ai",
+        lang: "en",
+      },
+      {
+        guid: "tie-b",
+        feed_id: "openai-blog",
+        title: "Tie B",
+        url: "https://x.test/o/tie-b",
+        summary: null,
+        author: null,
+        published_at: TIE_AT,
+        category: "ai",
+        lang: "en",
+      },
+      {
+        guid: "tie-c",
+        feed_id: "openai-blog",
+        title: "Tie C",
+        url: "https://x.test/o/tie-c",
+        summary: null,
+        author: null,
+        published_at: TIE_AT,
+        category: "ai",
+        lang: "en",
+      },
+    ]);
+
+    const res = await SELF.fetch("https://example.com/api/articles/tie-b/neighbors");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ prev: Article; next: Article }>();
+    expect(body.prev.guid).toBe("tie-a");
+    expect(body.next.guid).toBe("tie-c");
+  });
+
+  it("does not return articles from a different feed", async () => {
+    // g-bt-1 は google-research フィード。openai-blog 記事は neighbors に現れない
+    const res = await SELF.fetch("https://example.com/api/articles/g-bt-1/neighbors");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ prev: Article | null; next: Article | null }>();
+    // google-research には g-bt-1 のみなので両方 null
+    expect(body.prev).toBeNull();
+    expect(body.next).toBeNull();
+  });
+
+  it("returns Cache-Control: public, max-age=300", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/o-ai-1/neighbors");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=300");
+  });
+
+  it("returns Content-Type: application/json", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/o-ai-1/neighbors");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toMatch(/application\/json/);
+  });
+});

--- a/apps/web/worker/api/articles.ts
+++ b/apps/web/worker/api/articles.ts
@@ -5,6 +5,7 @@ import {
   countArticlesByMonth,
   getArticleById,
   getArticlesByMonth,
+  getNeighbors,
   getRandomArticles,
   getRelatedArticles,
   listArticles,
@@ -140,6 +141,13 @@ app.get("/:guid/related", async (c) => {
   const items = await getRelatedArticles(c.env.DB, guid, n);
   if (items === null) return c.json({ error: "not found" }, 404);
   return c.json({ items }, 200, { "Cache-Control": "public, max-age=300" });
+});
+
+app.get("/:guid/neighbors", async (c) => {
+  const guid = c.req.param("guid");
+  const neighbors = await getNeighbors(c.env.DB, guid);
+  if (neighbors === null) return c.json({ error: "not found" }, 404);
+  return c.json(neighbors, 200, { "Cache-Control": "public, max-age=300" });
 });
 
 app.get("/archive", async (c) => {

--- a/apps/web/worker/db/articles.ts
+++ b/apps/web/worker/db/articles.ts
@@ -270,6 +270,57 @@ export async function getRelatedArticles(
   return [...sameFeedArticles, ...(sameCategoryRows.results ?? [])];
 }
 
+export interface NeighborArticles {
+  prev: Article | null;
+  next: Article | null;
+}
+
+/**
+ * guid の前後記事を同 feed_id 内で取得する。
+ * tie-break は published_at が同一の場合 guid の辞書順で決定性を保証する。
+ * guid が存在しない場合は null を返す (呼び出し側で 404 ハンドル)。
+ */
+export async function getNeighbors(db: D1Database, guid: string): Promise<NeighborArticles | null> {
+  const target = await findArticleByGuid(db, guid);
+  if (!target) return null;
+
+  const { feed_id, published_at } = target;
+
+  const [prevResult, nextResult] = await Promise.all([
+    db
+      .prepare(
+        `SELECT a.id, a.guid, a.feed_id, f.name AS feed_name, a.title, a.url, a.summary,
+                a.author, a.published_at, a.fetched_at, a.category, a.lang
+         FROM articles a
+         LEFT JOIN feeds f ON f.id = a.feed_id
+         WHERE a.feed_id = ?1
+           AND (a.published_at < ?2 OR (a.published_at = ?2 AND a.guid < ?3))
+         ORDER BY a.published_at DESC, a.guid DESC
+         LIMIT 1`,
+      )
+      .bind(feed_id, published_at, guid)
+      .first<Article>(),
+    db
+      .prepare(
+        `SELECT a.id, a.guid, a.feed_id, f.name AS feed_name, a.title, a.url, a.summary,
+                a.author, a.published_at, a.fetched_at, a.category, a.lang
+         FROM articles a
+         LEFT JOIN feeds f ON f.id = a.feed_id
+         WHERE a.feed_id = ?1
+           AND (a.published_at > ?2 OR (a.published_at = ?2 AND a.guid > ?3))
+         ORDER BY a.published_at ASC, a.guid ASC
+         LIMIT 1`,
+      )
+      .bind(feed_id, published_at, guid)
+      .first<Article>(),
+  ]);
+
+  return {
+    prev: prevResult ?? null,
+    next: nextResult ?? null,
+  };
+}
+
 export async function countAllArticles(db: D1Database): Promise<number> {
   const row = await db.prepare(`SELECT COUNT(*) AS c FROM articles`).first<{ c: number }>();
   return row?.c ?? 0;


### PR DESCRIPTION
## Summary

- `db/articles.ts` に `getNeighbors(db, guid)` を追加。同 `feed_id` 内で1つ古い/新しい記事を返す
- tie-break は `(published_at, guid)` の複合キーで deterministic に解決
- `api/articles.ts` に `GET /:guid/neighbors` を `/:guid/related` と `/archive` の間に登録
- レスポンスに `Cache-Control: public, max-age=300` を付与
- テスト 8 件追加: 404/prev-null/next-null/tie-break/cross-feed-isolation/headers

## Test plan

- [x] `pnpm build` 成功
- [x] `pnpm test` — 303 件全通過
- [x] `pnpm lint` — 0 errors
- [x] `pnpm typecheck` — エラーなし
- [x] `pnpm format` — フォーマット適用済み

Closes #159