### PR TITLE
feat(api): GET /api/articles/by-author/:author で著者別記事一覧

### DIFF
--- a/apps/web/tests/worker/api/articles.test.ts
+++ b/apps/web/tests/worker/api/articles.test.ts
@@ -755,3 +755,159 @@ describe("GET /api/articles/:guid/neighbors", () => {
     expect(res.headers.get("Content-Type")).toMatch(/application\/json/);
   });
 });
+
+describe("GET /api/articles/by-author/:author", () => {
+  it("returns 200 with articles for a known author", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/by-author/Author%20A");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ articles: { author: string }[]; next_cursor: string | null }>();
+    expect(Array.isArray(body.articles)).toBe(true);
+    expect(body.articles.length).toBe(1);
+    expect(body.articles[0].author).toBe("Author A");
+    expect(body.next_cursor).toBeNull();
+  });
+
+  it("returns 200 with empty array when author has no articles", async () => {
+    const res = await SELF.fetch(
+      "https://example.com/api/articles/by-author/NonExistentAuthor",
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json<{ articles: unknown[]; next_cursor: string | null }>();
+    expect(body.articles).toEqual([]);
+    expect(body.next_cursor).toBeNull();
+  });
+
+  it("returns 400 when limit=0", async () => {
+    const res = await SELF.fetch(
+      "https://example.com/api/articles/by-author/Author%20A?limit=0",
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toMatch(/limit/);
+  });
+
+  it("returns 400 when limit=51", async () => {
+    const res = await SELF.fetch(
+      "https://example.com/api/articles/by-author/Author%20A?limit=51",
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toMatch(/limit/);
+  });
+
+  it("returns 400 when limit is non-numeric", async () => {
+    const res = await SELF.fetch(
+      "https://example.com/api/articles/by-author/Author%20A?limit=abc",
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toMatch(/limit/);
+  });
+
+  it("returns 400 when cursor is malformed", async () => {
+    const res = await SELF.fetch(
+      "https://example.com/api/articles/by-author/Author%20A?cursor=not-valid-base64!!!",
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toMatch(/cursor/);
+  });
+
+  it("decodes URL-encoded author name (space)", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/by-author/Author%20A");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ articles: { author: string }[] }>();
+    expect(body.articles.length).toBeGreaterThan(0);
+    expect(body.articles[0].author).toBe("Author A");
+  });
+
+  it("returns articles in published_at DESC order", async () => {
+    // Author B に 2 件目を追加して順序確認
+    await insertArticles(env.DB, [
+      {
+        guid: "o-ai-10",
+        feed_id: "openai-blog",
+        title: "Author B Older",
+        url: "https://x.test/o/10",
+        summary: null,
+        author: "Author B",
+        published_at: "2024-03-01T00:00:00.000Z",
+        category: "ai",
+        lang: "en",
+      },
+    ]);
+    const res = await SELF.fetch("https://example.com/api/articles/by-author/Author%20B");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ articles: { published_at: string }[] }>();
+    expect(body.articles.length).toBe(2);
+    // published_at DESC: 2024-04-02 が先
+    expect(body.articles[0].published_at > body.articles[1].published_at).toBe(true);
+  });
+
+  it("paginates with cursor: first page + second page", async () => {
+    // Author C に追加で 2 件挿入して合計 3 件にする
+    await insertArticles(env.DB, [
+      {
+        guid: "o-ai-11",
+        feed_id: "openai-blog",
+        title: "Author C Second",
+        url: "https://x.test/o/11",
+        summary: null,
+        author: "Author C",
+        published_at: "2024-04-02T00:00:00.000Z",
+        category: "ai",
+        lang: "en",
+      },
+      {
+        guid: "o-ai-12",
+        feed_id: "openai-blog",
+        title: "Author C Third",
+        url: "https://x.test/o/12",
+        summary: null,
+        author: "Author C",
+        published_at: "2024-04-01T00:00:00.000Z",
+        category: "ai",
+        lang: "en",
+      },
+    ]);
+
+    // 1 ページ目: limit=2
+    const res1 = await SELF.fetch(
+      "https://example.com/api/articles/by-author/Author%20C?limit=2",
+    );
+    expect(res1.status).toBe(200);
+    const body1 = await res1.json<{
+      articles: { guid: string }[];
+      next_cursor: string | null;
+    }>();
+    expect(body1.articles.length).toBe(2);
+    expect(body1.next_cursor).not.toBeNull();
+
+    // 2 ページ目: cursor を使用
+    const res2 = await SELF.fetch(
+      `https://example.com/api/articles/by-author/Author%20C?limit=2&cursor=${body1.next_cursor}`,
+    );
+    expect(res2.status).toBe(200);
+    const body2 = await res2.json<{
+      articles: { guid: string }[];
+      next_cursor: string | null;
+    }>();
+    expect(body2.articles.length).toBe(1);
+    expect(body2.next_cursor).toBeNull();
+
+    // 2 ページ合わせて全 guid が揃うことを確認
+    const allGuids = [
+      ...body1.articles.map((a) => a.guid),
+      ...body2.articles.map((a) => a.guid),
+    ];
+    expect(allGuids).toContain("o-ai-2");
+    expect(allGuids).toContain("o-ai-11");
+    expect(allGuids).toContain("o-ai-12");
+  });
+
+  it("returns Cache-Control: public, max-age=300", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/by-author/Author%20A");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=300");
+  });
+});

--- a/apps/web/tests/worker/api/articles.test.ts
+++ b/apps/web/tests/worker/api/articles.test.ts
@@ -768,9 +768,7 @@ describe("GET /api/articles/by-author/:author", () => {
   });
 
   it("returns 200 with empty array when author has no articles", async () => {
-    const res = await SELF.fetch(
-      "https://example.com/api/articles/by-author/NonExistentAuthor",
-    );
+    const res = await SELF.fetch("https://example.com/api/articles/by-author/NonExistentAuthor");
     expect(res.status).toBe(200);
     const body = await res.json<{ articles: unknown[]; next_cursor: string | null }>();
     expect(body.articles).toEqual([]);
@@ -778,27 +776,21 @@ describe("GET /api/articles/by-author/:author", () => {
   });
 
   it("returns 400 when limit=0", async () => {
-    const res = await SELF.fetch(
-      "https://example.com/api/articles/by-author/Author%20A?limit=0",
-    );
+    const res = await SELF.fetch("https://example.com/api/articles/by-author/Author%20A?limit=0");
     expect(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
     expect(body.error).toMatch(/limit/);
   });
 
   it("returns 400 when limit=51", async () => {
-    const res = await SELF.fetch(
-      "https://example.com/api/articles/by-author/Author%20A?limit=51",
-    );
+    const res = await SELF.fetch("https://example.com/api/articles/by-author/Author%20A?limit=51");
     expect(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
     expect(body.error).toMatch(/limit/);
   });
 
   it("returns 400 when limit is non-numeric", async () => {
-    const res = await SELF.fetch(
-      "https://example.com/api/articles/by-author/Author%20A?limit=abc",
-    );
+    const res = await SELF.fetch("https://example.com/api/articles/by-author/Author%20A?limit=abc");
     expect(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
     expect(body.error).toMatch(/limit/);
@@ -872,9 +864,7 @@ describe("GET /api/articles/by-author/:author", () => {
     ]);
 
     // 1 ページ目: limit=2
-    const res1 = await SELF.fetch(
-      "https://example.com/api/articles/by-author/Author%20C?limit=2",
-    );
+    const res1 = await SELF.fetch("https://example.com/api/articles/by-author/Author%20C?limit=2");
     expect(res1.status).toBe(200);
     const body1 = await res1.json<{
       articles: { guid: string }[];
@@ -896,10 +886,7 @@ describe("GET /api/articles/by-author/:author", () => {
     expect(body2.next_cursor).toBeNull();
 
     // 2 ページ合わせて全 guid が揃うことを確認
-    const allGuids = [
-      ...body1.articles.map((a) => a.guid),
-      ...body2.articles.map((a) => a.guid),
-    ];
+    const allGuids = [...body1.articles.map((a) => a.guid), ...body2.articles.map((a) => a.guid)];
     expect(allGuids).toContain("o-ai-2");
     expect(allGuids).toContain("o-ai-11");
     expect(allGuids).toContain("o-ai-12");

--- a/apps/web/worker/api/articles.ts
+++ b/apps/web/worker/api/articles.ts
@@ -151,11 +151,9 @@ app.get("/by-author/:author", async (c) => {
 
   const result = await getArticlesByAuthor(c.env.DB, author, limitNum, cursor);
 
-  return c.json(
-    { articles: result.articles, next_cursor: encodeCursor(result.nextCursor) },
-    200,
-    { "Cache-Control": "public, max-age=300" },
-  );
+  return c.json({ articles: result.articles, next_cursor: encodeCursor(result.nextCursor) }, 200, {
+    "Cache-Control": "public, max-age=300",
+  });
 });
 
 app.get("/:guid/related", async (c) => {

--- a/apps/web/worker/api/articles.ts
+++ b/apps/web/worker/api/articles.ts
@@ -4,6 +4,7 @@ import { loadAllFeeds } from "../feed-config";
 import {
   countArticlesByMonth,
   getArticleById,
+  getArticlesByAuthor,
   getArticlesByMonth,
   getNeighbors,
   getRandomArticles,
@@ -130,6 +131,31 @@ app.get("/random", async (c) => {
 
   const articles = await getRandomArticles(c.env.DB, { n, category, lang, feedId });
   return c.json({ articles }, 200, { "Cache-Control": "no-store" });
+});
+
+app.get("/by-author/:author", async (c) => {
+  const authorRaw = c.req.param("author");
+  const author = decodeURIComponent(authorRaw);
+  if (!author) return c.json({ error: "author must not be empty" }, 400);
+
+  const limitRaw = c.req.query("limit") ?? "20";
+  const limitNum = Number(limitRaw);
+  if (!Number.isInteger(limitNum) || limitNum < 1 || limitNum > 50) {
+    return c.json({ error: "limit must be an integer between 1 and 50" }, 400);
+  }
+
+  const cursorRaw = c.req.query("cursor");
+  const cursor = decodeCursor(cursorRaw);
+  // cursor が指定されているのに decode に失敗した場合は 400
+  if (cursorRaw && !cursor) return c.json({ error: "invalid cursor" }, 400);
+
+  const result = await getArticlesByAuthor(c.env.DB, author, limitNum, cursor);
+
+  return c.json(
+    { articles: result.articles, next_cursor: encodeCursor(result.nextCursor) },
+    200,
+    { "Cache-Control": "public, max-age=300" },
+  );
 });
 
 app.get("/:guid/related", async (c) => {

--- a/apps/web/worker/db/articles.ts
+++ b/apps/web/worker/db/articles.ts
@@ -574,6 +574,56 @@ export async function countArticlesByMonth(
   return row?.c ?? 0;
 }
 
+export interface GetArticlesByAuthorResult {
+  articles: Article[];
+  nextCursor: { publishedAt: string; id: number } | null;
+}
+
+/** 著者名で記事を published_at DESC で取得。cursor は listArticles と同形式 */
+export async function getArticlesByAuthor(
+  db: D1Database,
+  author: string,
+  limit: number,
+  cursor: { publishedAt: string; id: number } | null,
+): Promise<GetArticlesByAuthorResult> {
+  const conds: string[] = [`a.author = ?1`];
+  const binds: unknown[] = [author];
+
+  if (cursor) {
+    conds.push(
+      `(a.published_at < ?${binds.length + 1} OR (a.published_at = ?${binds.length + 1} AND a.id < ?${binds.length + 2}))`,
+    );
+    binds.push(cursor.publishedAt, cursor.id);
+  }
+
+  const where = `WHERE ${conds.join(" AND ")}`;
+  const sql = `
+    SELECT a.id, a.guid, a.feed_id, f.name AS feed_name, a.title, a.url, a.summary,
+           a.author, a.published_at, a.fetched_at, a.category, a.lang
+    FROM articles a
+    LEFT JOIN feeds f ON f.id = a.feed_id
+    ${where}
+    ORDER BY a.published_at DESC, a.id DESC
+    LIMIT ?${binds.length + 1}
+  `;
+  binds.push(limit + 1);
+
+  const result = await db
+    .prepare(sql)
+    .bind(...binds)
+    .all<Article>();
+
+  const rows = result.results ?? [];
+  let nextCursor: { publishedAt: string; id: number } | null = null;
+  let articles = rows;
+  if (rows.length > limit) {
+    articles = rows.slice(0, limit);
+    const last = articles[articles.length - 1];
+    nextCursor = { publishedAt: last.published_at, id: last.id };
+  }
+  return { articles, nextCursor };
+}
+
 function escapeFtsQuery(input: string): string {
   // FTS5 で安全に扱うため、特殊記号を除去して各単語をフレーズ扱いにする
   const tokens = input


### PR DESCRIPTION
## Summary

- `GET /api/articles/by-author/:author` endpoint を追加
- DB 層に `getArticlesByAuthor()` を追加 (existing `listArticles` と同じ base64 JSON cursor 方式)
- ルート登録順序を `random → by-author/:author → /:guid/related → /archive → /:id` に調整し、静的セグメントが動的パラメータより先になるよう配置

## Test plan

- [ ] 200: 著者記事あり / なし (空配列) の確認
- [ ] 400: limit=0, limit=51, limit=非数値, 不正 cursor の確認
- [ ] URL encode された著者名 (スペース含む) のデコード確認
- [ ] published_at DESC 順の確認
- [ ] cursor pagination (1ページ目 + 2ページ目) の確認
- [ ] Cache-Control: public, max-age=300 の確認
- [ ] `pnpm check` (lint/fmt/typecheck) pass
- [ ] `pnpm test` (299 tests) pass

Closes #168