### PR TITLE
feat(api): add GET /api/categories for per-category summary

### DIFF
--- a/apps/web/tests/worker/api/categories.test.ts
+++ b/apps/web/tests/worker/api/categories.test.ts
@@ -1,0 +1,219 @@
+import { beforeEach, describe, expect, it } from "vite-plus/test";
+import { env, SELF } from "cloudflare:test";
+import { insertArticles } from "../../../worker/db/articles";
+import { syncFeeds } from "../../../worker/db/feeds";
+import type { FeedCategory, FeedConfig } from "../../../worker/types";
+
+const ALL_CATEGORIES: FeedCategory[] = ["bigtech", "ai", "jp", "zenn"];
+
+const FEEDS: FeedConfig[] = [
+  {
+    id: "openai-blog",
+    name: "OpenAI Blog",
+    url: "https://x.test/openai",
+    category: "ai",
+    lang: "en",
+    enabled: true,
+  },
+  {
+    id: "anthropic-blog",
+    name: "Anthropic Blog",
+    url: "https://x.test/anthropic",
+    category: "ai",
+    lang: "en",
+    enabled: true,
+  },
+  {
+    id: "google-research",
+    name: "Google Research",
+    url: "https://x.test/google",
+    category: "bigtech",
+    lang: "en",
+    enabled: true,
+  },
+  {
+    id: "zenn-ai",
+    name: "Zenn AI",
+    url: "https://zenn.dev/topics/ai/feed",
+    category: "zenn",
+    lang: "ja",
+    enabled: true,
+  },
+  // jp カテゴリのフィードは投入しない (feeds_count=0 になる)
+];
+
+// 今日を基準に日付を計算するヘルパ
+function daysAgo(n: number): string {
+  return new Date(Date.now() - n * 24 * 60 * 60 * 1000).toISOString();
+}
+
+interface CategorySummary {
+  category: FeedCategory;
+  feeds_count: number;
+  articles_30d: number;
+  last_published_at: string | null;
+}
+
+interface CategoriesResponse {
+  categories: CategorySummary[];
+}
+
+describe("GET /api/categories - DB 空の場合", () => {
+  it("フィードを 1 件も登録しなくても 4 カテゴリ全て返る", async () => {
+    const res = await SELF.fetch("https://example.com/api/categories");
+    expect(res.status).toBe(200);
+    const body = await res.json<CategoriesResponse>();
+    expect(Array.isArray(body.categories)).toBe(true);
+    expect(body.categories).toHaveLength(4);
+
+    const cats = body.categories.map((c) => c.category).sort();
+    expect(cats).toEqual([...ALL_CATEGORIES].sort());
+  });
+
+  it("DB 空の場合は全カテゴリで feeds_count=0, articles_30d=0, last_published_at=null", async () => {
+    const res = await SELF.fetch("https://example.com/api/categories");
+    const body = await res.json<CategoriesResponse>();
+
+    for (const cat of body.categories) {
+      expect(cat.feeds_count).toBe(0);
+      expect(cat.articles_30d).toBe(0);
+      expect(cat.last_published_at).toBeNull();
+    }
+  });
+});
+
+describe("GET /api/categories - テストデータあり", () => {
+  beforeEach(async () => {
+    await syncFeeds(env.DB, FEEDS);
+
+    await insertArticles(env.DB, [
+      // ai カテゴリ: 30d 以内 2 件、31d 超 1 件
+      {
+        guid: "ai-1",
+        feed_id: "openai-blog",
+        title: "AI Article 1",
+        url: "https://x.test/ai/1",
+        summary: null,
+        author: null,
+        published_at: daysAgo(5),
+        category: "ai",
+        lang: "en",
+      },
+      {
+        guid: "ai-2",
+        feed_id: "anthropic-blog",
+        title: "AI Article 2",
+        url: "https://x.test/ai/2",
+        summary: null,
+        author: null,
+        published_at: daysAgo(20),
+        category: "ai",
+        lang: "en",
+      },
+      {
+        guid: "ai-3-old",
+        feed_id: "openai-blog",
+        title: "AI Article 3 (old)",
+        url: "https://x.test/ai/3",
+        summary: null,
+        author: null,
+        // 30d 窓外
+        published_at: daysAgo(31),
+        category: "ai",
+        lang: "en",
+      },
+      // bigtech カテゴリ: 30d 以内 1 件
+      {
+        guid: "bt-1",
+        feed_id: "google-research",
+        title: "BigTech Article 1",
+        url: "https://x.test/bt/1",
+        summary: null,
+        author: null,
+        published_at: daysAgo(10),
+        category: "bigtech",
+        lang: "en",
+      },
+      // zenn: 記事なし (articles_30d=0, last_published_at=null)
+    ]);
+  });
+
+  it("4 カテゴリ全てが返る", async () => {
+    const res = await SELF.fetch("https://example.com/api/categories");
+    expect(res.status).toBe(200);
+    const body = await res.json<CategoriesResponse>();
+    expect(body.categories).toHaveLength(4);
+
+    const cats = body.categories.map((c) => c.category).sort();
+    expect(cats).toEqual([...ALL_CATEGORIES].sort());
+  });
+
+  it("feeds_count が正しい (ai=2, bigtech=1, zenn=1, jp=0)", async () => {
+    const res = await SELF.fetch("https://example.com/api/categories");
+    const body = await res.json<CategoriesResponse>();
+
+    const byCategory = Object.fromEntries(body.categories.map((c) => [c.category, c]));
+    expect(byCategory["ai"]!.feeds_count).toBe(2);
+    expect(byCategory["bigtech"]!.feeds_count).toBe(1);
+    expect(byCategory["zenn"]!.feeds_count).toBe(1);
+    // jp フィードは登録していないので 0
+    expect(byCategory["jp"]!.feeds_count).toBe(0);
+  });
+
+  it("articles_30d は 30 日以内の記事のみカウント (31d 前の記事は含まれない)", async () => {
+    const res = await SELF.fetch("https://example.com/api/categories");
+    const body = await res.json<CategoriesResponse>();
+
+    const byCategory = Object.fromEntries(body.categories.map((c) => [c.category, c]));
+    // ai: daysAgo(5) + daysAgo(20) = 2件。daysAgo(31) は除外
+    expect(byCategory["ai"]!.articles_30d).toBe(2);
+    expect(byCategory["bigtech"]!.articles_30d).toBe(1);
+  });
+
+  it("articles_30d=0 のカテゴリは 0 で返る (jp と zenn)", async () => {
+    const res = await SELF.fetch("https://example.com/api/categories");
+    const body = await res.json<CategoriesResponse>();
+
+    const byCategory = Object.fromEntries(body.categories.map((c) => [c.category, c]));
+    expect(byCategory["jp"]!.articles_30d).toBe(0);
+    expect(byCategory["zenn"]!.articles_30d).toBe(0);
+  });
+
+  it("last_published_at は各カテゴリの MAX(published_at)", async () => {
+    const res = await SELF.fetch("https://example.com/api/categories");
+    const body = await res.json<CategoriesResponse>();
+
+    const byCategory = Object.fromEntries(body.categories.map((c) => [c.category, c]));
+
+    // ai: ai-1 (5d前) が最新
+    expect(byCategory["ai"]!.last_published_at).not.toBeNull();
+    const aiLatest = new Date(byCategory["ai"]!.last_published_at!);
+    const fiveDaysAgo = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000);
+    expect(aiLatest.getTime()).toBeGreaterThan(fiveDaysAgo.getTime() - 60_000);
+
+    // bigtech: bt-1 (10d前)
+    expect(byCategory["bigtech"]!.last_published_at).not.toBeNull();
+
+    // 記事なし -> null
+    expect(byCategory["jp"]!.last_published_at).toBeNull();
+    expect(byCategory["zenn"]!.last_published_at).toBeNull();
+  });
+
+  it("Cache-Control: public, max-age=300 が設定されている", async () => {
+    const res = await SELF.fetch("https://example.com/api/categories");
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=300");
+  });
+
+  it("Content-Type は application/json", async () => {
+    const res = await SELF.fetch("https://example.com/api/categories");
+    expect(res.headers.get("Content-Type")).toContain("application/json");
+  });
+
+  it("レスポンスは { categories: [...] } の形 (object でラップ)", async () => {
+    const res = await SELF.fetch("https://example.com/api/categories");
+    const body = await res.json<Record<string, unknown>>();
+    expect(typeof body).toBe("object");
+    expect("categories" in body).toBe(true);
+    expect(Array.isArray(body["categories"])).toBe(true);
+  });
+});

--- a/apps/web/worker/api/categories.ts
+++ b/apps/web/worker/api/categories.ts
@@ -1,0 +1,13 @@
+import { Hono } from "hono";
+import type { Env } from "../types";
+import { getCategoriesSummary } from "../db/feeds";
+
+const app = new Hono<{ Bindings: Env }>();
+
+app.get("/", async (c) => {
+  const categories = await getCategoriesSummary(c.env.DB);
+  c.header("Cache-Control", "public, max-age=300");
+  return c.json({ categories });
+});
+
+export default app;

--- a/apps/web/worker/api/router.ts
+++ b/apps/web/worker/api/router.ts
@@ -3,6 +3,7 @@ import { cors } from "hono/cors";
 import type { Context, Next } from "hono";
 import type { Env } from "../types";
 import articles from "./articles";
+import categories from "./categories";
 import feeds from "./feeds";
 import health from "./health";
 import stats from "./stats";
@@ -23,12 +24,13 @@ function allowedOriginsCors(c: Context<{ Bindings: Env }>, next: Next) {
   return cors({ origin: origins })(c, next);
 }
 
-const PUBLIC_PATHS = ["/articles/*", "/feeds/*", "/stats/*", "/health/*"] as const;
+const PUBLIC_PATHS = ["/articles/*", "/categories/*", "/feeds/*", "/stats/*", "/health/*"] as const;
 for (const path of PUBLIC_PATHS) {
   api.use(path, allowedOriginsCors);
 }
 
 api.route("/articles", articles);
+api.route("/categories", categories);
 api.route("/feeds", feeds);
 api.route("/health", health);
 api.route("/stats", stats);

--- a/apps/web/worker/db/feeds.ts
+++ b/apps/web/worker/db/feeds.ts
@@ -287,6 +287,65 @@ export async function findFeedWithStats(db: D1Database, id: string): Promise<Fee
   };
 }
 
+export interface CategorySummary {
+  category: "bigtech" | "ai" | "jp" | "zenn";
+  feeds_count: number;
+  articles_30d: number;
+  last_published_at: string | null;
+}
+
+const ALL_CATEGORIES: Array<"bigtech" | "ai" | "jp" | "zenn"> = ["bigtech", "ai", "jp", "zenn"];
+
+/**
+ * カテゴリ別のサマリを 1 クエリで取得する。
+ * feeds テーブルに articles を LEFT JOIN して GROUP BY category。
+ * D1 の結果に含まれないカテゴリ (フィード 0 件) は TS 側で 0 埋めして必ず 4 件返す。
+ */
+export async function getCategoriesSummary(db: D1Database): Promise<CategorySummary[]> {
+  const threshold = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+
+  const rows = await db
+    .prepare(
+      `SELECT f.category,
+              COUNT(DISTINCT f.id) AS feeds_count,
+              COUNT(CASE WHEN a.published_at >= ?1 THEN 1 END) AS articles_30d,
+              MAX(a.published_at) AS last_published_at
+       FROM feeds f
+       LEFT JOIN articles a ON a.feed_id = f.id
+       GROUP BY f.category`,
+    )
+    .bind(threshold)
+    .all<{
+      category: string;
+      feeds_count: number;
+      articles_30d: number;
+      last_published_at: string | null;
+    }>();
+
+  const dbMap = new Map(
+    (rows.results ?? []).map((r) => [
+      r.category,
+      {
+        category: r.category as CategorySummary["category"],
+        feeds_count: r.feeds_count,
+        articles_30d: r.articles_30d,
+        last_published_at: r.last_published_at,
+      },
+    ]),
+  );
+
+  // DB に存在しないカテゴリも 0 埋めして全 4 カテゴリを返す
+  return ALL_CATEGORIES.map(
+    (cat) =>
+      dbMap.get(cat) ?? {
+        category: cat,
+        feeds_count: 0,
+        articles_30d: 0,
+        last_published_at: null,
+      },
+  );
+}
+
 /**
  * 指定フィードの最近の記事を published_at 降順で返す。
  * db/articles.ts への変更を避けるため feeds.ts 内に定義。


### PR DESCRIPTION
## 概要

/api/categories エンドポイントを追加する。各カテゴリ (bigtech/ai/jp/zenn) のフィード数・30日以内の記事件数・最終公開日時を返す。

Closes #171

## 変更内容

- apps/web/worker/db/feeds.ts: getCategoriesSummary() 追加
- apps/web/worker/api/categories.ts: GET /api/categories 新規作成
- apps/web/worker/api/router.ts: /categories route 登録 + CORS 追加
- apps/web/tests/worker/api/categories.test.ts: 統合テスト追加

## テスト

- [x] 4 カテゴリ全てが返る (DB 空の場合も)
- [x] feeds_count / articles_30d / last_published_at 正確
- [x] 31d 前の記事は articles_30d に含まれない
- [x] Cache-Control: public, max-age=300
- [x] pnpm build && pnpm test (299 tests passed)
- [x] pnpm check pass