### PR TITLE
feat: /feeds/author/:author.{xml,json,atom} 著者別 syndication feed

### DIFF
--- a/apps/web/tests/worker/api/syndication.test.ts
+++ b/apps/web/tests/worker/api/syndication.test.ts
@@ -447,7 +447,7 @@ describe("/feeds/author/:author.xml (author RSS)", () => {
     expect(res.headers.get("Cache-Control")).toBe("public, max-age=600");
   });
 
-  it("returns ETag header matching W/\"hex16\" format", async () => {
+  it('returns ETag header matching W/"hex16" format', async () => {
     const res = await SELF.fetch("https://example.com/feeds/author/Sam.xml");
     const etag = res.headers.get("ETag");
     expect(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);

--- a/apps/web/tests/worker/api/syndication.test.ts
+++ b/apps/web/tests/worker/api/syndication.test.ts
@@ -407,3 +407,198 @@ describe("/feeds/category/:cat.atom", () => {
     expect(second.status).toBe(304);
   });
 });
+
+describe("/feeds/author/:author.xml (author RSS)", () => {
+  it("returns 200 with application/rss+xml and channel title", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/author/Sam.xml");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("application/rss+xml");
+    const text = await res.text();
+    expect(text.startsWith("<?xml")).toBe(true);
+    expect(text).toContain('<rss version="2.0"');
+    expect(text).toContain("<title>Sam - tech-news-bot</title>");
+    expect(text).toContain("g-ai");
+    expect(text).not.toContain("g-jp");
+    expect(text).not.toContain("g-bigtech");
+  });
+
+  it("returns 200 with empty feed for unknown author", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/author/UnknownPerson.xml");
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain('<rss version="2.0"');
+    // items が存在しないこと
+    expect(text).not.toContain("<item>");
+  });
+
+  it("decodes URL-encoded author name", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/author/Sam.xml");
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain("g-ai");
+
+    // URL エンコードされた名前でもデコードされて同じ結果を返す
+    // "Sam" に含まれる文字は特別なエンコードが不要だが、スペースを含む著者名をテスト
+    // beforeEach で "Author A" を追加してエンコードテストを行う
+  });
+
+  it("returns Cache-Control: public, max-age=600", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/author/Sam.xml");
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=600");
+  });
+
+  it("returns ETag header matching W/\"hex16\" format", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/author/Sam.xml");
+    const etag = res.headers.get("ETag");
+    expect(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
+  });
+
+  it("returns 304 on If-None-Match match (ETag round-trip)", async () => {
+    const res1 = await SELF.fetch("https://example.com/feeds/author/Sam.xml");
+    expect(res1.status).toBe(200);
+    const etag = res1.headers.get("ETag")!;
+
+    const res2 = await SELF.fetch("https://example.com/feeds/author/Sam.xml", {
+      headers: { "If-None-Match": etag },
+    });
+    expect(res2.status).toBe(304);
+    expect(res2.headers.get("ETag")).toBe(etag);
+  });
+
+  it("returns articles in published_at DESC order", async () => {
+    // beforeEach で Sam の記事は g-ai (2024-04-02) のみ
+    // 新たに Sam の記事を追加して順序を確認
+    await insertArticles(env.DB, [
+      {
+        guid: "g-sam-newer",
+        feed_id: "openai-blog",
+        title: "Sam Newer Article",
+        url: "https://x.test/o/sam-newer",
+        summary: null,
+        author: "Sam",
+        published_at: "2024-04-10T00:00:00.000Z",
+        category: "ai",
+        lang: "en",
+      },
+    ]);
+    const res = await SELF.fetch("https://example.com/feeds/author/Sam.xml");
+    const text = await res.text();
+    const pos1 = text.indexOf("g-sam-newer");
+    const pos2 = text.indexOf("g-ai");
+    // 新しい記事が先に出現する
+    expect(pos1).toBeLessThan(pos2);
+  });
+
+  it("returns at most 50 articles (limit test with 51 articles)", async () => {
+    // Sam の記事を 50 件追加 (beforeEach で g-ai が既に 1 件あるので計 51 件)
+    const extra = Array.from({ length: 50 }, (_, i) => ({
+      guid: `g-sam-extra-${i}`,
+      feed_id: "openai-blog" as const,
+      title: `Sam Extra ${i}`,
+      url: `https://x.test/o/sam-extra-${i}`,
+      summary: null,
+      author: "Sam",
+      published_at: new Date(Date.UTC(2024, 2, i + 1)).toISOString(),
+      category: "ai" as const,
+      lang: "en" as const,
+    }));
+    await insertArticles(env.DB, extra);
+
+    const res = await SELF.fetch("https://example.com/feeds/author/Sam.xml");
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    // <item> タグの数を数えて 50 件以下であることを確認
+    const itemCount = (text.match(/<item>/g) ?? []).length;
+    expect(itemCount).toBeLessThanOrEqual(50);
+    expect(itemCount).toBe(50);
+  });
+});
+
+describe("/feeds/author/:author.json (author JSON Feed)", () => {
+  it("returns 200 with application/feed+json and items array", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/author/Sam.json");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("application/feed+json");
+    const body = (await res.json()) as {
+      version: string;
+      title: string;
+      items: { id: string }[];
+    };
+    expect(body.version).toBe("https://jsonfeed.org/version/1.1");
+    expect(body.title).toBe("Sam - tech-news-bot");
+    expect(body.items.map((i) => i.id)).toContain("g-ai");
+  });
+
+  it("returns 200 with empty items for unknown author", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/author/NoSuchPerson.json");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { items: unknown[] };
+    expect(body.items).toEqual([]);
+  });
+
+  it("decodes URL-encoded author name (%20 → space)", async () => {
+    // "Author A" という著者を登録してエンコード URL でアクセス
+    await insertArticles(env.DB, [
+      {
+        guid: "g-author-a",
+        feed_id: "openai-blog",
+        title: "Article by Author A",
+        url: "https://x.test/o/author-a",
+        summary: null,
+        author: "Author A",
+        published_at: "2024-04-05T00:00:00.000Z",
+        category: "ai",
+        lang: "en",
+      },
+    ]);
+    const res = await SELF.fetch("https://example.com/feeds/author/Author%20A.json");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { title: string; items: { id: string }[] };
+    expect(body.title).toBe("Author A - tech-news-bot");
+    expect(body.items.map((i) => i.id)).toContain("g-author-a");
+  });
+
+  it("returns Cache-Control: public, max-age=600", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/author/Sam.json");
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=600");
+  });
+});
+
+describe("/feeds/author/:author.atom (author Atom)", () => {
+  it("returns 200 with application/atom+xml", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/author/Sam.atom");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("application/atom+xml");
+    const text = await res.text();
+    expect(text.startsWith("<?xml")).toBe(true);
+    expect(text).toContain('<feed xmlns="http://www.w3.org/2005/Atom">');
+    expect(text).toContain("<title>Sam - tech-news-bot</title>");
+    expect(text).toContain("g-ai");
+  });
+
+  it("returns 200 with empty feed for unknown author", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/author/Ghost.atom");
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain('<feed xmlns="http://www.w3.org/2005/Atom">');
+    // entry が存在しないこと
+    expect(text).not.toContain("<entry>");
+  });
+
+  it("returns Cache-Control: public, max-age=600", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/author/Sam.atom");
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=600");
+  });
+
+  it("returns ETag header and supports 304 round-trip", async () => {
+    const res1 = await SELF.fetch("https://example.com/feeds/author/Sam.atom");
+    expect(res1.status).toBe(200);
+    const etag = res1.headers.get("ETag")!;
+    expect(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
+
+    const res2 = await SELF.fetch("https://example.com/feeds/author/Sam.atom", {
+      headers: { "If-None-Match": etag },
+    });
+    expect(res2.status).toBe(304);
+  });
+});

--- a/apps/web/worker/api/syndication.ts
+++ b/apps/web/worker/api/syndication.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import type { Context } from "hono";
-import type { Env, FeedCategory, FeedLang, FeedsFile } from "../types";
+import type { Article, Env, FeedCategory, FeedLang, FeedsFile } from "../types";
 import { listArticles } from "../db/articles";
 import { computeSyndicationEtag } from "../utils/etag";
 import { loadAllFeeds } from "../feed-config";
@@ -298,6 +298,214 @@ app.get("/feeds/category/*", async (c) => {
   }
   return buildRssFeed(c, { category: cat, titleOverride });
 });
+
+// 著者別 syndication エンドポイント
+// /feeds/category/* と同様、/feeds/:filename より先に登録することで優先マッチさせる。
+// author は URL decode して大文字小文字を区別する完全一致で検索する。
+// 0 件でも 200 で空 feed を返す (RSS リーダーが定期 polling するため 404 にしない)。
+app.get("/feeds/author/*", async (c) => {
+  const pathname = new URL(c.req.url).pathname;
+  const basename = pathname.replace(/^.*\/feeds\/author\//, "");
+
+  let rawAuthor: string;
+  let format: "xml" | "json" | "atom";
+
+  if (basename.endsWith(".json")) {
+    rawAuthor = basename.slice(0, -5);
+    format = "json";
+  } else if (basename.endsWith(".xml")) {
+    rawAuthor = basename.slice(0, -4);
+    format = "xml";
+  } else if (basename.endsWith(".atom")) {
+    rawAuthor = basename.slice(0, -5);
+    format = "atom";
+  } else {
+    return c.json({ error: "Not Found" }, 404);
+  }
+
+  const author = decodeURIComponent(rawAuthor);
+  const titleOverride = `${author} - tech-news-bot`;
+
+  if (format === "json") {
+    return buildAuthorJsonFeed(c, author, titleOverride);
+  }
+  if (format === "atom") {
+    return buildAuthorAtomFeed(c, author, titleOverride);
+  }
+  return buildAuthorRssFeed(c, author, titleOverride);
+});
+
+// 著者別記事取得: db/articles.ts を変更せず syndication 層で直接クエリする
+async function fetchArticlesByAuthor(db: D1Database, author: string): Promise<Article[]> {
+  const result = await db
+    .prepare(
+      `SELECT a.id, a.guid, a.feed_id, f.name AS feed_name, a.title, a.url, a.summary,
+              a.author, a.published_at, a.fetched_at, a.category, a.lang
+       FROM articles a
+       LEFT JOIN feeds f ON f.id = a.feed_id
+       WHERE a.author = ?1
+       ORDER BY a.published_at DESC, a.id DESC
+       LIMIT ?2`,
+    )
+    .bind(author, FEED_LIMIT)
+    .all<Article>();
+  return result.results ?? [];
+}
+
+async function buildAuthorRssFeed(
+  c: Context<{ Bindings: Env }>,
+  author: string,
+  title: string,
+): Promise<Response> {
+  const etag = await computeSyndicationEtag(c.env.DB, FEEDS_VERSION, { author });
+  if (c.req.header("If-None-Match") === etag) {
+    c.header("ETag", etag);
+    c.header("Cache-Control", "public, max-age=600");
+    return c.body(null, 304);
+  }
+
+  const articles = await fetchArticlesByAuthor(c.env.DB, author);
+  const origin = siteOrigin(c.req.url);
+  const feedUrl = new URL(c.req.url).toString();
+  const lastBuild = articles[0]?.published_at ?? new Date().toISOString();
+  const description = `${author} の最新記事`;
+
+  const items = articles
+    .map((a) => {
+      const parts = [
+        `<item>`,
+        `<title>${escapeXml(a.title)}</title>`,
+        `<link>${escapeXml(a.url)}</link>`,
+        `<guid isPermaLink="false">${escapeXml(a.guid)}</guid>`,
+        `<pubDate>${toRfc822(a.published_at)}</pubDate>`,
+        `<category>${escapeXml(a.category)}</category>`,
+      ];
+      if (a.feed_name) parts.push(`<source>${escapeXml(a.feed_name)}</source>`);
+      if (a.author) parts.push(`<author>${escapeXml(a.author)}</author>`);
+      if (a.summary) parts.push(`<description>${escapeXml(a.summary)}</description>`);
+      parts.push(`</item>`);
+      return parts.join("");
+    })
+    .join("");
+
+  const xml =
+    `<?xml version="1.0" encoding="UTF-8"?>` +
+    `<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">` +
+    `<channel>` +
+    `<title>${escapeXml(title)}</title>` +
+    `<link>${escapeXml(origin)}</link>` +
+    `<description>${escapeXml(description)}</description>` +
+    `<lastBuildDate>${toRfc822(lastBuild)}</lastBuildDate>` +
+    `<atom:link href="${escapeXml(feedUrl)}" rel="self" type="application/rss+xml"/>` +
+    items +
+    `</channel></rss>`;
+
+  c.header("Content-Type", "application/rss+xml; charset=utf-8");
+  c.header("ETag", etag);
+  c.header("Cache-Control", "public, max-age=600");
+  return c.body(xml);
+}
+
+async function buildAuthorJsonFeed(
+  c: Context<{ Bindings: Env }>,
+  author: string,
+  title: string,
+): Promise<Response> {
+  const etag = await computeSyndicationEtag(c.env.DB, FEEDS_VERSION, { author });
+  if (c.req.header("If-None-Match") === etag) {
+    c.header("ETag", etag);
+    c.header("Cache-Control", "public, max-age=600");
+    return c.body(null, 304);
+  }
+
+  const articles = await fetchArticlesByAuthor(c.env.DB, author);
+  const origin = siteOrigin(c.req.url);
+  const feedUrl = new URL(c.req.url).toString();
+  const description = `${author} の最新記事`;
+
+  const json = {
+    version: "https://jsonfeed.org/version/1.1",
+    title,
+    description,
+    home_page_url: origin || undefined,
+    feed_url: feedUrl,
+    items: articles.map((a) => ({
+      id: a.guid,
+      url: a.url,
+      title: a.title,
+      content_text: a.summary ?? "",
+      summary: a.summary ?? undefined,
+      date_published: a.published_at,
+      authors: a.author ? [{ name: a.author }] : undefined,
+      tags: [a.category, a.lang, ...(a.feed_name ? [a.feed_name] : [])],
+      _feed_id: a.feed_id,
+    })),
+  };
+
+  c.header("Content-Type", "application/feed+json; charset=utf-8");
+  c.header("ETag", etag);
+  c.header("Cache-Control", "public, max-age=600");
+  return c.body(JSON.stringify(json));
+}
+
+async function buildAuthorAtomFeed(
+  c: Context<{ Bindings: Env }>,
+  author: string,
+  title: string,
+): Promise<Response> {
+  const etag = await computeSyndicationEtag(c.env.DB, FEEDS_VERSION, { author });
+  if (c.req.header("If-None-Match") === etag) {
+    c.header("ETag", etag);
+    c.header("Cache-Control", "public, max-age=600");
+    return c.body(null, 304);
+  }
+
+  const articles = await fetchArticlesByAuthor(c.env.DB, author);
+  const origin = siteOrigin(c.req.url);
+  const feedUrl = new URL(c.req.url).toString();
+  const feedPath = new URL(c.req.url).pathname;
+  const hostname = new URL(c.req.url).hostname || "example.com";
+  const year = new Date().getFullYear();
+  const description = `${author} の最新記事`;
+  const updated = articles[0]?.published_at ?? new Date().toISOString();
+
+  const entries = articles
+    .map((a) => {
+      const authorName = a.author ?? a.feed_name ?? "";
+      const parts = [
+        `<entry>`,
+        `<title>${escapeXml(a.title)}</title>`,
+        `<id>${escapeXml(a.guid)}</id>`,
+        `<link href="${escapeXml(a.url)}" rel="alternate"/>`,
+        `<updated>${a.published_at}</updated>`,
+        `<published>${a.published_at}</published>`,
+      ];
+      if (authorName) parts.push(`<author><name>${escapeXml(authorName)}</name></author>`);
+      parts.push(`<category term="${escapeXml(a.category)}"/>`);
+      if (a.summary) parts.push(`<summary type="html">${escapeXml(a.summary)}</summary>`);
+      parts.push(`</entry>`);
+      return parts.join("");
+    })
+    .join("");
+
+  const xml =
+    `<?xml version="1.0" encoding="utf-8"?>` +
+    `<feed xmlns="http://www.w3.org/2005/Atom">` +
+    `<title>${escapeXml(title)}</title>` +
+    `<subtitle>${escapeXml(description)}</subtitle>` +
+    `<link href="${escapeXml(origin)}/" rel="alternate"/>` +
+    `<link href="${escapeXml(feedUrl)}" rel="self"/>` +
+    `<id>tag:${escapeXml(hostname)},${year}:${escapeXml(feedPath)}</id>` +
+    `<updated>${updated}</updated>` +
+    `<generator uri="https://github.com/rikeda71/tech-news-bot">tech-news-bot</generator>` +
+    entries +
+    `</feed>`;
+
+  c.header("Content-Type", "application/atom+xml; charset=utf-8");
+  c.header("ETag", etag);
+  c.header("Cache-Control", "public, max-age=600");
+  return c.body(xml);
+}
 
 // per-feed エンドポイント: feeds.yaml に定義された id のみ受け付ける
 // enabled: false でも過去記事の履歴閲覧ができるよう全フィードを対象とする

--- a/apps/web/worker/utils/etag.ts
+++ b/apps/web/worker/utils/etag.ts
@@ -13,6 +13,7 @@ export interface SyndicationEtagParams {
   category?: FeedCategory;
   lang?: FeedLang;
   feedId?: string;
+  author?: string;
 }
 
 // MAX(published_at) を取るだけの軽量クエリでリビジョンを取得する
@@ -98,9 +99,18 @@ export async function computeSyndicationEtag(
     conditions.push(`feed_id = ?${binds.length + 1}`);
     binds.push(params.feedId);
   }
+  if (params.author) {
+    conditions.push(`author = ?${binds.length + 1}`);
+    binds.push(params.author);
+  }
 
   const maxPublished = await fetchMaxPublishedAt(db, conditions, binds);
-  const paramStr = [opt(params.category), opt(params.lang), opt(params.feedId)].join("|");
+  const paramStr = [
+    opt(params.category),
+    opt(params.lang),
+    opt(params.feedId),
+    opt(params.author),
+  ].join("|");
   const source = `${maxPublished}|v${feedsVersion}|${paramStr}`;
   const hash = await sha256Hex16(source);
   return `W/"${hash}"`;


### PR DESCRIPTION
## Summary

- `apps/web/worker/api/syndication.ts` に `/feeds/author/:author.xml`, `/feeds/author/:author.json`, `/feeds/author/:author.atom` エンドポイントを追加
- `apps/web/worker/utils/etag.ts` の `SyndicationEtagParams` に `author` フィールドを追加して著者別 ETag を生成
- テストを `apps/web/tests/worker/api/syndication.test.ts` に追加 (3 describe ブロック、合計 15 テスト)

## 実装詳細

- `fetchArticlesByAuthor()` を syndication.ts 内で定義し、`db/articles.ts` を変更せずに著者別クエリを実現
- `:author` は `decodeURIComponent` でデコード (例: `Author%20A` → `"Author A"`)
- 不明な著者でも 200 + 空 feed を返す (RSS リーダーが定期 polling するため 404 にしない)
- 直近 50 件 (FEED_LIMIT) を `published_at DESC` で取得
- `Cache-Control: public, max-age=600` (per-feed の 60 秒より長い TTL)
- ETag (SHA-256 truncated 16 hex chars) + 304 対応
- `/feeds/author/*` を `/feeds/:filename` より前に登録してルーティング優先順位を保証

## Test plan

- [x] `/feeds/author/Sam.xml` → 200 + `application/rss+xml` + `<channel><title>Sam - tech-news-bot</title>`
- [x] `/feeds/author/Sam.json` → 200 + `application/feed+json` + `items` 配列
- [x] `/feeds/author/Sam.atom` → 200 + `application/atom+xml`
- [x] 不明な author → 200 + 空 feed (`<item>` なし / `<entry>` なし / `items: []`)
- [x] URL エンコード済み著者名 (`Author%20A`) のデコード
- [x] 51 件投入時に上限 50 件が返ること
- [x] `published_at DESC` 順であること
- [x] `Cache-Control: public, max-age=600`
- [x] ETag ヘッダー + 304 ラウンドトリップ

Closes #173