### PR TITLE
feat(spa): add /feed/:id feed detail page

### DIFF
--- a/apps/web/client/App.tsx
+++ b/apps/web/client/App.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ArticleList } from "./components/ArticleList";
+import { FeedDetail } from "./components/FeedDetail";
 import { FilterBar } from "./components/FilterBar";
 import { type AppView, Header } from "./components/Header";
 import { PresetBar } from "./components/PresetBar";
@@ -78,12 +79,21 @@ function buildSearch(
   return s ? `?${s}` : window.location.pathname;
 }
 
+/** /feed/<id> パスを解析してフィード詳細ページの feedId を返す。それ以外は null。*/
+function readFeedDetailFromPath(): string | null {
+  const m = window.location.pathname.match(/^\/feed\/(.+)$/);
+  return m ? decodeURIComponent(m[1]) : null;
+}
+
 function readViewFromUrl(): AppView {
-  return window.location.pathname === "/stats" ? "stats" : "articles";
+  if (window.location.pathname === "/stats") return "stats";
+  if (readFeedDetailFromPath() !== null) return "feed";
+  return "articles";
 }
 
 function AppInner() {
   const [view, setView] = useState<AppView>(readViewFromUrl);
+  const [feedDetailId, setFeedDetailId] = useState<string>(() => readFeedDetailFromPath() ?? "");
   const [urlFilters, setUrlFilters] = useUrlState();
   const { q, category, lang, bookmarksOnly: bookmarkedOnly } = urlFilters;
   const [feedId, setFeedId] = useState<string>(() => readFromUrl().feedId);
@@ -108,6 +118,7 @@ function AppInner() {
 
   const handleViewChange = useCallback((next: AppView) => {
     setView(next);
+    setFeedDetailId("");
     const path = next === "stats" ? "/stats" : "/";
     if (window.location.pathname !== path) {
       window.history.pushState(null, "", path);
@@ -118,13 +129,19 @@ function AppInner() {
   // feedId/dateFrom/dateTo/unreadOnly/starredOnly はこちらで処理)
   useEffect(() => {
     const onPop = () => {
+      const nextView = readViewFromUrl();
+      setView(nextView);
+      if (nextView === "feed") {
+        setFeedDetailId(readFeedDetailFromPath() ?? "");
+        return;
+      }
+      setFeedDetailId("");
       const next = readFromUrl();
       setFeedId(next.feedId);
       setDateFrom(next.dateFrom);
       setDateTo(next.dateTo);
       setUnreadOnly(next.unreadOnly);
       setStarredOnly(next.starredOnly);
-      setView(readViewFromUrl());
     };
     window.addEventListener("popstate", onPop);
     return () => window.removeEventListener("popstate", onPop);
@@ -300,10 +317,19 @@ function AppInner() {
     [pushFilter, lang, q, dateFrom, dateTo, unreadOnly, starredOnly],
   );
 
-  const handleFilterByFeedId = useCallback(
-    (id: string) => pushFilter(category, lang, id, q, dateFrom, dateTo, unreadOnly, starredOnly),
-    [pushFilter, category, lang, q, dateFrom, dateTo, unreadOnly, starredOnly],
-  );
+  // 記事カードの取得元クリックでフィード詳細へ drill-down する
+  const handleGoToFeedDetail = useCallback((id: string) => {
+    window.history.pushState(null, "", `/feed/${encodeURIComponent(id)}`);
+    setView("feed");
+    setFeedDetailId(id);
+  }, []);
+
+  const handleBackFromFeedDetail = useCallback(() => {
+    window.history.pushState(null, "", "/");
+    window.dispatchEvent(new PopStateEvent("popstate"));
+    setView("articles");
+    setFeedDetailId("");
+  }, []);
 
   const query = useMemo(
     () => ({
@@ -395,6 +421,13 @@ function AppInner() {
 
       {view === "stats" ? (
         <StatsDashboard />
+      ) : view === "feed" && feedDetailId ? (
+        <FeedDetail
+          feedId={feedDetailId}
+          onBack={handleBackFromFeedDetail}
+          onFilterByFeedId={handleGoToFeedDetail}
+          onFilterByCategory={handleFilterByCategory}
+        />
       ) : (
         <>
           <header className="header">
@@ -498,7 +531,7 @@ function AppInner() {
               articles={articles}
               selectedIndex={selectedIndex}
               onFilterByCategory={handleFilterByCategory}
-              onFilterByFeedId={handleFilterByFeedId}
+              onFilterByFeedId={handleGoToFeedDetail}
               q={q}
             />
           )}

--- a/apps/web/client/components/FeedDetail.tsx
+++ b/apps/web/client/components/FeedDetail.tsx
@@ -1,0 +1,92 @@
+import { useFeedDetail } from "../hooks/useFeedDetail";
+import type { FeedCategory } from "../types/api";
+import { ArticleCard } from "./ArticleCard";
+
+const CATEGORY_LABEL: Record<string, string> = {
+  bigtech: "Big Tech",
+  ai: "AI",
+  jp: "日本企業",
+  zenn: "Zenn",
+};
+
+interface Props {
+  feedId: string;
+  onBack: () => void;
+  onFilterByFeedId: (id: string) => void;
+  onFilterByCategory: (c: FeedCategory) => void;
+}
+
+export function FeedDetail({ feedId, onBack, onFilterByFeedId, onFilterByCategory }: Props) {
+  const { feed, articles, isLoading, error } = useFeedDetail(feedId);
+
+  if (isLoading) {
+    return <div className="loader">読み込み中…</div>;
+  }
+
+  if (error === "feed_not_found") {
+    return (
+      <div className="feed-detail">
+        <button type="button" className="feed-detail-back" onClick={onBack}>
+          ← 一覧に戻る
+        </button>
+        <div className="error">フィードが見つかりません</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="feed-detail">
+        <button type="button" className="feed-detail-back" onClick={onBack}>
+          ← 一覧に戻る
+        </button>
+        <div className="error">取得エラー: {error}</div>
+      </div>
+    );
+  }
+
+  if (!feed) return null;
+
+  return (
+    <div className="feed-detail">
+      <button type="button" className="feed-detail-back" onClick={onBack}>
+        ← 一覧に戻る
+      </button>
+
+      <section className="feed-detail-info">
+        <h2 className="feed-detail-name">{feed.name}</h2>
+        <div className="feed-detail-meta">
+          <a href={feed.url} target="_blank" rel="noopener noreferrer" className="feed-detail-url">
+            {feed.url}
+          </a>
+          <span className={`badge cat-${feed.category}`}>
+            {CATEGORY_LABEL[feed.category] ?? feed.category}
+          </span>
+          <span className="feed-detail-lang">{feed.lang.toUpperCase()}</span>
+        </div>
+        <div className="feed-detail-stats">
+          <span className="feed-detail-stat-label">30 日の記事数:</span>
+          <span className="feed-detail-stat-value">{feed.articles_30d}</span>
+        </div>
+      </section>
+
+      <section className="feed-detail-articles">
+        <h3 className="feed-detail-articles-title">直近の記事</h3>
+        {articles.length === 0 ? (
+          <div className="empty">記事がありません</div>
+        ) : (
+          <div className="article-list">
+            {articles.map((a) => (
+              <ArticleCard
+                key={a.id}
+                article={a}
+                onFilterByCategory={onFilterByCategory}
+                onFilterByFeedId={onFilterByFeedId}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/web/client/components/Header.tsx
+++ b/apps/web/client/components/Header.tsx
@@ -1,6 +1,7 @@
 import { useTheme } from "../hooks/useTheme";
 
-export type AppView = "articles" | "stats";
+// "feed" は /feed/:id のフィード詳細ページで使用。nav タブには載せない
+export type AppView = "articles" | "stats" | "feed";
 
 interface HeaderProps {
   view?: AppView;
@@ -64,9 +65,9 @@ export function Header({ view, onViewChange }: HeaderProps) {
         <nav className="app-nav" aria-label="ページ切替">
           <button
             type="button"
-            className={`app-nav-tab${view === "articles" || !view ? " active" : ""}`}
+            className={`app-nav-tab${view === "articles" ? " active" : ""}`}
             onClick={() => onViewChange("articles")}
-            aria-current={view === "articles" || !view ? "page" : undefined}
+            aria-current={view === "articles" ? "page" : undefined}
           >
             Articles
           </button>

--- a/apps/web/client/hooks/useFeedDetail.ts
+++ b/apps/web/client/hooks/useFeedDetail.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from "react";
+import type { Article, FeedDetail, FeedDetailResponse } from "../types/api";
+
+interface UseFeedDetailResult {
+  feed: FeedDetail | null;
+  articles: Article[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+export function useFeedDetail(feedId: string): UseFeedDetailResult {
+  const [feed, setFeed] = useState<FeedDetail | null>(null);
+  const [articles, setArticles] = useState<Article[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    setIsLoading(true);
+    setError(null);
+    setFeed(null);
+    setArticles([]);
+
+    void (async () => {
+      try {
+        const res = await fetch(`/api/feeds/${feedId}?recent=20`);
+        if (!res.ok) {
+          // 404 は専用メッセージで区別する
+          const msg = res.status === 404 ? "feed_not_found" : `HTTP ${res.status}`;
+          if (alive) setError(msg);
+          return;
+        }
+        const data = (await res.json()) as FeedDetailResponse;
+        if (alive) {
+          setFeed(data.feed);
+          setArticles(data.recent_articles);
+        }
+      } catch (err) {
+        if (alive) setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        if (alive) setIsLoading(false);
+      }
+    })();
+
+    return () => {
+      alive = false;
+    };
+  }, [feedId]);
+
+  return { feed, articles, isLoading, error };
+}

--- a/apps/web/client/index.css
+++ b/apps/web/client/index.css
@@ -1009,114 +1009,79 @@ kbd {
   color: var(--fg);
 }
 
-/* ヘッダーナビ (Articles | Stats) */
-.app-nav {
-  display: flex;
-  gap: 4px;
+/* フィード詳細ページ */
+.feed-detail {
+  padding: 8px 0;
 }
 
-.app-nav-tab {
-  padding: 4px 12px;
+.feed-detail-back {
   background: none;
-  border: 1px solid transparent;
-  border-radius: 6px;
-  color: var(--fg-muted);
-  font-size: 0.9rem;
-  font-family: inherit;
-  cursor: pointer;
-  transition:
-    background 0.15s,
-    color 0.15s;
-}
-
-.app-nav-tab:hover {
-  background: var(--bg-elev-2);
-  color: var(--fg);
-}
-
-.app-nav-tab.active {
-  background: var(--accent-soft);
-  border-color: var(--accent);
+  border: none;
   color: var(--accent);
-  font-weight: 600;
+  cursor: pointer;
+  font-size: 0.9rem;
+  padding: 4px 0;
+  margin-bottom: 16px;
+  font-family: inherit;
 }
 
-/* 統計ダッシュボード */
-.stats-dashboard {
-  padding: 16px 0;
+.feed-detail-back:hover {
+  text-decoration: underline;
 }
 
-.stats-cards {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-  gap: 12px;
-  margin-bottom: 24px;
-}
-
-.stats-card {
+.feed-detail-info {
   background: var(--bg-elev);
   border: 1px solid var(--border);
   border-radius: 8px;
   padding: 16px;
-  text-align: center;
-}
-
-.stats-card-label {
-  font-size: 0.8rem;
-  color: var(--fg-muted);
-  margin-bottom: 6px;
-}
-
-.stats-card-value {
-  font-size: 1.6rem;
-  font-weight: 700;
-  color: var(--fg);
-}
-
-.stats-section {
   margin-bottom: 24px;
 }
 
-.stats-section-title {
-  font-size: 0.95rem;
-  font-weight: 600;
-  color: var(--fg-muted);
-  margin: 0 0 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
+.feed-detail-name {
+  margin: 0 0 8px;
+  font-size: 1.2rem;
 }
 
-.stats-bar-list {
+.feed-detail-meta {
   display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.stats-bar-row {
-  display: grid;
-  grid-template-columns: 160px 1fr 60px;
   align-items: center;
   gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
 }
 
-.stats-bar-label {
+.feed-detail-url {
   font-size: 0.85rem;
-  color: var(--fg);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  word-break: break-all;
 }
 
-.stats-bar {
-  height: 14px;
-  background: var(--accent);
-  border-radius: 3px;
-  min-width: 2px;
-  transition: width 0.3s ease;
-}
-
-.stats-bar-count {
-  font-size: 0.8rem;
+.feed-detail-lang {
+  font-size: 0.75rem;
+  background: var(--bg-elev-2);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 1px 6px;
   color: var(--fg-muted);
-  text-align: right;
+}
+
+.feed-detail-stats {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.9rem;
+}
+
+.feed-detail-stat-label {
+  color: var(--fg-muted);
+}
+
+.feed-detail-stat-value {
+  font-weight: 600;
+}
+
+.feed-detail-articles-title {
+  font-size: 1rem;
+  margin: 0 0 12px;
+  color: var(--fg-muted);
+  font-weight: 500;
 }

--- a/apps/web/client/types/api.ts
+++ b/apps/web/client/types/api.ts
@@ -37,3 +37,19 @@ export interface FeedsResponse {
   feeds: FeedSummary[];
   nextCursor: string | null;
 }
+
+export interface FeedDetail {
+  id: string;
+  name: string;
+  url: string;
+  category: FeedCategory;
+  lang: FeedLang;
+  enabled: boolean;
+  articles_30d: number;
+  last_published_at: string | null;
+}
+
+export interface FeedDetailResponse {
+  feed: FeedDetail;
+  recent_articles: Article[];
+}

--- a/apps/web/tests/client/FeedDetail.test.tsx
+++ b/apps/web/tests/client/FeedDetail.test.tsx
@@ -1,0 +1,225 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import type { Article, FeedDetailResponse } from "../../client/types/api";
+
+// dynamic import で ESM の副作用（localStorage アクセス等）を各テスト前に初期化する
+const { FeedDetail } = await import("../../client/components/FeedDetail");
+
+const baseFeedResponse: FeedDetailResponse = {
+  feed: {
+    id: "test-feed",
+    name: "Test Feed",
+    url: "https://example.com/feed",
+    category: "ai",
+    lang: "en",
+    enabled: true,
+    articles_30d: 42,
+    last_published_at: "2024-01-15T10:00:00Z",
+  },
+  recent_articles: [],
+};
+
+const makeArticle = (id: number): Article => ({
+  id,
+  guid: `guid-${id}`,
+  feed_id: "test-feed",
+  feed_name: "Test Feed",
+  title: `Article ${id}`,
+  url: `https://example.com/article/${id}`,
+  summary: `Summary ${id}`,
+  author: "Author",
+  published_at: "2024-01-15T10:00:00Z",
+  fetched_at: "2024-01-15T11:00:00Z",
+  category: "ai",
+  lang: "en",
+});
+
+describe("FeedDetail", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("ローディング中は読み込み中テキストを表示する", () => {
+    // fetch を pending のままにして loading 状態を維持する
+    globalThis.fetch = vi.fn<() => Promise<Response>>(() => new Promise(() => {}));
+    render(
+      <FeedDetail
+        feedId="test-feed"
+        onBack={() => {}}
+        onFilterByFeedId={() => {}}
+        onFilterByCategory={() => {}}
+      />,
+    );
+    expect(screen.getByText("読み込み中…")).toBeTruthy();
+  });
+
+  it("フィード名・URL・articles_30d を表示する", async () => {
+    globalThis.fetch = vi.fn<() => Promise<Response>>().mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(baseFeedResponse),
+    } as unknown as Response);
+
+    render(
+      <FeedDetail
+        feedId="test-feed"
+        onBack={() => {}}
+        onFilterByFeedId={() => {}}
+        onFilterByCategory={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Test Feed")).toBeTruthy();
+    });
+
+    expect(screen.getByText("https://example.com/feed")).toBeTruthy();
+    expect(screen.getByText("42")).toBeTruthy();
+  });
+
+  it("記事 5 件の場合に 5 枚のカードが表示される", async () => {
+    const articles = Array.from({ length: 5 }, (_, i) => makeArticle(i + 1));
+    globalThis.fetch = vi.fn<() => Promise<Response>>().mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ ...baseFeedResponse, recent_articles: articles }),
+    } as unknown as Response);
+
+    render(
+      <FeedDetail
+        feedId="test-feed"
+        onBack={() => {}}
+        onFilterByFeedId={() => {}}
+        onFilterByCategory={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Test Feed")).toBeTruthy();
+    });
+
+    for (let i = 1; i <= 5; i++) {
+      expect(screen.getByText(`Article ${i}`)).toBeTruthy();
+    }
+  });
+
+  it("記事 0 件のとき空状態メッセージを表示する", async () => {
+    globalThis.fetch = vi.fn<() => Promise<Response>>().mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ ...baseFeedResponse, recent_articles: [] }),
+    } as unknown as Response);
+
+    render(
+      <FeedDetail
+        feedId="test-feed"
+        onBack={() => {}}
+        onFilterByFeedId={() => {}}
+        onFilterByCategory={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("記事がありません")).toBeTruthy();
+    });
+  });
+
+  it("404 エラーのとき「フィードが見つかりません」を表示する", async () => {
+    globalThis.fetch = vi.fn<() => Promise<Response>>().mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+    } as unknown as Response);
+
+    render(
+      <FeedDetail
+        feedId="unknown-feed"
+        onBack={() => {}}
+        onFilterByFeedId={() => {}}
+        onFilterByCategory={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("フィードが見つかりません")).toBeTruthy();
+    });
+  });
+
+  it("「← 一覧に戻る」ボタンクリックで onBack が呼ばれる", async () => {
+    globalThis.fetch = vi.fn<() => Promise<Response>>().mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(baseFeedResponse),
+    } as unknown as Response);
+
+    const onBack = vi.fn<() => void>();
+    render(
+      <FeedDetail
+        feedId="test-feed"
+        onBack={onBack}
+        onFilterByFeedId={() => {}}
+        onFilterByCategory={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Test Feed")).toBeTruthy();
+    });
+
+    const backButton = screen.getByText("← 一覧に戻る");
+    const user = userEvent.setup();
+    await user.click(backButton);
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("feedId が変わると再 fetch する", async () => {
+    const fetchMock = vi.fn<() => Promise<Response>>();
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(baseFeedResponse),
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            ...baseFeedResponse,
+            feed: { ...baseFeedResponse.feed, id: "other-feed", name: "Other Feed" },
+          }),
+      } as unknown as Response);
+    globalThis.fetch = fetchMock;
+
+    const { rerender } = render(
+      <FeedDetail
+        feedId="test-feed"
+        onBack={() => {}}
+        onFilterByFeedId={() => {}}
+        onFilterByCategory={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Test Feed")).toBeTruthy();
+    });
+
+    rerender(
+      <FeedDetail
+        feedId="other-feed"
+        onBack={() => {}}
+        onFilterByFeedId={() => {}}
+        onFilterByCategory={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Other Feed")).toBeTruthy();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(1, "/api/feeds/test-feed?recent=20");
+    expect(fetchMock).toHaveBeenNthCalledWith(2, "/api/feeds/other-feed?recent=20");
+  });
+});

--- a/apps/web/tests/client/FeedDetail.test.tsx
+++ b/apps/web/tests/client/FeedDetail.test.tsx
@@ -100,8 +100,9 @@ describe("FeedDetail", () => {
       />,
     );
 
+    // フィード名は h2 として表示されるため role で絞り込む
     await waitFor(() => {
-      expect(screen.getByText("Test Feed")).toBeTruthy();
+      expect(screen.getByRole("heading", { name: "Test Feed" })).toBeTruthy();
     });
 
     for (let i = 1; i <= 5; i++) {
@@ -166,7 +167,7 @@ describe("FeedDetail", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("Test Feed")).toBeTruthy();
+      expect(screen.getByRole("heading", { name: "Test Feed" })).toBeTruthy();
     });
 
     const backButton = screen.getByText("← 一覧に戻る");
@@ -202,7 +203,7 @@ describe("FeedDetail", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("Test Feed")).toBeTruthy();
+      expect(screen.getByRole("heading", { name: "Test Feed" })).toBeTruthy();
     });
 
     rerender(
@@ -215,7 +216,7 @@ describe("FeedDetail", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("Other Feed")).toBeTruthy();
+      expect(screen.getByRole("heading", { name: "Other Feed" })).toBeTruthy();
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
## Summary

- SPA に /feed/:id ルートを追加し、フィード詳細ページを実装
- 記事カードの取得元クリックで /feed/:id へ drill-down するナビゲーション
- GET /api/feeds/:id?recent=20 を fetch する useFeedDetail hook 新規追加
- フィード情報（名前・URL・カテゴリ・言語・30日記事数）と直近20件の記事カードを表示
- ブラウザの戻る/進む（popstate）に対応
- 7件のテストケースを FeedDetail.test.tsx に追加

## Test plan

- vp check pass (lint + fmt + typecheck)
- vp test run pass (299 tests)
- pnpm build pass

Closes #167