### PR TITLE
feat(spa): /author/:name の著者詳細ページを追加

### DIFF
--- a/apps/web/client/App.tsx
+++ b/apps/web/client/App.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ArticleList } from "./components/ArticleList";
+import { AuthorDetail } from "./components/AuthorDetail";
 import { FeedDetail } from "./components/FeedDetail";
 import { FilterBar } from "./components/FilterBar";
 import { type AppView, Header } from "./components/Header";
@@ -85,15 +86,23 @@ function readFeedDetailFromPath(): string | null {
   return m ? decodeURIComponent(m[1]) : null;
 }
 
+/** /author/<name> パスを解析して著者名を返す。それ以外は null。*/
+function readAuthorFromPath(): string | null {
+  const m = window.location.pathname.match(/^\/author\/(.+)$/);
+  return m ? decodeURIComponent(m[1]) : null;
+}
+
 function readViewFromUrl(): AppView {
   if (window.location.pathname === "/stats") return "stats";
   if (readFeedDetailFromPath() !== null) return "feed";
+  if (readAuthorFromPath() !== null) return "author";
   return "articles";
 }
 
 function AppInner() {
   const [view, setView] = useState<AppView>(readViewFromUrl);
   const [feedDetailId, setFeedDetailId] = useState<string>(() => readFeedDetailFromPath() ?? "");
+  const [authorName, setAuthorName] = useState<string>(() => readAuthorFromPath() ?? "");
   const [urlFilters, setUrlFilters] = useUrlState();
   const { q, category, lang, bookmarksOnly: bookmarkedOnly } = urlFilters;
   const [feedId, setFeedId] = useState<string>(() => readFromUrl().feedId);
@@ -119,6 +128,7 @@ function AppInner() {
   const handleViewChange = useCallback((next: AppView) => {
     setView(next);
     setFeedDetailId("");
+    setAuthorName("");
     const path = next === "stats" ? "/stats" : "/";
     if (window.location.pathname !== path) {
       window.history.pushState(null, "", path);
@@ -133,9 +143,16 @@ function AppInner() {
       setView(nextView);
       if (nextView === "feed") {
         setFeedDetailId(readFeedDetailFromPath() ?? "");
+        setAuthorName("");
+        return;
+      }
+      if (nextView === "author") {
+        setAuthorName(readAuthorFromPath() ?? "");
+        setFeedDetailId("");
         return;
       }
       setFeedDetailId("");
+      setAuthorName("");
       const next = readFromUrl();
       setFeedId(next.feedId);
       setDateFrom(next.dateFrom);
@@ -331,6 +348,19 @@ function AppInner() {
     setFeedDetailId("");
   }, []);
 
+  const handleGoToAuthorDetail = useCallback((name: string) => {
+    window.history.pushState(null, "", `/author/${encodeURIComponent(name)}`);
+    setView("author");
+    setAuthorName(name);
+  }, []);
+
+  const handleBackFromAuthorDetail = useCallback(() => {
+    window.history.pushState(null, "", "/");
+    window.dispatchEvent(new PopStateEvent("popstate"));
+    setView("articles");
+    setAuthorName("");
+  }, []);
+
   const query = useMemo(
     () => ({
       category: category || undefined,
@@ -420,13 +450,20 @@ function AppInner() {
       <ShortcutsHelp open={helpOpen} onClose={() => setHelpOpen(false)} />
 
       {view === "stats" ? (
-        <StatsDashboard />
+        <StatsDashboard onNavigateToAuthor={handleGoToAuthorDetail} />
       ) : view === "feed" && feedDetailId ? (
         <FeedDetail
           feedId={feedDetailId}
           onBack={handleBackFromFeedDetail}
           onFilterByFeedId={handleGoToFeedDetail}
           onFilterByCategory={handleFilterByCategory}
+        />
+      ) : view === "author" && authorName ? (
+        <AuthorDetail
+          author={authorName}
+          onBack={handleBackFromAuthorDetail}
+          onFilterByCategory={handleFilterByCategory}
+          onFilterByFeedId={handleGoToFeedDetail}
         />
       ) : (
         <>
@@ -532,6 +569,7 @@ function AppInner() {
               selectedIndex={selectedIndex}
               onFilterByCategory={handleFilterByCategory}
               onFilterByFeedId={handleGoToFeedDetail}
+              onNavigateToAuthor={handleGoToAuthorDetail}
               q={q}
             />
           )}

--- a/apps/web/client/components/ArticleCard.tsx
+++ b/apps/web/client/components/ArticleCard.tsx
@@ -11,6 +11,7 @@ interface Props {
   isSelected?: boolean;
   onFilterByCategory: (c: FeedCategory) => void;
   onFilterByFeedId: (id: string) => void;
+  onNavigateToAuthor?: (author: string) => void;
   q?: string;
 }
 
@@ -47,6 +48,7 @@ export function ArticleCard({
   isSelected,
   onFilterByCategory,
   onFilterByFeedId,
+  onNavigateToAuthor,
   q = "",
 }: Props) {
   const { isRead, markRead, markUnread } = useReadState();
@@ -125,7 +127,20 @@ export function ArticleCard({
         {article.author && (
           <>
             <span>·</span>
-            <span>{article.author}</span>
+            {onNavigateToAuthor ? (
+              <button
+                type="button"
+                className="author-name author-name-clickable"
+                onClick={() => {
+                  if (article.author) onNavigateToAuthor(article.author);
+                }}
+                title={`${article.author} の記事一覧`}
+              >
+                {article.author}
+              </button>
+            ) : (
+              <span className="author-name">{article.author}</span>
+            )}
           </>
         )}
       </div>

--- a/apps/web/client/components/ArticleList.tsx
+++ b/apps/web/client/components/ArticleList.tsx
@@ -6,6 +6,7 @@ interface Props {
   selectedIndex?: number;
   onFilterByCategory: (c: FeedCategory) => void;
   onFilterByFeedId: (id: string) => void;
+  onNavigateToAuthor?: (author: string) => void;
   q?: string;
 }
 
@@ -14,6 +15,7 @@ export function ArticleList({
   selectedIndex = -1,
   onFilterByCategory,
   onFilterByFeedId,
+  onNavigateToAuthor,
   q,
 }: Props) {
   return (
@@ -25,6 +27,7 @@ export function ArticleList({
           isSelected={i === selectedIndex}
           onFilterByCategory={onFilterByCategory}
           onFilterByFeedId={onFilterByFeedId}
+          onNavigateToAuthor={onNavigateToAuthor}
           q={q}
         />
       ))}

--- a/apps/web/client/components/AuthorDetail.tsx
+++ b/apps/web/client/components/AuthorDetail.tsx
@@ -1,0 +1,54 @@
+import type { FeedCategory } from "../types/api";
+import { useAuthorArticles } from "../hooks/useAuthorArticles";
+import { ArticleCard } from "./ArticleCard";
+
+interface Props {
+  author: string;
+  onBack: () => void;
+  onFilterByCategory: (c: FeedCategory) => void;
+  onFilterByFeedId: (id: string) => void;
+}
+
+export function AuthorDetail({ author, onBack, onFilterByCategory, onFilterByFeedId }: Props) {
+  const { articles, isLoading, error, hasMore, loadMore, loadingMore } =
+    useAuthorArticles(author);
+
+  return (
+    <div className="author-detail">
+      <div className="author-detail-header">
+        <button type="button" className="back-button" onClick={onBack}>
+          ← 一覧に戻る
+        </button>
+        <h1 className="author-detail-name">{author}</h1>
+        {!isLoading && !error && (
+          <span className="author-detail-count">{articles.length} 件</span>
+        )}
+      </div>
+
+      {isLoading && <div className="loader">読み込み中…</div>}
+      {error && !isLoading && <div className="error">取得エラー: {error}</div>}
+      {!isLoading && !error && articles.length === 0 && (
+        <div className="empty">記事がありません</div>
+      )}
+
+      {articles.length > 0 && (
+        <div className="article-list">
+          {articles.map((a) => (
+            <ArticleCard
+              key={a.id}
+              article={a}
+              onFilterByCategory={onFilterByCategory}
+              onFilterByFeedId={onFilterByFeedId}
+            />
+          ))}
+        </div>
+      )}
+
+      {hasMore && (
+        <button type="button" className="load-more" onClick={loadMore} disabled={loadingMore}>
+          {loadingMore ? "読み込み中…" : "もっと見る"}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/client/components/AuthorDetail.tsx
+++ b/apps/web/client/components/AuthorDetail.tsx
@@ -10,8 +10,7 @@ interface Props {
 }
 
 export function AuthorDetail({ author, onBack, onFilterByCategory, onFilterByFeedId }: Props) {
-  const { articles, isLoading, error, hasMore, loadMore, loadingMore } =
-    useAuthorArticles(author);
+  const { articles, isLoading, error, hasMore, loadMore, loadingMore } = useAuthorArticles(author);
 
   return (
     <div className="author-detail">
@@ -20,9 +19,7 @@ export function AuthorDetail({ author, onBack, onFilterByCategory, onFilterByFee
           ← 一覧に戻る
         </button>
         <h1 className="author-detail-name">{author}</h1>
-        {!isLoading && !error && (
-          <span className="author-detail-count">{articles.length} 件</span>
-        )}
+        {!isLoading && !error && <span className="author-detail-count">{articles.length} 件</span>}
       </div>
 
       {isLoading && <div className="loader">読み込み中…</div>}

--- a/apps/web/client/components/Header.tsx
+++ b/apps/web/client/components/Header.tsx
@@ -1,7 +1,8 @@
 import { useTheme } from "../hooks/useTheme";
 
 // "feed" は /feed/:id のフィード詳細ページで使用。nav タブには載せない
-export type AppView = "articles" | "stats" | "feed";
+// "author" は /author/:name の著者詳細ページで使用。nav タブには載せない
+export type AppView = "articles" | "stats" | "feed" | "author";
 
 interface HeaderProps {
   view?: AppView;

--- a/apps/web/client/components/StatsDashboard.tsx
+++ b/apps/web/client/components/StatsDashboard.tsx
@@ -10,11 +10,32 @@ function SummaryCard({ label, value }: { label: string; value: number }) {
   );
 }
 
-function BarRow({ label, count, maxCount }: { label: string; count: number; maxCount: number }) {
+function BarRow({
+  label,
+  count,
+  maxCount,
+  onClick,
+}: {
+  label: string;
+  count: number;
+  maxCount: number;
+  onClick?: () => void;
+}) {
   const pct = maxCount > 0 ? Math.round((count / maxCount) * 100) : 0;
   return (
     <div className="stats-bar-row">
-      <span className="stats-bar-label">{label}</span>
+      {onClick ? (
+        <button
+          type="button"
+          className="stats-bar-label stats-bar-label-clickable"
+          onClick={onClick}
+          title={`${label} の記事一覧`}
+        >
+          {label}
+        </button>
+      ) : (
+        <span className="stats-bar-label">{label}</span>
+      )}
       <div
         className="stats-bar"
         role="img"
@@ -26,7 +47,13 @@ function BarRow({ label, count, maxCount }: { label: string; count: number; maxC
   );
 }
 
-function AuthorsSection({ authors }: { authors: AuthorCount[] }) {
+function AuthorsSection({
+  authors,
+  onAuthorClick,
+}: {
+  authors: AuthorCount[];
+  onAuthorClick?: (author: string) => void;
+}) {
   const top = authors.slice(0, 10);
   const max = top[0]?.count ?? 1;
   return (
@@ -34,7 +61,13 @@ function AuthorsSection({ authors }: { authors: AuthorCount[] }) {
       <h3 className="stats-section-title">著者別 (30 日・上位 10 件)</h3>
       <div className="stats-bar-list">
         {top.map((a) => (
-          <BarRow key={a.author} label={a.author} count={a.count} maxCount={max} />
+          <BarRow
+            key={a.author}
+            label={a.author}
+            count={a.count}
+            maxCount={max}
+            onClick={onAuthorClick ? () => onAuthorClick(a.author) : undefined}
+          />
         ))}
       </div>
     </section>
@@ -86,7 +119,11 @@ function CategorySection({ byCategory }: { byCategory: Record<string, number> })
   );
 }
 
-export function StatsDashboard() {
+interface StatsDashboardProps {
+  onNavigateToAuthor?: (author: string) => void;
+}
+
+export function StatsDashboard({ onNavigateToAuthor }: StatsDashboardProps = {}) {
   const [stats, setStats] = useState<Stats | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -135,7 +172,7 @@ export function StatsDashboard() {
       </div>
 
       {stats.top_authors_30d && stats.top_authors_30d.length > 0 && (
-        <AuthorsSection authors={stats.top_authors_30d} />
+        <AuthorsSection authors={stats.top_authors_30d} onAuthorClick={onNavigateToAuthor} />
       )}
 
       {stats.top_publishers_30d && stats.top_publishers_30d.length > 0 && (

--- a/apps/web/client/hooks/useAuthorArticles.ts
+++ b/apps/web/client/hooks/useAuthorArticles.ts
@@ -1,0 +1,92 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Article, ArticlesResponse } from "../types/api";
+
+interface State {
+  articles: Article[];
+  nextCursor: string | null;
+  isLoading: boolean;
+  loadingMore: boolean;
+  error: string | null;
+}
+
+const initial: State = {
+  articles: [],
+  nextCursor: null,
+  isLoading: false,
+  loadingMore: false,
+  error: null,
+};
+
+function buildUrl(author: string, limit: number, cursor?: string | null): string {
+  const params = new URLSearchParams();
+  params.set("limit", String(limit));
+  if (cursor) params.set("cursor", cursor);
+  return `/api/articles/by-author/${encodeURIComponent(author)}?${params.toString()}`;
+}
+
+export function useAuthorArticles(author: string, limit = 20) {
+  const [state, setState] = useState<State>(initial);
+  const reqIdRef = useRef(0);
+
+  const fetchInitial = useCallback(async () => {
+    if (!author) return;
+    const reqId = ++reqIdRef.current;
+    setState((s) => ({ ...s, isLoading: true, error: null }));
+    try {
+      const res = await fetch(buildUrl(author, limit));
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = (await res.json()) as ArticlesResponse;
+      if (reqId !== reqIdRef.current) return;
+      setState({
+        articles: data.articles,
+        nextCursor: data.nextCursor,
+        isLoading: false,
+        loadingMore: false,
+        error: null,
+      });
+    } catch (err) {
+      if (reqId !== reqIdRef.current) return;
+      setState({
+        articles: [],
+        nextCursor: null,
+        isLoading: false,
+        loadingMore: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }, [author, limit]);
+
+  useEffect(() => {
+    void fetchInitial();
+  }, [fetchInitial]);
+
+  const loadMore = useCallback(async () => {
+    if (!state.nextCursor || state.loadingMore) return;
+    const cursor = state.nextCursor;
+    const reqId = reqIdRef.current;
+    setState((s) => ({ ...s, loadingMore: true }));
+    try {
+      const res = await fetch(buildUrl(author, limit, cursor));
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = (await res.json()) as ArticlesResponse;
+      if (reqId !== reqIdRef.current) return;
+      setState((s) => ({
+        articles: [...s.articles, ...data.articles],
+        nextCursor: data.nextCursor,
+        isLoading: false,
+        loadingMore: false,
+        error: null,
+      }));
+    } catch (err) {
+      if (reqId !== reqIdRef.current) return;
+      setState((s) => ({
+        ...s,
+        loadingMore: false,
+        error: err instanceof Error ? err.message : String(err),
+      }));
+    }
+  }, [author, limit, state.nextCursor, state.loadingMore]);
+
+  const hasMore = state.nextCursor !== null;
+  return { ...state, hasMore, loadMore };
+}

--- a/apps/web/tests/client/AuthorDetail.test.tsx
+++ b/apps/web/tests/client/AuthorDetail.test.tsx
@@ -48,7 +48,14 @@ describe("AuthorDetail", () => {
 
   it("ローディング表示", () => {
     vi.stubGlobal("fetch", vi.fn().mockReturnValue(new Promise(() => {})));
-    render(<AuthorDetail author="Author A" onBack={noop} onFilterByCategory={noop} onFilterByFeedId={noop} />);
+    render(
+      <AuthorDetail
+        author="Author A"
+        onBack={noop}
+        onFilterByCategory={noop}
+        onFilterByFeedId={noop}
+      />,
+    );
     expect(screen.getByText(/読み込み中/)).toBeTruthy();
   });
 
@@ -57,7 +64,14 @@ describe("AuthorDetail", () => {
       makeArticle({ id: i + 1, guid: `guid-${i + 1}`, title: `記事 ${i + 1}` }),
     );
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeArticlesResponse(articles)));
-    render(<AuthorDetail author="Author A" onBack={noop} onFilterByCategory={noop} onFilterByFeedId={noop} />);
+    render(
+      <AuthorDetail
+        author="Author A"
+        onBack={noop}
+        onFilterByCategory={noop}
+        onFilterByFeedId={noop}
+      />,
+    );
     // h1 に著者名
     expect(screen.getByRole("heading", { level: 1, name: "Author A" })).toBeTruthy();
     // 記事タイトルが全て表示される
@@ -70,17 +84,28 @@ describe("AuthorDetail", () => {
 
   it("0 件で「記事がありません」が表示される", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeArticlesResponse([])));
-    render(<AuthorDetail author="Author A" onBack={noop} onFilterByCategory={noop} onFilterByFeedId={noop} />);
+    render(
+      <AuthorDetail
+        author="Author A"
+        onBack={noop}
+        onFilterByCategory={noop}
+        onFilterByFeedId={noop}
+      />,
+    );
     const empty = await screen.findByText("記事がありません");
     expect(empty).toBeTruthy();
   });
 
   it("エラー (500) 時にエラーメッセージを表示する", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({ ok: false, status: 500 }),
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+    render(
+      <AuthorDetail
+        author="Author A"
+        onBack={noop}
+        onFilterByCategory={noop}
+        onFilterByFeedId={noop}
+      />,
     );
-    render(<AuthorDetail author="Author A" onBack={noop} onFilterByCategory={noop} onFilterByFeedId={noop} />);
     const err = await screen.findByText(/取得エラー/);
     expect(err).toBeTruthy();
   });
@@ -89,7 +114,14 @@ describe("AuthorDetail", () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeArticlesResponse([])));
     const onBack = vi.fn();
     const user = userEvent.setup();
-    render(<AuthorDetail author="Author A" onBack={onBack} onFilterByCategory={noop} onFilterByFeedId={noop} />);
+    render(
+      <AuthorDetail
+        author="Author A"
+        onBack={onBack}
+        onFilterByCategory={noop}
+        onFilterByFeedId={noop}
+      />,
+    );
     // ボタンが出るまで待つ
     const backBtn = screen.getByRole("button", { name: /一覧に戻る/ });
     await user.click(backBtn);
@@ -99,7 +131,14 @@ describe("AuthorDetail", () => {
   it("fetch の URL に著者名が URL エンコードされて含まれる", async () => {
     const mockFetch = vi.fn().mockResolvedValue(makeArticlesResponse([]));
     vi.stubGlobal("fetch", mockFetch);
-    render(<AuthorDetail author="Author A" onBack={noop} onFilterByCategory={noop} onFilterByFeedId={noop} />);
+    render(
+      <AuthorDetail
+        author="Author A"
+        onBack={noop}
+        onFilterByCategory={noop}
+        onFilterByFeedId={noop}
+      />,
+    );
     await screen.findByText("記事がありません");
     expect(mockFetch).toHaveBeenCalledWith(
       expect.stringContaining("/api/articles/by-author/Author%20A"),

--- a/apps/web/tests/client/AuthorDetail.test.tsx
+++ b/apps/web/tests/client/AuthorDetail.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import type { Article } from "../../client/types/api";
+
+const { AuthorDetail } = await import("../../client/components/AuthorDetail");
+
+function makeArticle(overrides: Partial<Article> = {}): Article {
+  return {
+    id: 1,
+    guid: "guid-1",
+    feed_id: "feed-a",
+    feed_name: "Feed A",
+    title: "Test Article",
+    url: "https://example.com/article",
+    summary: "A short summary.",
+    author: "Author A",
+    published_at: "2024-01-01T00:00:00Z",
+    fetched_at: "2024-01-01T01:00:00Z",
+    category: "ai",
+    lang: "en",
+    ...overrides,
+  };
+}
+
+function makeArticlesResponse(articles: Article[], nextCursor: string | null = null) {
+  return {
+    ok: true,
+    json: () =>
+      Promise.resolve({
+        articles,
+        nextCursor,
+      }),
+  };
+}
+
+const noop = () => {};
+
+describe("AuthorDetail", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("ローディング表示", () => {
+    vi.stubGlobal("fetch", vi.fn().mockReturnValue(new Promise(() => {})));
+    render(<AuthorDetail author="Author A" onBack={noop} onFilterByCategory={noop} onFilterByFeedId={noop} />);
+    expect(screen.getByText(/読み込み中/)).toBeTruthy();
+  });
+
+  it("著者名と記事カード 5 件が描画される", async () => {
+    const articles = Array.from({ length: 5 }, (_, i) =>
+      makeArticle({ id: i + 1, guid: `guid-${i + 1}`, title: `記事 ${i + 1}` }),
+    );
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeArticlesResponse(articles)));
+    render(<AuthorDetail author="Author A" onBack={noop} onFilterByCategory={noop} onFilterByFeedId={noop} />);
+    // h1 に著者名
+    expect(screen.getByRole("heading", { level: 1, name: "Author A" })).toBeTruthy();
+    // 記事タイトルが全て表示される
+    for (let i = 1; i <= 5; i++) {
+      expect(await screen.findByText(`記事 ${i}`)).toBeTruthy();
+    }
+    // 件数表示
+    expect(screen.getByText(/5 件/)).toBeTruthy();
+  });
+
+  it("0 件で「記事がありません」が表示される", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeArticlesResponse([])));
+    render(<AuthorDetail author="Author A" onBack={noop} onFilterByCategory={noop} onFilterByFeedId={noop} />);
+    const empty = await screen.findByText("記事がありません");
+    expect(empty).toBeTruthy();
+  });
+
+  it("エラー (500) 時にエラーメッセージを表示する", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 500 }),
+    );
+    render(<AuthorDetail author="Author A" onBack={noop} onFilterByCategory={noop} onFilterByFeedId={noop} />);
+    const err = await screen.findByText(/取得エラー/);
+    expect(err).toBeTruthy();
+  });
+
+  it("「← 一覧に戻る」ボタン click で onBack が呼ばれる", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeArticlesResponse([])));
+    const onBack = vi.fn();
+    const user = userEvent.setup();
+    render(<AuthorDetail author="Author A" onBack={onBack} onFilterByCategory={noop} onFilterByFeedId={noop} />);
+    // ボタンが出るまで待つ
+    const backBtn = screen.getByRole("button", { name: /一覧に戻る/ });
+    await user.click(backBtn);
+    expect(onBack).toHaveBeenCalledOnce();
+  });
+
+  it("fetch の URL に著者名が URL エンコードされて含まれる", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(makeArticlesResponse([]));
+    vi.stubGlobal("fetch", mockFetch);
+    render(<AuthorDetail author="Author A" onBack={noop} onFilterByCategory={noop} onFilterByFeedId={noop} />);
+    await screen.findByText("記事がありません");
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/articles/by-author/Author%20A"),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- `useAuthorArticles` hook を新規追加: `/api/articles/by-author/:author` を cursor pagination で fetch し `{ articles, isLoading, error, hasMore, loadMore }` を返す
- `AuthorDetail` コンポーネントを新規追加: 著者名 (h1)・記事総数・記事カードリスト・loading / error / empty 表示・「もっと見る」ボタン
- `ArticleCard` に `onNavigateToAuthor` prop を追加し著者名を clickable ボタンに変更
- `ArticleList` に `onNavigateToAuthor` prop を追加し `ArticleCard` へ伝播
- `StatsDashboard` の著者バーを clickable にして著者詳細へ drill-down
- `Header` の `AppView` 型に `'author'` を追加
- `App.tsx` に `/author/:name` URL routing・`authorName` state・遷移ハンドラを追加

## Test plan

- [ ] `apps/web/tests/client/AuthorDetail.test.tsx` が pass する (CI で確認)
  - fetch モックで `/api/articles/by-author/Author%20A?limit=20` を返す
  - 著者名・記事カード 5 件の描画
  - 0 件で「記事がありません」状態
  - ローディング表示
  - エラー (500) 表示
  - 「← 一覧に戻る」ボタン click で `onBack` が呼ばれる
  - fetch URL に `Author%20A` が含まれる
- [ ] `pnpm check` pass (CI で確認)

Closes #177