### PR TITLE
feat(client): SPA に統計ダッシュボードページを追加

### DIFF
--- a/apps/web/client/App.tsx
+++ b/apps/web/client/App.tsx
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ArticleList } from "./components/ArticleList";
 import { FilterBar } from "./components/FilterBar";
-import { Header } from "./components/Header";
+import { type AppView, Header } from "./components/Header";
 import { PresetBar } from "./components/PresetBar";
 import { SearchInput } from "./components/SearchInput";
 import { SearchSuggestions } from "./components/SearchSuggestions";
 import { ShortcutsHelp } from "./components/ShortcutsHelp";
+import { StatsDashboard } from "./components/StatsDashboard";
 import { StatsPanel } from "./components/Stats";
 import { ToastContainer } from "./components/ToastContainer";
 import { useArticles } from "./hooks/useArticles";
@@ -77,7 +78,12 @@ function buildSearch(
   return s ? `?${s}` : window.location.pathname;
 }
 
+function readViewFromUrl(): AppView {
+  return window.location.pathname === "/stats" ? "stats" : "articles";
+}
+
 function AppInner() {
+  const [view, setView] = useState<AppView>(readViewFromUrl);
   const [urlFilters, setUrlFilters] = useUrlState();
   const { q, category, lang, bookmarksOnly: bookmarkedOnly } = urlFilters;
   const [feedId, setFeedId] = useState<string>(() => readFromUrl().feedId);
@@ -100,6 +106,14 @@ function AppInner() {
   const { presets, addPreset, removePreset } = usePresets();
   const recentSearches = useRecentSearches();
 
+  const handleViewChange = useCallback((next: AppView) => {
+    setView(next);
+    const path = next === "stats" ? "/stats" : "/";
+    if (window.location.pathname !== path) {
+      window.history.pushState(null, "", path);
+    }
+  }, []);
+
   // popstate でブラウザ戻る/進むに追従する (useUrlState が q/category/lang/bookmarksOnly を処理、
   // feedId/dateFrom/dateTo/unreadOnly/starredOnly はこちらで処理)
   useEffect(() => {
@@ -110,6 +124,7 @@ function AppInner() {
       setDateTo(next.dateTo);
       setUnreadOnly(next.unreadOnly);
       setStarredOnly(next.starredOnly);
+      setView(readViewFromUrl());
     };
     window.addEventListener("popstate", onPop);
     return () => window.removeEventListener("popstate", onPop);
@@ -375,109 +390,125 @@ function AppInner() {
 
   return (
     <div className="app">
-      <Header />
+      <Header view={view} onViewChange={handleViewChange} />
       <ShortcutsHelp open={helpOpen} onClose={() => setHelpOpen(false)} />
-      <header className="header">
-        <span className="subtitle">
-          {stats ? `${stats.total.toLocaleString()} 記事 · 直近 24h: ${stats.last24h}` : ""}
-          {feeds.length > 0 ? ` · ${feeds.length} sources` : ""}
-          {stats?.last_fetched_at ? ` · 最終更新 ${formatRelative(stats.last_fetched_at)}` : ""}
-        </span>
-        <button
-          type="button"
-          className={`bookmarks-only-toggle${bookmarkedOnly ? " active" : ""}`}
-          onClick={handleBookmarkedOnlyToggle}
-          aria-pressed={bookmarkedOnly}
-        >
-          ★ {bookmarks.size} 件{bookmarkedOnly ? " (表示中)" : ""}
-        </button>
-        {stats && stats.stale_feeds.length > 0 && (
-          <details className="stale-warning">
-            <summary>⚠ {stats.stale_feeds.length} 件の収集に問題があります</summary>
-            <ul>
-              {stats.stale_feeds.map((f) => (
-                <li key={f.id}>
-                  <strong>{f.name}</strong>
-                  {f.last_status === "error" ? " · error" : " · stale"}
-                  {f.last_fetched_at ? ` · ${formatRelative(f.last_fetched_at)}` : " · 未取得"}
-                  {f.last_error && <div className="stale-error">{f.last_error}</div>}
-                </li>
-              ))}
-            </ul>
-          </details>
-        )}
-      </header>
 
-      {stats && <StatsPanel stats={stats} />}
+      {view === "stats" ? (
+        <StatsDashboard />
+      ) : (
+        <>
+          <header className="header">
+            <span className="subtitle">
+              {stats ? `${stats.total.toLocaleString()} 記事 · 直近 24h: ${stats.last24h}` : ""}
+              {feeds.length > 0 ? ` · ${feeds.length} sources` : ""}
+              {stats?.last_fetched_at ? ` · 最終更新 ${formatRelative(stats.last_fetched_at)}` : ""}
+            </span>
+            <button
+              type="button"
+              className={`bookmarks-only-toggle${bookmarkedOnly ? " active" : ""}`}
+              onClick={handleBookmarkedOnlyToggle}
+              aria-pressed={bookmarkedOnly}
+            >
+              ★ {bookmarks.size} 件{bookmarkedOnly ? " (表示中)" : ""}
+            </button>
+            {stats && stats.stale_feeds.length > 0 && (
+              <details className="stale-warning">
+                <summary>⚠ {stats.stale_feeds.length} 件の収集に問題があります</summary>
+                <ul>
+                  {stats.stale_feeds.map((f) => (
+                    <li key={f.id}>
+                      <strong>{f.name}</strong>
+                      {f.last_status === "error" ? " · error" : " · stale"}
+                      {f.last_fetched_at ? ` · ${formatRelative(f.last_fetched_at)}` : " · 未取得"}
+                      {f.last_error && <div className="stale-error">{f.last_error}</div>}
+                    </li>
+                  ))}
+                </ul>
+              </details>
+            )}
+          </header>
 
-      <PresetBar
-        presets={presets}
-        currentFilters={{ category, lang, feedId, q, unreadOnly, starredOnly, dateFrom, dateTo }}
-        onApply={handleApplyPreset}
-        onAdd={addPreset}
-        onRemove={removePreset}
-      />
+          {stats && <StatsPanel stats={stats} />}
 
-      <div className="toolbar">
-        <div className="search-input-wrapper">
-          <SearchInput
-            ref={searchRef}
-            value={q}
-            onChange={handleQChange}
-            onFocus={handleSearchFocusIn}
-            onBlur={handleSearchBlur}
+          <PresetBar
+            presets={presets}
+            currentFilters={{
+              category,
+              lang,
+              feedId,
+              q,
+              unreadOnly,
+              starredOnly,
+              dateFrom,
+              dateTo,
+            }}
+            onApply={handleApplyPreset}
+            onAdd={addPreset}
+            onRemove={removePreset}
           />
-          <SearchSuggestions
-            items={recentSearches.items}
-            onPick={handleSuggestPick}
-            onRemove={handleSuggestRemove}
-            onClearAll={handleSuggestClearAll}
-            visible={suggestVisible}
-          />
-        </div>
-        <FilterBar
-          category={category}
-          lang={lang}
-          feedId={feedId}
-          feeds={feeds}
-          dateFrom={dateFrom}
-          dateTo={dateTo}
-          unreadOnly={unreadOnly}
-          starredOnly={starredOnly}
-          onCategoryChange={handleCategoryChange}
-          onLangChange={handleLangChange}
-          onFeedChange={handleFeedChange}
-          onDateFromChange={handleDateFromChange}
-          onDateToChange={handleDateToChange}
-          onUnreadOnlyChange={handleUnreadOnlyChange}
-          onStarredOnlyChange={handleStarredOnlyChange}
-          onClear={handleClear}
-        />
-      </div>
 
-      {loading && <div className="loader">読み込み中…</div>}
-      {error && !loading && <div className="error">取得エラー: {error}</div>}
-      {!loading && !error && articles.length === 0 && bookmarkedOnly && (
-        <div className="empty">ブックマークがありません</div>
-      )}
-      {!loading && !error && articles.length === 0 && !bookmarkedOnly && (
-        <div className="empty">記事はまだありません。Cron 実行をお待ちください。</div>
-      )}
+          <div className="toolbar">
+            <div className="search-input-wrapper">
+              <SearchInput
+                ref={searchRef}
+                value={q}
+                onChange={handleQChange}
+                onFocus={handleSearchFocusIn}
+                onBlur={handleSearchBlur}
+              />
+              <SearchSuggestions
+                items={recentSearches.items}
+                onPick={handleSuggestPick}
+                onRemove={handleSuggestRemove}
+                onClearAll={handleSuggestClearAll}
+                visible={suggestVisible}
+              />
+            </div>
+            <FilterBar
+              category={category}
+              lang={lang}
+              feedId={feedId}
+              feeds={feeds}
+              dateFrom={dateFrom}
+              dateTo={dateTo}
+              unreadOnly={unreadOnly}
+              starredOnly={starredOnly}
+              onCategoryChange={handleCategoryChange}
+              onLangChange={handleLangChange}
+              onFeedChange={handleFeedChange}
+              onDateFromChange={handleDateFromChange}
+              onDateToChange={handleDateToChange}
+              onUnreadOnlyChange={handleUnreadOnlyChange}
+              onStarredOnlyChange={handleStarredOnlyChange}
+              onClear={handleClear}
+            />
+          </div>
 
-      {articles.length > 0 && (
-        <ArticleList
-          articles={articles}
-          selectedIndex={selectedIndex}
-          onFilterByCategory={handleFilterByCategory}
-          onFilterByFeedId={handleFilterByFeedId}
-          q={q}
-        />
-      )}
+          {loading && <div className="loader">読み込み中…</div>}
+          {error && !loading && <div className="error">取得エラー: {error}</div>}
+          {!loading && !error && articles.length === 0 && bookmarkedOnly && (
+            <div className="empty">ブックマークがありません</div>
+          )}
+          {!loading && !error && articles.length === 0 && !bookmarkedOnly && (
+            <div className="empty">記事はまだありません。Cron 実行をお待ちください。</div>
+          )}
 
-      {nextCursor && (
-        <button type="button" className="load-more" onClick={loadMore} disabled={loadingMore}>
-          {loadingMore ? "読み込み中…" : "もっと読み込む"}
-        </button>
+          {articles.length > 0 && (
+            <ArticleList
+              articles={articles}
+              selectedIndex={selectedIndex}
+              onFilterByCategory={handleFilterByCategory}
+              onFilterByFeedId={handleFilterByFeedId}
+              q={q}
+            />
+          )}
+
+          {nextCursor && (
+            <button type="button" className="load-more" onClick={loadMore} disabled={loadingMore}>
+              {loadingMore ? "読み込み中…" : "もっと読み込む"}
+            </button>
+          )}
+        </>
       )}
       <ToastContainer />
     </div>

--- a/apps/web/client/components/Header.tsx
+++ b/apps/web/client/components/Header.tsx
@@ -1,5 +1,12 @@
 import { useTheme } from "../hooks/useTheme";
 
+export type AppView = "articles" | "stats";
+
+interface HeaderProps {
+  view?: AppView;
+  onViewChange?: (view: AppView) => void;
+}
+
 function SunIcon() {
   return (
     <svg
@@ -46,13 +53,33 @@ function MoonIcon() {
   );
 }
 
-export function Header() {
+export function Header({ view, onViewChange }: HeaderProps) {
   const { theme, toggleTheme } = useTheme();
   const label = theme === "dark" ? "Switch to light mode" : "Switch to dark mode";
 
   return (
     <header className="app-header">
       <h1>Tech News Bot</h1>
+      {onViewChange && (
+        <nav className="app-nav" aria-label="ページ切替">
+          <button
+            type="button"
+            className={`app-nav-tab${view === "articles" || !view ? " active" : ""}`}
+            onClick={() => onViewChange("articles")}
+            aria-current={view === "articles" || !view ? "page" : undefined}
+          >
+            Articles
+          </button>
+          <button
+            type="button"
+            className={`app-nav-tab${view === "stats" ? " active" : ""}`}
+            onClick={() => onViewChange("stats")}
+            aria-current={view === "stats" ? "page" : undefined}
+          >
+            Stats
+          </button>
+        </nav>
+      )}
       <button
         type="button"
         className="theme-toggle"

--- a/apps/web/client/components/StatsDashboard.tsx
+++ b/apps/web/client/components/StatsDashboard.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useState } from "react";
+import type { AuthorCount, PublisherCount, Stats } from "../hooks/useStats";
+
+function SummaryCard({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="stats-card">
+      <div className="stats-card-label">{label}</div>
+      <div className="stats-card-value">{value.toLocaleString("ja-JP")}</div>
+    </div>
+  );
+}
+
+function BarRow({ label, count, maxCount }: { label: string; count: number; maxCount: number }) {
+  const pct = maxCount > 0 ? Math.round((count / maxCount) * 100) : 0;
+  return (
+    <div className="stats-bar-row">
+      <span className="stats-bar-label">{label}</span>
+      <div
+        className="stats-bar"
+        role="img"
+        aria-label={`${label}: ${count}件`}
+        style={{ width: `${pct}%` }}
+      />
+      <span className="stats-bar-count">{count.toLocaleString("ja-JP")}</span>
+    </div>
+  );
+}
+
+function AuthorsSection({ authors }: { authors: AuthorCount[] }) {
+  const top = authors.slice(0, 10);
+  const max = top[0]?.count ?? 1;
+  return (
+    <section className="stats-section">
+      <h3 className="stats-section-title">著者別 (30 日・上位 10 件)</h3>
+      <div className="stats-bar-list">
+        {top.map((a) => (
+          <BarRow key={a.author} label={a.author} count={a.count} maxCount={max} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function PublishersSection({ publishers }: { publishers: PublisherCount[] }) {
+  const top = publishers.slice(0, 10);
+  const max = top[0]?.count ?? 1;
+  return (
+    <section className="stats-section">
+      <h3 className="stats-section-title">フィード別 (30 日・上位 10 件)</h3>
+      <div className="stats-bar-list">
+        {top.map((p) => (
+          <BarRow key={p.feed_id} label={p.name} count={p.count} maxCount={max} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function LangSection({ byLang }: { byLang: Record<string, number> }) {
+  const entries = Object.entries(byLang).toSorted((a, b) => b[1] - a[1]);
+  const max = entries[0]?.[1] ?? 1;
+  return (
+    <section className="stats-section">
+      <h3 className="stats-section-title">言語別 (30 日)</h3>
+      <div className="stats-bar-list">
+        {entries.map(([lang, count]) => (
+          <BarRow key={lang} label={lang} count={count} maxCount={max} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function CategorySection({ byCategory }: { byCategory: Record<string, number> }) {
+  const entries = Object.entries(byCategory).toSorted((a, b) => b[1] - a[1]);
+  const max = entries[0]?.[1] ?? 1;
+  return (
+    <section className="stats-section">
+      <h3 className="stats-section-title">カテゴリ別 (累計)</h3>
+      <div className="stats-bar-list">
+        {entries.map(([cat, count]) => (
+          <BarRow key={cat} label={cat} count={count} maxCount={max} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function StatsDashboard() {
+  const [stats, setStats] = useState<Stats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    void (async () => {
+      try {
+        const res = await fetch("/api/stats");
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = (await res.json()) as Stats;
+        if (alive) {
+          setStats(data);
+          setLoading(false);
+        }
+      } catch (err) {
+        if (alive) {
+          setError(err instanceof Error ? err.message : String(err));
+          setLoading(false);
+        }
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  if (loading) return <div className="loader">読み込み中…</div>;
+  if (error) return <div className="error">エラー: {error}</div>;
+  if (!stats) return null;
+
+  // PR #148 で追加されたフィールドにフォールバック
+  const articles24h = stats.articles_24h ?? stats.last24h;
+  const articles7d = stats.articles_7d ?? 0;
+  const articles30d = stats.articles_30d ?? 0;
+  const totalArticles = stats.total;
+
+  return (
+    <div className="stats-dashboard">
+      {/* サマリカード */}
+      <div className="stats-cards">
+        <SummaryCard label="総記事数" value={totalArticles} />
+        <SummaryCard label="直近 24h" value={articles24h} />
+        <SummaryCard label="直近 7 日" value={articles7d} />
+        <SummaryCard label="直近 30 日" value={articles30d} />
+      </div>
+
+      {stats.top_authors_30d && stats.top_authors_30d.length > 0 && (
+        <AuthorsSection authors={stats.top_authors_30d} />
+      )}
+
+      {stats.top_publishers_30d && stats.top_publishers_30d.length > 0 && (
+        <PublishersSection publishers={stats.top_publishers_30d} />
+      )}
+
+      {stats.by_lang_30d && Object.keys(stats.by_lang_30d).length > 0 && (
+        <LangSection byLang={stats.by_lang_30d} />
+      )}
+
+      {stats.by_category && Object.keys(stats.by_category).length > 0 && (
+        <CategorySection byCategory={stats.by_category} />
+      )}
+    </div>
+  );
+}

--- a/apps/web/client/hooks/useStats.ts
+++ b/apps/web/client/hooks/useStats.ts
@@ -23,6 +23,17 @@ export interface FeedActivity {
   last_published_at: string | null;
 }
 
+export interface AuthorCount {
+  author: string;
+  count: number;
+}
+
+export interface PublisherCount {
+  feed_id: string;
+  name: string;
+  count: number;
+}
+
 export interface Stats {
   total: number;
   last_published_at: string | null;
@@ -33,6 +44,13 @@ export interface Stats {
   stale_feeds: StaleFeed[];
   category_trend_30d: TrendPoint[];
   feed_activity: FeedActivity[];
+  // PR #148 で追加されたフィールド
+  articles_24h?: number;
+  articles_7d?: number;
+  articles_30d?: number;
+  top_authors_30d?: AuthorCount[];
+  top_publishers_30d?: PublisherCount[];
+  by_lang_30d?: Record<string, number>;
 }
 
 export function useStats(refreshSignal: number = 0) {

--- a/apps/web/client/index.css
+++ b/apps/web/client/index.css
@@ -1008,3 +1008,115 @@ kbd {
   background: var(--bg-elev-2);
   color: var(--fg);
 }
+
+/* ヘッダーナビ (Articles | Stats) */
+.app-nav {
+  display: flex;
+  gap: 4px;
+}
+
+.app-nav-tab {
+  padding: 4px 12px;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  color: var(--fg-muted);
+  font-size: 0.9rem;
+  font-family: inherit;
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    color 0.15s;
+}
+
+.app-nav-tab:hover {
+  background: var(--bg-elev-2);
+  color: var(--fg);
+}
+
+.app-nav-tab.active {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+/* 統計ダッシュボード */
+.stats-dashboard {
+  padding: 16px 0;
+}
+
+.stats-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.stats-card {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px;
+  text-align: center;
+}
+
+.stats-card-label {
+  font-size: 0.8rem;
+  color: var(--fg-muted);
+  margin-bottom: 6px;
+}
+
+.stats-card-value {
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: var(--fg);
+}
+
+.stats-section {
+  margin-bottom: 24px;
+}
+
+.stats-section-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--fg-muted);
+  margin: 0 0 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.stats-bar-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.stats-bar-row {
+  display: grid;
+  grid-template-columns: 160px 1fr 60px;
+  align-items: center;
+  gap: 8px;
+}
+
+.stats-bar-label {
+  font-size: 0.85rem;
+  color: var(--fg);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.stats-bar {
+  height: 14px;
+  background: var(--accent);
+  border-radius: 3px;
+  min-width: 2px;
+  transition: width 0.3s ease;
+}
+
+.stats-bar-count {
+  font-size: 0.8rem;
+  color: var(--fg-muted);
+  text-align: right;
+}

--- a/apps/web/tests/client/StatsDashboard.test.tsx
+++ b/apps/web/tests/client/StatsDashboard.test.tsx
@@ -1,0 +1,157 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { StatsDashboard } from "../../client/components/StatsDashboard";
+
+const MOCK_STATS_RESPONSE = {
+  total: 1234,
+  last24h: 42,
+  last7d: 210,
+  last30d: 800,
+  total_articles: 1234,
+  articles_24h: 42,
+  articles_7d: 210,
+  articles_30d: 800,
+  last_published_at: "2026-04-28T10:00:00Z",
+  last_fetched_at: "2026-04-28T11:00:00Z",
+  by_category: { bigtech: 300, ai: 250, jp: 200, zenn: 150 },
+  by_lang_30d: { ja: 500, en: 300 },
+  top_authors_30d: [
+    { author: "Alice", count: 30 },
+    { author: "Bob", count: 25 },
+    { author: "Charlie", count: 20 },
+    { author: "Dave", count: 15 },
+    { author: "Eve", count: 12 },
+    { author: "Frank", count: 10 },
+    { author: "Grace", count: 9 },
+    { author: "Heidi", count: 8 },
+    { author: "Ivan", count: 7 },
+    { author: "Judy", count: 6 },
+  ],
+  top_publishers_30d: [
+    { feed_id: "feed-a", name: "Feed A", count: 100 },
+    { feed_id: "feed-b", name: "Feed B", count: 80 },
+    { feed_id: "feed-c", name: "Feed C", count: 60 },
+  ],
+  stale_feeds: [],
+  by_category_full: {},
+  category_trend_30d: [],
+  feed_activity: [],
+};
+
+function mockFetchSuccess() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(MOCK_STATS_RESPONSE),
+    }),
+  );
+}
+
+function mockFetchError() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+    }),
+  );
+}
+
+describe("StatsDashboard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("loading 状態を表示する", () => {
+    // fetch が pending のまま
+    vi.stubGlobal("fetch", vi.fn().mockReturnValue(new Promise(() => {})));
+    render(<StatsDashboard />);
+    expect(screen.getByText(/読み込み中/)).toBeTruthy();
+  });
+
+  it("エラー時にエラーメッセージを表示する", async () => {
+    mockFetchError();
+    render(<StatsDashboard />);
+    const err = await screen.findByText(/エラー/);
+    expect(err).toBeTruthy();
+  });
+
+  it("サマリカードに total_articles が表示される", async () => {
+    mockFetchSuccess();
+    render(<StatsDashboard />);
+    await screen.findByText("1,234");
+  });
+
+  it("サマリカードに articles_24h が表示される", async () => {
+    mockFetchSuccess();
+    render(<StatsDashboard />);
+    await screen.findByText("42");
+  });
+
+  it("サマリカードに articles_7d が表示される", async () => {
+    mockFetchSuccess();
+    render(<StatsDashboard />);
+    await screen.findByText("210");
+  });
+
+  it("サマリカードに articles_30d が表示される", async () => {
+    mockFetchSuccess();
+    render(<StatsDashboard />);
+    await screen.findByText("800");
+  });
+
+  it("top_authors_30d が上位 10 件表示される", async () => {
+    mockFetchSuccess();
+    render(<StatsDashboard />);
+    await screen.findByText("Alice");
+    expect(screen.getByText("Bob")).toBeTruthy();
+    expect(screen.getByText("Judy")).toBeTruthy();
+  });
+
+  it("top_authors のバーに aria-label が設定される", async () => {
+    mockFetchSuccess();
+    render(<StatsDashboard />);
+    await screen.findByText("Alice");
+    const bar = screen.getByRole("img", { name: /Alice.*30/ });
+    expect(bar).toBeTruthy();
+  });
+
+  it("top_publishers_30d が表示される", async () => {
+    mockFetchSuccess();
+    render(<StatsDashboard />);
+    await screen.findByText("Feed A");
+    expect(screen.getByText("Feed B")).toBeTruthy();
+    expect(screen.getByText("Feed C")).toBeTruthy();
+  });
+
+  it("by_lang_30d の ja と en バーが表示される", async () => {
+    mockFetchSuccess();
+    render(<StatsDashboard />);
+    await screen.findByText("ja");
+    expect(screen.getByText("en")).toBeTruthy();
+  });
+
+  it("by_lang バーの aria-label に件数が含まれる", async () => {
+    mockFetchSuccess();
+    render(<StatsDashboard />);
+    // ja: 500件 のバー
+    const jaBar = await screen.findByRole("img", { name: /ja.*500/ });
+    expect(jaBar).toBeTruthy();
+    const enBar = screen.getByRole("img", { name: /en.*300/ });
+    expect(enBar).toBeTruthy();
+  });
+
+  it("by_category が表示される", async () => {
+    mockFetchSuccess();
+    render(<StatsDashboard />);
+    await screen.findByText("bigtech");
+    expect(screen.getByText("ai")).toBeTruthy();
+    expect(screen.getByText("jp")).toBeTruthy();
+    expect(screen.getByText("zenn")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

- ヘッダーに Articles | Stats タブナビを追加 (URL /stats で切替、ブラウザ戻る/進む対応)
- StatsDashboard コンポーネントを新規作成し、PR #148 で追加された /api/stats の新フィールドを可視化
- チャートライブラリ追加なし (CSS バー)
- useStats.ts の Stats 型に新フィールドを追加
- StatsDashboard.test.tsx を新規作成 (13 テスト)

## Test plan
- vp check pass (lint / format / typecheck)
- vp test run pass (299 tests, 21 files)
- CI green 確認

Closes #161