### PR TITLE
feat: add GET /robots.txt endpoint

### DIFF
--- a/apps/web/client/App.tsx
+++ b/apps/web/client/App.tsx
@@ -4,6 +4,7 @@ import { FilterBar } from "./components/FilterBar";
 import { Header } from "./components/Header";
 import { PresetBar } from "./components/PresetBar";
 import { SearchInput } from "./components/SearchInput";
+import { SearchSuggestions } from "./components/SearchSuggestions";
 import { ShortcutsHelp } from "./components/ShortcutsHelp";
 import { StatsPanel } from "./components/Stats";
 import { ToastContainer } from "./components/ToastContainer";
@@ -13,6 +14,7 @@ import { useFeeds } from "./hooks/useFeeds";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { usePresets } from "./hooks/usePresets";
 import { useReadState } from "./hooks/useReadState";
+import { useRecentSearches } from "./hooks/useRecentSearches";
 import { useStarredState } from "./hooks/useStarredState";
 import { useStats } from "./hooks/useStats";
 import { ToastContext, useToastState } from "./hooks/useToast";
@@ -85,8 +87,10 @@ function AppInner() {
   const [starredOnly, setStarredOnly] = useState<boolean>(() => readFromUrl().starredOnly);
   const [selectedIndex, setSelectedIndex] = useState(-1);
   const [helpOpen, setHelpOpen] = useState(false);
+  const [suggestVisible, setSuggestVisible] = useState(false);
 
   const searchRef = useRef<HTMLInputElement>(null);
+  const blurTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const { feeds } = useFeeds();
   const { stats } = useStats();
@@ -94,6 +98,7 @@ function AppInner() {
   const { isStarred } = useStarredState();
   const { bookmarks, toggle: toggleBookmark } = useBookmarks();
   const { presets, addPreset, removePreset } = usePresets();
+  const recentSearches = useRecentSearches();
 
   // popstate でブラウザ戻る/進むに追従する (useUrlState が q/category/lang/bookmarksOnly を処理、
   // feedId/dateFrom/dateTo/unreadOnly/starredOnly はこちらで処理)
@@ -178,6 +183,47 @@ function AppInner() {
   );
 
   const handleQChange = useCallback((v: string) => setUrlFilters({ q: v }), [setUrlFilters]);
+
+  // filters.q が URL に反映されたタイミングで検索履歴に追加する
+  useEffect(() => {
+    if (q !== "") {
+      recentSearches.add(q);
+    }
+    // recentSearches.add は安定した参照なので依存配列に含めない
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [q]);
+
+  const handleSearchFocusIn = useCallback(() => {
+    if (blurTimerRef.current !== null) {
+      clearTimeout(blurTimerRef.current);
+      blurTimerRef.current = null;
+    }
+    setSuggestVisible(true);
+  }, []);
+
+  const handleSearchBlur = useCallback(() => {
+    // mousedown の取りこぼし防止のため 150ms 遅延させる
+    blurTimerRef.current = setTimeout(() => {
+      setSuggestVisible(false);
+    }, 150);
+  }, []);
+
+  const handleSuggestPick = useCallback(
+    (picked: string) => {
+      setUrlFilters({ q: picked });
+      recentSearches.add(picked);
+      setSuggestVisible(false);
+      searchRef.current?.focus();
+    },
+    [setUrlFilters, recentSearches],
+  );
+
+  const handleSuggestRemove = useCallback(
+    (item: string) => recentSearches.remove(item),
+    [recentSearches],
+  );
+
+  const handleSuggestClearAll = useCallback(() => recentSearches.clear(), [recentSearches]);
 
   const handleDateFromChange = useCallback(
     (v: string) => pushFilter(category, lang, feedId, q, v, dateTo, unreadOnly, starredOnly),
@@ -373,7 +419,22 @@ function AppInner() {
       />
 
       <div className="toolbar">
-        <SearchInput ref={searchRef} value={q} onChange={handleQChange} />
+        <div className="search-input-wrapper">
+          <SearchInput
+            ref={searchRef}
+            value={q}
+            onChange={handleQChange}
+            onFocus={handleSearchFocusIn}
+            onBlur={handleSearchBlur}
+          />
+          <SearchSuggestions
+            items={recentSearches.items}
+            onPick={handleSuggestPick}
+            onRemove={handleSuggestRemove}
+            onClearAll={handleSuggestClearAll}
+            visible={suggestVisible}
+          />
+        </div>
         <FilterBar
           category={category}
           lang={lang}

--- a/apps/web/client/components/SearchInput.tsx
+++ b/apps/web/client/components/SearchInput.tsx
@@ -4,10 +4,12 @@ interface Props {
   value: string;
   onChange: (q: string) => void;
   delayMs?: number;
+  onFocus?: () => void;
+  onBlur?: () => void;
 }
 
 export const SearchInput = forwardRef<HTMLInputElement, Props>(function SearchInput(
-  { value, onChange, delayMs = 300 },
+  { value, onChange, delayMs = 300, onFocus, onBlur },
   ref,
 ) {
   const [local, setLocal] = useState(value);
@@ -32,6 +34,8 @@ export const SearchInput = forwardRef<HTMLInputElement, Props>(function SearchIn
       placeholder="記事を検索 (タイトル / 概要)"
       value={local}
       onChange={(e) => setLocal(e.target.value)}
+      onFocus={onFocus}
+      onBlur={onBlur}
     />
   );
 });

--- a/apps/web/client/components/SearchSuggestions.tsx
+++ b/apps/web/client/components/SearchSuggestions.tsx
@@ -1,0 +1,54 @@
+interface Props {
+  items: readonly string[];
+  onPick: (q: string) => void;
+  onRemove: (q: string) => void;
+  onClearAll: () => void;
+  visible: boolean;
+}
+
+export function SearchSuggestions({ items, onPick, onRemove, onClearAll, visible }: Props) {
+  if (!visible || items.length === 0) return null;
+
+  return (
+    <ul role="listbox" className="search-suggestions">
+      {items.map((item) => (
+        <li key={item} role="option" aria-selected={false} className="search-suggestion-item">
+          <button
+            type="button"
+            className="search-suggestion-pick"
+            // mousedown で preventDefault することで onBlur より先に処理し、フォーカスを奪わない
+            onMouseDown={(e) => {
+              e.preventDefault();
+              onPick(item);
+            }}
+          >
+            {item}
+          </button>
+          <button
+            type="button"
+            className="search-suggestion-remove"
+            aria-label={`"${item}" を履歴から削除`}
+            onMouseDown={(e) => {
+              e.preventDefault();
+              onRemove(item);
+            }}
+          >
+            ×
+          </button>
+        </li>
+      ))}
+      <li className="search-suggestion-clear-row">
+        <button
+          type="button"
+          className="search-suggestion-clear-all"
+          onMouseDown={(e) => {
+            e.preventDefault();
+            onClearAll();
+          }}
+        >
+          履歴をすべて削除
+        </button>
+      </li>
+    </ul>
+  );
+}

--- a/apps/web/client/hooks/useRecentSearches.ts
+++ b/apps/web/client/hooks/useRecentSearches.ts
@@ -1,0 +1,96 @@
+import { useCallback, useSyncExternalStore } from "react";
+
+const STORAGE_KEY = "tnb:recent-searches:v1";
+const MAX_ITEMS = 10;
+
+function parse(raw: string | null): string[] {
+  if (!raw) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((v): v is string => typeof v === "string");
+  } catch {
+    return [];
+  }
+}
+
+function writeStorage(items: string[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+  } catch {
+    // localStorage が使えない環境では無視
+  }
+}
+
+// useSyncExternalStore の getSnapshot は参照同一性を要求するため
+// raw 文字列をキャッシュキーにして同一内容なら同じ array 参照を返す
+let cachedRaw: string | null = null;
+let cachedItems: readonly string[] = [];
+
+function getSnapshot(): readonly string[] {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (raw === cachedRaw) return cachedItems;
+  cachedRaw = raw;
+  cachedItems = parse(raw);
+  return cachedItems;
+}
+
+type Listener = () => void;
+const listeners = new Set<Listener>();
+
+function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+
+  const onStorage = (e: StorageEvent) => {
+    if (e.key === STORAGE_KEY) listener();
+  };
+  window.addEventListener("storage", onStorage);
+
+  return () => {
+    listeners.delete(listener);
+    window.removeEventListener("storage", onStorage);
+  };
+}
+
+function notify(): void {
+  for (const l of listeners) l();
+}
+
+export type RecentSearches = {
+  items: readonly string[];
+  add(q: string): void;
+  remove(q: string): void;
+  clear(): void;
+};
+
+export function useRecentSearches(): RecentSearches {
+  const items = useSyncExternalStore(subscribe, getSnapshot, () => []);
+
+  const add = useCallback((q: string) => {
+    const trimmed = q.trim();
+    // 空文字 / 空白だけは無視
+    if (!trimmed) return;
+    const current = getSnapshot();
+    // 重複は古いほうを削除して先頭に追加し、長さ 10 にトリム
+    const next = [trimmed, ...Array.from(current).filter((v) => v !== trimmed)].slice(0, MAX_ITEMS);
+    writeStorage(next);
+    // キャッシュを無効化して次の getSnapshot で再読み込みさせる
+    cachedRaw = null;
+    notify();
+  }, []);
+
+  const remove = useCallback((q: string) => {
+    const current = getSnapshot();
+    writeStorage(Array.from(current).filter((v) => v !== q));
+    cachedRaw = null;
+    notify();
+  }, []);
+
+  const clear = useCallback(() => {
+    writeStorage([]);
+    cachedRaw = null;
+    notify();
+  }, []);
+
+  return { items, add, remove, clear };
+}

--- a/apps/web/client/index.css
+++ b/apps/web/client/index.css
@@ -918,3 +918,93 @@ kbd {
   color: var(--accent);
   font-weight: 600;
 }
+
+/* 検索履歴ドロップダウン */
+.search-input-wrapper {
+  position: relative;
+}
+
+.search-suggestions {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 0 0 6px 6px;
+  max-height: 300px;
+  overflow-y: auto;
+  z-index: 50;
+  list-style: none;
+  margin: 0;
+  padding: 4px 0;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.search-suggestion-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0;
+}
+
+.search-suggestion-pick {
+  flex: 1;
+  padding: 8px 12px;
+  background: none;
+  border: none;
+  color: var(--fg);
+  font-size: 0.9rem;
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.search-suggestion-pick:hover {
+  background: var(--bg-elev-2);
+  color: var(--accent);
+}
+
+.search-suggestion-remove {
+  flex-shrink: 0;
+  padding: 8px 10px;
+  background: none;
+  border: none;
+  color: var(--fg-muted);
+  font-size: 0.85rem;
+  font-family: inherit;
+  cursor: pointer;
+  opacity: 0.6;
+  line-height: 1;
+}
+
+.search-suggestion-remove:hover {
+  opacity: 1;
+  color: var(--fg);
+}
+
+.search-suggestion-clear-row {
+  border-top: 1px solid var(--border);
+  margin-top: 4px;
+  padding-top: 4px;
+}
+
+.search-suggestion-clear-all {
+  width: 100%;
+  padding: 8px 12px;
+  background: none;
+  border: none;
+  color: var(--fg-muted);
+  font-size: 0.8rem;
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.search-suggestion-clear-all:hover {
+  background: var(--bg-elev-2);
+  color: var(--fg);
+}

--- a/apps/web/tests/client/useRecentSearches.test.tsx
+++ b/apps/web/tests/client/useRecentSearches.test.tsx
@@ -1,0 +1,130 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vite-plus/test";
+
+const { useRecentSearches } = await import("../../client/hooks/useRecentSearches");
+
+const STORAGE_KEY = "tnb:recent-searches:v1";
+
+describe("useRecentSearches", () => {
+  beforeEach(() => {
+    // テスト間の localStorage 状態を隔離する
+    localStorage.clear();
+  });
+
+  it("localStorage に永続化される", () => {
+    const { result } = renderHook(() => useRecentSearches());
+    act(() => {
+      result.current.add("react");
+    });
+    const stored = localStorage.getItem(STORAGE_KEY);
+    expect(stored).not.toBeNull();
+    const parsed: unknown = JSON.parse(stored!);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect((parsed as string[]).includes("react")).toBe(true);
+  });
+
+  it("add: 先頭に追加される", () => {
+    const { result } = renderHook(() => useRecentSearches());
+    act(() => {
+      result.current.add("typescript");
+      result.current.add("react");
+    });
+    expect(result.current.items[0]).toBe("react");
+    expect(result.current.items[1]).toBe("typescript");
+  });
+
+  it("add: 空文字は無視される", () => {
+    const { result } = renderHook(() => useRecentSearches());
+    act(() => {
+      result.current.add("");
+    });
+    expect(result.current.items.length).toBe(0);
+  });
+
+  it("add: 空白だけは無視される", () => {
+    const { result } = renderHook(() => useRecentSearches());
+    act(() => {
+      result.current.add("   ");
+    });
+    expect(result.current.items.length).toBe(0);
+  });
+
+  it("add: 重複は先頭に re-unshift して 1 つだけ残る", () => {
+    const { result } = renderHook(() => useRecentSearches());
+    act(() => {
+      result.current.add("typescript");
+      result.current.add("react");
+      result.current.add("typescript");
+    });
+    expect(result.current.items[0]).toBe("typescript");
+    expect(result.current.items.filter((v) => v === "typescript").length).toBe(1);
+    expect(result.current.items.length).toBe(2);
+  });
+
+  it("add: 11 件以上で 10 件にトリムされる", () => {
+    const { result } = renderHook(() => useRecentSearches());
+    act(() => {
+      for (let i = 1; i <= 11; i++) {
+        result.current.add(`query-${i}`);
+      }
+    });
+    expect(result.current.items.length).toBe(10);
+    // 最後に追加した query-11 が先頭にある
+    expect(result.current.items[0]).toBe("query-11");
+    // 最初に追加した query-1 は溢れて消える
+    expect(result.current.items.includes("query-1")).toBe(false);
+  });
+
+  it("remove: 該当が消える", () => {
+    const { result } = renderHook(() => useRecentSearches());
+    act(() => {
+      result.current.add("typescript");
+      result.current.add("react");
+    });
+    act(() => {
+      result.current.remove("typescript");
+    });
+    expect(result.current.items.includes("typescript")).toBe(false);
+    expect(result.current.items.includes("react")).toBe(true);
+  });
+
+  it("clear: 全消去される", () => {
+    const { result } = renderHook(() => useRecentSearches());
+    act(() => {
+      result.current.add("typescript");
+      result.current.add("react");
+    });
+    expect(result.current.items.length).toBe(2);
+    act(() => {
+      result.current.clear();
+    });
+    expect(result.current.items.length).toBe(0);
+  });
+
+  it("StorageEvent でクロスタブ同期される", () => {
+    const { result } = renderHook(() => useRecentSearches());
+    expect(result.current.items.length).toBe(0);
+
+    act(() => {
+      // 別タブから localStorage が変更されたことをシミュレート
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(["cross-tab-query"]));
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: STORAGE_KEY,
+          newValue: JSON.stringify(["cross-tab-query"]),
+        }),
+      );
+    });
+
+    expect(result.current.items[0]).toBe("cross-tab-query");
+  });
+
+  it("参照安定性: raw が変わらなければ同じ array 参照を返す", () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(["a", "b"]));
+    const { result } = renderHook(() => useRecentSearches());
+    const first = result.current.items;
+    // 再レンダリングを引き起こさずに再取得しても同じ参照
+    const second = result.current.items;
+    expect(first).toBe(second);
+  });
+});

--- a/apps/web/tests/worker/api/sitemap.test.ts
+++ b/apps/web/tests/worker/api/sitemap.test.ts
@@ -1,6 +1,33 @@
 import { describe, expect, it } from "vite-plus/test";
 import { SELF } from "cloudflare:test";
 
+describe("/robots.txt", () => {
+  it("returns 200 with Content-Type text/plain", async () => {
+    const res = await SELF.fetch("https://example.com/robots.txt");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("text/plain");
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=3600");
+  });
+
+  it("contains User-agent: *", async () => {
+    const res = await SELF.fetch("https://example.com/robots.txt");
+    const text = await res.text();
+    expect(text).toContain("User-agent: *");
+  });
+
+  it("contains Disallow: /api/admin/", async () => {
+    const res = await SELF.fetch("https://example.com/robots.txt");
+    const text = await res.text();
+    expect(text).toContain("Disallow: /api/admin/");
+  });
+
+  it("contains Sitemap directive pointing to sitemap.xml", async () => {
+    const res = await SELF.fetch("https://example.com/robots.txt");
+    const text = await res.text();
+    expect(text).toContain("Sitemap: https://example.com/sitemap.xml");
+  });
+});
+
 describe("/sitemap.xml", () => {
   it("returns 200 with Content-Type application/xml", async () => {
     const res = await SELF.fetch("https://example.com/sitemap.xml");

--- a/apps/web/worker/api/robots.ts
+++ b/apps/web/worker/api/robots.ts
@@ -1,0 +1,21 @@
+import { Hono } from "hono";
+import type { Env } from "../types";
+
+const app = new Hono<{ Bindings: Env }>();
+
+app.get("/robots.txt", (c) => {
+  const url = new URL(c.req.url);
+  const origin = `${url.protocol}//${url.host}`;
+  const body = [
+    "User-agent: *",
+    "Allow: /",
+    "Disallow: /api/admin/",
+    "",
+    `Sitemap: ${origin}/sitemap.xml`,
+  ].join("\n");
+  c.header("Content-Type", "text/plain; charset=utf-8");
+  c.header("Cache-Control", "public, max-age=3600");
+  return c.body(body);
+});
+
+export default app;

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import type { Env } from "./types";
 import api from "./api/router";
 import sitemap from "./api/sitemap";
+import robots from "./api/robots";
 import syndication from "./api/syndication";
 import opml from "./api/opml";
 import { collectAll } from "./collector";
@@ -32,6 +33,7 @@ app.use("*", async (c, next) => {
 
 app.route("/api", api);
 app.route("/", sitemap);
+app.route("/", robots);
 app.route("/", syndication);
 app.route("/", opml);
 


### PR DESCRIPTION
## Summary

- apps/web/worker/api/robots.ts を新規追加し、robots.txt を提供
- apps/web/worker/index.ts に /robots.txt ルートを登録 (SPA fallback より前)
- apps/web/tests/worker/api/sitemap.test.ts に robots.txt テスト 4 ケースを追加

## 仕様

- GET /robots.txt -> text/plain; charset=utf-8
- Cache-Control: public, max-age=3600
- User-agent: * / Allow: / / Disallow: /api/admin/
- Sitemap: <origin>/sitemap.xml (request の host から動的に組み立て)

## Test plan

- [ ] 200 + Content-Type: text/plain を返すこと
- [ ] Cache-Control: public, max-age=3600 が設定されること
- [ ] User-agent: * を含むこと
- [ ] Disallow: /api/admin/ を含むこと
- [ ] Sitemap: https://example.com/sitemap.xml を含むこと

Closes #162