### PR TITLE
feat(admin): add GET /api/admin/cron-health for collector metrics

### DIFF
--- a/apps/web/tests/worker/api/admin-cron-health.test.ts
+++ b/apps/web/tests/worker/api/admin-cron-health.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it } from "vite-plus/test";
+import { env, SELF } from "cloudflare:test";
+import { finishRun, recordRunFeed, startRun } from "../../../worker/db/runs";
+
+const AUTH_HEADER = { authorization: "Bearer test-admin-token" };
+
+// ダミー run を挿入するヘルパー
+async function insertRun(
+  startedAt: string,
+  completedAt: string | null,
+  articlesInserted: number,
+  error?: string,
+): Promise<number> {
+  const { run_id } = await startRun(env.DB, startedAt, 2);
+  if (completedAt !== null) {
+    await finishRun(
+      env.DB,
+      run_id,
+      completedAt,
+      error ? 0 : 2,
+      error ? 1 : 0,
+      articlesInserted,
+      error,
+    );
+  }
+  return run_id;
+}
+
+// 7 日以内の日時文字列を生成する
+function daysAgo(days: number): string {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+beforeEach(async () => {
+  // setup.ts の beforeEach で reset + applyD1Migrations が実行される
+});
+
+describe("GET /api/admin/cron-health", () => {
+  it("401: token なし → 401", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/cron-health");
+    expect(res.status).toBe(401);
+  });
+
+  it("401: 不正 token → 401", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/cron-health", {
+      headers: { authorization: "Bearer wrong-token" },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("400: days=99 → 400", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/cron-health?days=99", {
+      headers: AUTH_HEADER,
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/days must be 7 or 30/);
+  });
+
+  it("400: days=0 → 400", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/cron-health?days=0", {
+      headers: AUTH_HEADER,
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("200: データなし → ゼロ値を返す", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/cron-health", {
+      headers: AUTH_HEADER,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      window_days: number;
+      runs_total: number;
+      runs_succeeded: number;
+      runs_failed: number;
+      articles_collected: number;
+      top_failing_feeds: unknown[];
+    };
+    expect(body.window_days).toBe(7);
+    expect(body.runs_total).toBe(0);
+    expect(body.runs_succeeded).toBe(0);
+    expect(body.runs_failed).toBe(0);
+    expect(body.articles_collected).toBe(0);
+    expect(Array.isArray(body.top_failing_feeds)).toBe(true);
+    expect(body.top_failing_feeds).toHaveLength(0);
+  });
+
+  it("200: runs_total / runs_succeeded / runs_failed のカウントが正しい", async () => {
+    // 成功 run × 2
+    await insertRun(daysAgo(1), daysAgo(1), 5);
+    await insertRun(daysAgo(2), daysAgo(2), 3);
+    // 失敗 run × 1
+    await insertRun(daysAgo(3), daysAgo(3), 0, "connection error");
+
+    const res = await SELF.fetch("https://example.com/api/admin/cron-health?days=7", {
+      headers: AUTH_HEADER,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      runs_total: number;
+      runs_succeeded: number;
+      runs_failed: number;
+      articles_collected: number;
+    };
+    expect(body.runs_total).toBe(3);
+    expect(body.runs_succeeded).toBe(2);
+    expect(body.runs_failed).toBe(1);
+    expect(body.articles_collected).toBe(8);
+  });
+
+  it("200: top_failing_feeds が failures 降順", async () => {
+    const run1 = await insertRun(daysAgo(1), daysAgo(1), 0, "err");
+    await recordRunFeed(env.DB, run1, "feed-a", "failed", 0, 100, "err");
+    await recordRunFeed(env.DB, run1, "feed-b", "failed", 0, 100, "err");
+
+    const run2 = await insertRun(daysAgo(2), daysAgo(2), 0, "err");
+    await recordRunFeed(env.DB, run2, "feed-a", "failed", 0, 100, "err");
+
+    const res = await SELF.fetch("https://example.com/api/admin/cron-health?days=7", {
+      headers: AUTH_HEADER,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      top_failing_feeds: { feed_id: string; failures: number }[];
+    };
+    // feed-a (failures=2) が feed-b (failures=1) より先
+    expect(body.top_failing_feeds.length).toBeGreaterThanOrEqual(2);
+    expect(body.top_failing_feeds[0].feed_id).toBe("feed-a");
+    expect(body.top_failing_feeds[0].failures).toBe(2);
+    expect(body.top_failing_feeds[1].feed_id).toBe("feed-b");
+    expect(body.top_failing_feeds[1].failures).toBe(1);
+  });
+
+  it("200: days=7 で古いデータは含まれない", async () => {
+    // 8 日前のデータ (7 日ウィンドウには含まれないはず)
+    await insertRun(daysAgo(8), daysAgo(8), 10);
+
+    const res = await SELF.fetch("https://example.com/api/admin/cron-health?days=7", {
+      headers: AUTH_HEADER,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { runs_total: number };
+    expect(body.runs_total).toBe(0);
+  });
+
+  it("200: days=30 で 8 日前のデータが含まれる", async () => {
+    // 8 日前のデータ (30 日ウィンドウには含まれる)
+    await insertRun(daysAgo(8), daysAgo(8), 5);
+
+    const res = await SELF.fetch("https://example.com/api/admin/cron-health?days=30", {
+      headers: AUTH_HEADER,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { runs_total: number; window_days: number };
+    expect(body.window_days).toBe(30);
+    expect(body.runs_total).toBe(1);
+  });
+
+  it("200: Cache-Control ヘッダが private, max-age=60 を含む", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/cron-health", {
+      headers: AUTH_HEADER,
+    });
+    expect(res.status).toBe(200);
+    const cacheControl = res.headers.get("cache-control") ?? "";
+    expect(cacheControl).toContain("private");
+    expect(cacheControl).toContain("max-age=60");
+  });
+});

--- a/apps/web/worker/api/admin.ts
+++ b/apps/web/worker/api/admin.ts
@@ -3,7 +3,7 @@ import type { Env } from "../types";
 import { collectAll, collectFeeds } from "../collector";
 import { loadAllFeeds } from "../feed-config";
 import { setFeedEnabled } from "../db/feeds";
-import { getRun, listRuns, startRun } from "../db/runs";
+import { getCronHealth, getFeedFailures, getRun, listRuns, startRun } from "../db/runs";
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -237,6 +237,34 @@ app.get("/runs/:id", async (c) => {
     return c.json({ error: "not found" }, 404);
   }
   return c.json(detail);
+});
+
+app.get("/cron-health", async (c) => {
+  const current = c.env.ADMIN_TOKEN;
+  const next = c.env.ADMIN_TOKEN_NEXT;
+  if (!current) {
+    return c.json({ error: "ADMIN_TOKEN is not configured" }, 503);
+  }
+  const auth = c.req.header("authorization") ?? "";
+  const token = auth.replace(/^Bearer\s+/i, "");
+  if (!token || !isValidAdminToken(token, current, next)) {
+    return c.json({ error: "unauthorized" }, 401);
+  }
+
+  const daysParam = c.req.query("days") ?? "7";
+  const daysNum = Number(daysParam);
+  if (daysNum !== 7 && daysNum !== 30) {
+    return c.json({ error: "days must be 7 or 30" }, 400);
+  }
+  const days = daysNum as 7 | 30;
+
+  const [health, topFailingFeeds] = await Promise.all([
+    getCronHealth(c.env.DB, days),
+    getFeedFailures(c.env.DB, days, 10),
+  ]);
+
+  c.header("Cache-Control", "private, max-age=60");
+  return c.json({ ...health, top_failing_feeds: topFailingFeeds });
 });
 
 export default app;

--- a/apps/web/worker/db/runs.ts
+++ b/apps/web/worker/db/runs.ts
@@ -107,6 +107,93 @@ export async function listRuns(db: D1Database, limit = 20): Promise<RunRow[]> {
   return result.results ?? [];
 }
 
+interface CronHealthRow {
+  runs_total: number;
+  runs_succeeded: number;
+  runs_failed: number;
+  avg_run_ms: number | null;
+  articles_collected: number;
+}
+
+interface FeedFailureRow {
+  feed_id: string;
+  failures: number;
+  successes: number;
+  last_error: string | null;
+  last_attempted_at: string | null;
+}
+
+// collector_runs を集計して運用メトリクスを返す。1 クエリで完結させ D1 CPU を節約する。
+export async function getCronHealth(
+  db: D1Database,
+  days: 7 | 30,
+): Promise<{
+  window_days: number;
+  runs_total: number;
+  runs_succeeded: number;
+  runs_failed: number;
+  avg_run_ms: number | null;
+  articles_collected: number;
+}> {
+  const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+  const row = await db
+    .prepare(
+      `SELECT
+         COUNT(*) AS runs_total,
+         SUM(CASE WHEN completed_at IS NOT NULL AND (error IS NULL OR error = '') THEN 1 ELSE 0 END) AS runs_succeeded,
+         SUM(CASE WHEN error IS NOT NULL AND error != '' THEN 1 ELSE 0 END) AS runs_failed,
+         AVG(
+           CASE
+             WHEN completed_at IS NOT NULL
+             THEN CAST((julianday(completed_at) - julianday(started_at)) * 86400000 AS INTEGER)
+           END
+         ) AS avg_run_ms,
+         SUM(COALESCE(articles_inserted, 0)) AS articles_collected
+       FROM collector_runs
+       WHERE started_at >= ?1`,
+    )
+    .bind(since)
+    .first<CronHealthRow>();
+
+  return {
+    window_days: days,
+    runs_total: row?.runs_total ?? 0,
+    runs_succeeded: row?.runs_succeeded ?? 0,
+    runs_failed: row?.runs_failed ?? 0,
+    avg_run_ms: row?.avg_run_ms ?? null,
+    articles_collected: row?.articles_collected ?? 0,
+  };
+}
+
+// 指定期間内で失敗の多いフィードを返す。failures 降順、successes 昇順で上位 N 件を返す。
+export async function getFeedFailures(
+  db: D1Database,
+  days: 7 | 30,
+  limit: number,
+): Promise<FeedFailureRow[]> {
+  const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+  const safeLimit = Math.min(Math.max(limit, 1), 100);
+  const result = await db
+    .prepare(
+      `SELECT
+         crf.feed_id,
+         SUM(CASE WHEN crf.status = 'failed' THEN 1 ELSE 0 END) AS failures,
+         SUM(CASE WHEN crf.status = 'ok' THEN 1 ELSE 0 END) AS successes,
+         MAX(CASE WHEN crf.status = 'failed' THEN crf.error END) AS last_error,
+         MAX(cr.started_at) AS last_attempted_at
+       FROM collector_run_feeds crf
+       JOIN collector_runs cr ON cr.id = crf.run_id
+       WHERE cr.started_at >= ?1
+       GROUP BY crf.feed_id
+       HAVING failures > 0
+       ORDER BY failures DESC, successes ASC
+       LIMIT ?2`,
+    )
+    .bind(since, safeLimit)
+    .all<FeedFailureRow>();
+  return result.results ?? [];
+}
+
 export async function getRun(
   db: D1Database,
   run_id: number,

--- a/apps/web/worker/types.ts
+++ b/apps/web/worker/types.ts
@@ -102,3 +102,21 @@ export interface FeedHealth {
   consecutive_failures: number;
   articles_last_7d: number;
 }
+
+export interface CronHealth {
+  window_days: number;
+  runs_total: number;
+  runs_succeeded: number;
+  runs_failed: number;
+  avg_run_ms: number | null;
+  articles_collected: number;
+  top_failing_feeds: FeedFailure[];
+}
+
+export interface FeedFailure {
+  feed_id: string;
+  failures: number;
+  successes: number;
+  last_error: string | null;
+  last_attempted_at: string | null;
+}


### PR DESCRIPTION
## Summary

- `db/runs.ts` に `getCronHealth` (1クエリ集計) と `getFeedFailures` (失敗フィード一覧) helper を追加
- `api/admin.ts` に `GET /api/admin/cron-health?days=7|30` endpoint を追加 (ADMIN_TOKEN 必須、400 on invalid days、`Cache-Control: private, max-age=60`)
- `types.ts` に `CronHealth` / `FeedFailure` インターフェースを追加
- `admin-cron-health.test.ts` 新規: 401 / 400 / 200、カウント精度、failures 降順、7 vs 30 日フィルタを検証

## Test plan

- [ ] 401 (token なし / 不正 token)
- [ ] 400 (days=99, days=0)
- [ ] 200 データなし → ゼロ値
- [ ] 200 runs_total / runs_succeeded / runs_failed カウント正確性
- [ ] 200 top_failing_feeds が failures 降順
- [ ] 200 7 日ウィンドウで 8 日前データを除外
- [ ] 200 30 日ウィンドウで 8 日前データを含む
- [ ] Cache-Control: private, max-age=60

Closes #165

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin API endpoint for monitoring cron job health, including operational metrics (total runs, succeeded/failed counts, average runtime duration, articles collected) and top failing feed statistics.
  * Endpoint supports configurable time windows (7 or 30 days) with token-based authorization and response caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->