### PR TITLE
feat(api): add GET /api/articles/calendar for daily article counts

### DIFF
--- a/apps/web/tests/worker/api/articles.test.ts
+++ b/apps/web/tests/worker/api/articles.test.ts
@@ -628,6 +628,227 @@ describe("GET /api/articles/:guid/related", () => {
   });
 });
 
+describe("GET /api/articles/calendar", () => {
+  it("returns 200 with empty items when no articles in range", async () => {
+    // beforeEach の記事は 2024-04 のため、days=30 (今から 30 日以内) では 0 件
+    const res = await SELF.fetch("https://example.com/api/articles/calendar?days=30");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ days: number; items: unknown[] }>();
+    expect(body.days).toBe(30);
+    expect(Array.isArray(body.items)).toBe(true);
+    // 2024-04 の記事は今から 30 日以内に含まれないので空
+    expect(body.items.length).toBe(0);
+  });
+
+  it("returns correct daily counts after inserting recent articles", async () => {
+    // 今日の日付 (UTC) で記事を挿入
+    const today = new Date();
+    const todayStr = today.toISOString().slice(0, 10);
+    const yesterday = new Date(today);
+    yesterday.setUTCDate(today.getUTCDate() - 1);
+    const yesterdayStr = yesterday.toISOString().slice(0, 10);
+
+    await insertArticles(env.DB, [
+      {
+        guid: "cal-today-1",
+        feed_id: "google-research",
+        title: "Calendar Today 1",
+        url: "https://x.test/g/cal-today-1",
+        summary: null,
+        author: null,
+        published_at: `${todayStr}T10:00:00.000Z`,
+        category: "bigtech",
+        lang: "en",
+      },
+      {
+        guid: "cal-today-2",
+        feed_id: "google-research",
+        title: "Calendar Today 2",
+        url: "https://x.test/g/cal-today-2",
+        summary: null,
+        author: null,
+        published_at: `${todayStr}T11:00:00.000Z`,
+        category: "bigtech",
+        lang: "en",
+      },
+      {
+        guid: "cal-yesterday-1",
+        feed_id: "openai-blog",
+        title: "Calendar Yesterday 1",
+        url: "https://x.test/o/cal-yesterday-1",
+        summary: null,
+        author: null,
+        published_at: `${yesterdayStr}T09:00:00.000Z`,
+        category: "ai",
+        lang: "en",
+      },
+    ]);
+
+    const res = await SELF.fetch("https://example.com/api/articles/calendar?days=7");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ days: number; items: { date: string; count: number }[] }>();
+    expect(body.days).toBe(7);
+
+    const todayItem = body.items.find((i) => i.date === todayStr);
+    const yesterdayItem = body.items.find((i) => i.date === yesterdayStr);
+    expect(todayItem?.count).toBe(2);
+    expect(yesterdayItem?.count).toBe(1);
+  });
+
+  it("items are sorted by date ASC", async () => {
+    const today = new Date();
+    const todayStr = today.toISOString().slice(0, 10);
+    const yesterday = new Date(today);
+    yesterday.setUTCDate(today.getUTCDate() - 1);
+    const yesterdayStr = yesterday.toISOString().slice(0, 10);
+
+    await insertArticles(env.DB, [
+      {
+        guid: "sort-today",
+        feed_id: "google-research",
+        title: "Sort Today",
+        url: "https://x.test/g/sort-today",
+        summary: null,
+        author: null,
+        published_at: `${todayStr}T10:00:00.000Z`,
+        category: "bigtech",
+        lang: "en",
+      },
+      {
+        guid: "sort-yesterday",
+        feed_id: "openai-blog",
+        title: "Sort Yesterday",
+        url: "https://x.test/o/sort-yesterday",
+        summary: null,
+        author: null,
+        published_at: `${yesterdayStr}T10:00:00.000Z`,
+        category: "ai",
+        lang: "en",
+      },
+    ]);
+
+    const res = await SELF.fetch("https://example.com/api/articles/calendar?days=7");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ items: { date: string; count: number }[] }>();
+    const dates = body.items.map((i) => i.date);
+    const sorted = dates.toSorted((a, b) => a.localeCompare(b));
+    expect(dates).toEqual(sorted);
+  });
+
+  it("filters by lang=ja", async () => {
+    const today = new Date();
+    const todayStr = today.toISOString().slice(0, 10);
+
+    await insertArticles(env.DB, [
+      {
+        guid: "cal-ja-1",
+        feed_id: "google-research",
+        title: "Japanese Article",
+        url: "https://x.test/g/cal-ja-1",
+        summary: null,
+        author: null,
+        published_at: `${todayStr}T10:00:00.000Z`,
+        category: "bigtech",
+        lang: "ja",
+      },
+      {
+        guid: "cal-en-1",
+        feed_id: "openai-blog",
+        title: "English Article",
+        url: "https://x.test/o/cal-en-1",
+        summary: null,
+        author: null,
+        published_at: `${todayStr}T11:00:00.000Z`,
+        category: "ai",
+        lang: "en",
+      },
+    ]);
+
+    const res = await SELF.fetch("https://example.com/api/articles/calendar?days=7&lang=ja");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ items: { date: string; count: number }[] }>();
+    const todayItem = body.items.find((i) => i.date === todayStr);
+    // ja のみ: 1 件
+    expect(todayItem?.count).toBe(1);
+    // en の記事は含まれないので total count は 1
+    const totalCount = body.items.reduce((s, i) => s + i.count, 0);
+    expect(totalCount).toBe(1);
+  });
+
+  it("filters by category=ai", async () => {
+    const today = new Date();
+    const todayStr = today.toISOString().slice(0, 10);
+
+    await insertArticles(env.DB, [
+      {
+        guid: "cal-ai-1",
+        feed_id: "openai-blog",
+        title: "AI Article Cal",
+        url: "https://x.test/o/cal-ai-1",
+        summary: null,
+        author: null,
+        published_at: `${todayStr}T10:00:00.000Z`,
+        category: "ai",
+        lang: "en",
+      },
+      {
+        guid: "cal-bt-1",
+        feed_id: "google-research",
+        title: "BigTech Article Cal",
+        url: "https://x.test/g/cal-bt-1",
+        summary: null,
+        author: null,
+        published_at: `${todayStr}T11:00:00.000Z`,
+        category: "bigtech",
+        lang: "en",
+      },
+    ]);
+
+    const res = await SELF.fetch("https://example.com/api/articles/calendar?days=7&category=ai");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ items: { date: string; count: number }[] }>();
+    const todayItem = body.items.find((i) => i.date === todayStr);
+    // ai のみ: 1 件
+    expect(todayItem?.count).toBe(1);
+    const totalCount = body.items.reduce((s, i) => s + i.count, 0);
+    expect(totalCount).toBe(1);
+  });
+
+  it("returns 400 for days=10 (not in allowed values)", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/calendar?days=10");
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toContain("days");
+  });
+
+  it("returns 400 for lang=fr (invalid)", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/calendar?lang=fr");
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toContain("lang");
+  });
+
+  it("returns 400 for category=invalid", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/calendar?category=invalid");
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toContain("category");
+  });
+
+  it("returns Cache-Control: public, max-age=600", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/calendar?days=30");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=600");
+  });
+
+  it("uses default days=30 when days is not specified", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/calendar");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ days: number; items: unknown[] }>();
+    expect(body.days).toBe(30);
+  });
+});
+
 describe("GET /api/articles/:guid/neighbors", () => {
   // beforeEach で挿入される記事:
   //   g-bt-1 (google-research, 2024-04-01)

--- a/apps/web/worker/api/articles.ts
+++ b/apps/web/worker/api/articles.ts
@@ -5,6 +5,7 @@ import {
   countArticlesByMonth,
   getArticleById,
   getArticlesByAuthor,
+  getArticlesCalendar,
   getArticlesByMonth,
   getNeighbors,
   getRandomArticles,
@@ -153,6 +154,34 @@ app.get("/by-author/:author", async (c) => {
 
   return c.json({ articles: result.articles, next_cursor: encodeCursor(result.nextCursor) }, 200, {
     "Cache-Control": "public, max-age=300",
+  });
+});
+
+const VALID_CALENDAR_DAYS = [7, 30, 90, 365] as const;
+
+app.get("/calendar", async (c) => {
+  const daysRaw = c.req.query("days") ?? "30";
+  const days = parseInt(daysRaw, 10);
+  if (isNaN(days) || !(VALID_CALENDAR_DAYS as readonly number[]).includes(days)) {
+    return c.json({ error: "days must be one of 7, 30, 90, 365" }, 400);
+  }
+
+  const categoryRaw = c.req.query("category");
+  if (categoryRaw !== undefined && !(VALID_CATEGORIES as string[]).includes(categoryRaw)) {
+    return c.json({ error: "invalid category" }, 400);
+  }
+  const category = categoryRaw as FeedCategory | undefined;
+
+  const langRaw = c.req.query("lang");
+  if (langRaw !== undefined && !(VALID_LANGS as string[]).includes(langRaw)) {
+    return c.json({ error: "invalid lang" }, 400);
+  }
+  const lang = langRaw as FeedLang | undefined;
+
+  const items = await getArticlesCalendar(c.env.DB, days, lang, category);
+
+  return c.json({ days, items }, 200, {
+    "Cache-Control": "public, max-age=600",
   });
 });
 

--- a/apps/web/worker/db/articles.ts
+++ b/apps/web/worker/db/articles.ts
@@ -624,6 +624,47 @@ export async function getArticlesByAuthor(
   return { articles, nextCursor };
 }
 
+export interface CalendarItem {
+  date: string;
+  count: number;
+}
+
+/** 指定日数分の日別記事数を返す。0 件の日は含まない */
+export async function getArticlesCalendar(
+  db: D1Database,
+  days: number,
+  lang?: FeedLang | null,
+  category?: FeedCategory | null,
+): Promise<CalendarItem[]> {
+  const conds: string[] = [`published_at >= datetime('now', ?1)`];
+  const binds: unknown[] = [`-${days} days`];
+
+  if (lang) {
+    conds.push(`lang = ?${binds.length + 1}`);
+    binds.push(lang);
+  }
+  if (category) {
+    conds.push(`category = ?${binds.length + 1}`);
+    binds.push(category);
+  }
+
+  const where = `WHERE ${conds.join(" AND ")}`;
+  const sql = `
+    SELECT strftime('%Y-%m-%d', published_at) AS date, COUNT(*) AS count
+    FROM articles
+    ${where}
+    GROUP BY strftime('%Y-%m-%d', published_at)
+    ORDER BY date ASC
+  `;
+
+  const result = await db
+    .prepare(sql)
+    .bind(...binds)
+    .all<CalendarItem>();
+
+  return result.results ?? [];
+}
+
 function escapeFtsQuery(input: string): string {
   // FTS5 で安全に扱うため、特殊記号を除去して各単語をフレーズ扱いにする
   const tokens = input


### PR DESCRIPTION
## Summary

- DB 層に `getArticlesCalendar(db, days, lang?, category?)` を追加 (`apps/web/worker/db/articles.ts`)
- API 層に `GET /api/articles/calendar` ルートを追加 (`apps/web/worker/api/articles.ts`)
  - `days`: 7 / 30 / 90 / 365 のみ、default 30。範囲外は 400
  - `lang` / `category` は任意フィルタ。不正値は 400
  - レスポンス: `{ days: number, items: [{ date: string, count: number }] }`
  - `Cache-Control: public, max-age=600`
- ルート登録順: `/random` → `/by-author/:author` → `/calendar` → `/:guid/related` → ...
- テスト 9 件追加: 200 / 400 / Cache-Control / date ASC / lang・category フィルタ

Closes #174

## Test plan

- [x] `pnpm build && pnpm test` (347 tests pass)
- [x] `pnpm check` — 既存の worktree 固有 warning (categories.test.ts の sort、worker-configuration.d.ts) は今回変更外