### PR TITLE
feat(api): add GET /api/articles/by-feed/:feedId with cursor pagination

### DIFF
--- a/apps/web/tests/worker/api/articles.test.ts
+++ b/apps/web/tests/worker/api/articles.test.ts
@@ -977,6 +977,170 @@ describe("GET /api/articles/:guid/neighbors", () => {
   });
 });
 
+describe("GET /api/articles/by-feed/:feedId", () => {
+  it("returns 200 with articles for a known feedId", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/by-feed/openai-blog");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ articles: { feed_id: string }[]; next_cursor: string | null }>();
+    expect(Array.isArray(body.articles)).toBe(true);
+    expect(body.articles.length).toBe(2);
+    for (const article of body.articles) {
+      expect(article.feed_id).toBe("openai-blog");
+    }
+    expect(body.next_cursor).toBeNull();
+  });
+
+  it("returns 200 with empty array when feedId has no articles", async () => {
+    // 存在しない feed_id を指定 → 0 件で 200
+    const res = await SELF.fetch("https://example.com/api/articles/by-feed/nonexistent-feed-xyz");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ articles: unknown[]; next_cursor: string | null }>();
+    expect(body.articles).toEqual([]);
+    expect(body.next_cursor).toBeNull();
+  });
+
+  it("returns 400 when feedId is empty", async () => {
+    // Hono のルートでは /by-feed/ は別セグメントとして扱われないため
+    // 空文字チェックは URL decode 後に行う
+    const res = await SELF.fetch("https://example.com/api/articles/by-feed/%20");
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toMatch(/feedId/);
+  });
+
+  it("returns 400 when limit=0", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/by-feed/openai-blog?limit=0");
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toMatch(/limit/);
+  });
+
+  it("returns 400 when limit=51", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/by-feed/openai-blog?limit=51");
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toMatch(/limit/);
+  });
+
+  it("returns 400 when limit is non-numeric", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/by-feed/openai-blog?limit=abc");
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toMatch(/limit/);
+  });
+
+  it("returns 400 when cursor is malformed", async () => {
+    const res = await SELF.fetch(
+      "https://example.com/api/articles/by-feed/openai-blog?cursor=not-valid-base64!!!",
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toMatch(/cursor/);
+  });
+
+  it("returns articles in published_at DESC, id DESC order", async () => {
+    // openai-blog に同一 published_at の記事を追加して tie-break を確認
+    const SAME_AT = "2024-04-03T00:00:00.000Z";
+    await insertArticles(env.DB, [
+      {
+        guid: "o-ai-tie-1",
+        feed_id: "openai-blog",
+        title: "Tie 1",
+        url: "https://x.test/o/tie1",
+        summary: null,
+        author: null,
+        published_at: SAME_AT,
+        category: "ai",
+        lang: "en",
+      },
+    ]);
+    // o-ai-2 も SAME_AT (2024-04-03) なので tie → id DESC が効く
+    const res = await SELF.fetch("https://example.com/api/articles/by-feed/openai-blog");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ articles: { published_at: string; id: number }[] }>();
+    const dates = body.articles.map((a) => a.published_at);
+    const sorted = dates.toSorted((a, b) => b.localeCompare(a));
+    expect(dates).toEqual(sorted);
+    // 同一 published_at 内は id DESC
+    const sameAt = body.articles.filter((a) => a.published_at === SAME_AT);
+    if (sameAt.length >= 2) {
+      expect(sameAt[0].id).toBeGreaterThan(sameAt[1].id);
+    }
+  });
+
+  it("paginates with cursor: first page + second page covers all articles", async () => {
+    // openai-blog に追加で 2 件挿入して合計 4 件にする
+    await insertArticles(env.DB, [
+      {
+        guid: "o-page-1",
+        feed_id: "openai-blog",
+        title: "Page Article 1",
+        url: "https://x.test/o/page1",
+        summary: null,
+        author: null,
+        published_at: "2024-04-04T00:00:00.000Z",
+        category: "ai",
+        lang: "en",
+      },
+      {
+        guid: "o-page-2",
+        feed_id: "openai-blog",
+        title: "Page Article 2",
+        url: "https://x.test/o/page2",
+        summary: null,
+        author: null,
+        published_at: "2024-04-05T00:00:00.000Z",
+        category: "ai",
+        lang: "en",
+      },
+    ]);
+
+    // 1 ページ目: limit=2
+    const res1 = await SELF.fetch("https://example.com/api/articles/by-feed/openai-blog?limit=2");
+    expect(res1.status).toBe(200);
+    const body1 = await res1.json<{
+      articles: { guid: string }[];
+      next_cursor: string | null;
+    }>();
+    expect(body1.articles.length).toBe(2);
+    expect(body1.next_cursor).not.toBeNull();
+
+    // 2 ページ目: cursor を使用
+    const res2 = await SELF.fetch(
+      `https://example.com/api/articles/by-feed/openai-blog?limit=2&cursor=${body1.next_cursor}`,
+    );
+    expect(res2.status).toBe(200);
+    const body2 = await res2.json<{
+      articles: { guid: string }[];
+      next_cursor: string | null;
+    }>();
+    expect(body2.articles.length).toBe(2);
+    expect(body2.next_cursor).toBeNull();
+
+    // 2 ページ合わせて全 guid が揃う
+    const allGuids = [...body1.articles.map((a) => a.guid), ...body2.articles.map((a) => a.guid)];
+    expect(allGuids).toContain("o-ai-1");
+    expect(allGuids).toContain("o-ai-2");
+    expect(allGuids).toContain("o-page-1");
+    expect(allGuids).toContain("o-page-2");
+  });
+
+  it("does not mix articles from different feed_id", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/by-feed/google-research");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ articles: { feed_id: string }[] }>();
+    for (const article of body.articles) {
+      expect(article.feed_id).toBe("google-research");
+    }
+  });
+
+  it("returns Cache-Control: public, max-age=300", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/by-feed/openai-blog");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=300");
+  });
+});
+
 describe("GET /api/articles/by-author/:author", () => {
   it("returns 200 with articles for a known author", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-author/Author%20A");

--- a/apps/web/worker/api/articles.ts
+++ b/apps/web/worker/api/articles.ts
@@ -5,6 +5,7 @@ import {
   countArticlesByMonth,
   getArticleById,
   getArticlesByAuthor,
+  getArticlesByFeed,
   getArticlesCalendar,
   getArticlesByMonth,
   getNeighbors,
@@ -151,6 +152,29 @@ app.get("/by-author/:author", async (c) => {
   if (cursorRaw && !cursor) return c.json({ error: "invalid cursor" }, 400);
 
   const result = await getArticlesByAuthor(c.env.DB, author, limitNum, cursor);
+
+  return c.json({ articles: result.articles, next_cursor: encodeCursor(result.nextCursor) }, 200, {
+    "Cache-Control": "public, max-age=300",
+  });
+});
+
+app.get("/by-feed/:feedId", async (c) => {
+  const feedIdRaw = c.req.param("feedId");
+  const feedId = decodeURIComponent(feedIdRaw).trim();
+  if (!feedId) return c.json({ error: "feedId must not be empty" }, 400);
+
+  const limitRaw = c.req.query("limit") ?? "20";
+  const limitNum = Number(limitRaw);
+  if (!Number.isInteger(limitNum) || limitNum < 1 || limitNum > 50) {
+    return c.json({ error: "limit must be an integer between 1 and 50" }, 400);
+  }
+
+  const cursorRaw = c.req.query("cursor");
+  const cursor = decodeCursor(cursorRaw);
+  // cursor が指定されているのに decode に失敗した場合は 400
+  if (cursorRaw && !cursor) return c.json({ error: "invalid cursor" }, 400);
+
+  const result = await getArticlesByFeed(c.env.DB, feedId, limitNum, cursor);
 
   return c.json({ articles: result.articles, next_cursor: encodeCursor(result.nextCursor) }, 200, {
     "Cache-Control": "public, max-age=300",

--- a/apps/web/worker/db/articles.ts
+++ b/apps/web/worker/db/articles.ts
@@ -574,6 +574,56 @@ export async function countArticlesByMonth(
   return row?.c ?? 0;
 }
 
+export interface GetArticlesByFeedResult {
+  articles: Article[];
+  nextCursor: { publishedAt: string; id: number } | null;
+}
+
+/** feed_id で記事を published_at DESC で取得。cursor は listArticles / getArticlesByAuthor と同形式 */
+export async function getArticlesByFeed(
+  db: D1Database,
+  feedId: string,
+  limit: number,
+  cursor: { publishedAt: string; id: number } | null,
+): Promise<GetArticlesByFeedResult> {
+  const conds: string[] = [`a.feed_id = ?1`];
+  const binds: unknown[] = [feedId];
+
+  if (cursor) {
+    conds.push(
+      `(a.published_at < ?${binds.length + 1} OR (a.published_at = ?${binds.length + 1} AND a.id < ?${binds.length + 2}))`,
+    );
+    binds.push(cursor.publishedAt, cursor.id);
+  }
+
+  const where = `WHERE ${conds.join(" AND ")}`;
+  const sql = `
+    SELECT a.id, a.guid, a.feed_id, f.name AS feed_name, a.title, a.url, a.summary,
+           a.author, a.published_at, a.fetched_at, a.category, a.lang
+    FROM articles a
+    LEFT JOIN feeds f ON f.id = a.feed_id
+    ${where}
+    ORDER BY a.published_at DESC, a.id DESC
+    LIMIT ?${binds.length + 1}
+  `;
+  binds.push(limit + 1);
+
+  const result = await db
+    .prepare(sql)
+    .bind(...binds)
+    .all<Article>();
+
+  const rows = result.results ?? [];
+  let nextCursor: { publishedAt: string; id: number } | null = null;
+  let articles = rows;
+  if (rows.length > limit) {
+    articles = rows.slice(0, limit);
+    const last = articles[articles.length - 1];
+    nextCursor = { publishedAt: last.published_at, id: last.id };
+  }
+  return { articles, nextCursor };
+}
+
 export interface GetArticlesByAuthorResult {
   articles: Article[];
   nextCursor: { publishedAt: string; id: number } | null;


### PR DESCRIPTION
## Summary

- DB層に getArticlesByFeed を追加 (getArticlesByAuthor と同パターン)
- GET /api/articles/by-feed/:feedId?limit=20&cursor=... を追加 (limit: 1-50, Cache-Control: public, max-age=300)
- ルート登録順: /random -> /by-author -> /by-feed -> /calendar -> /:guid/related -> /:guid/neighbors -> /archive -> /:id
- テスト: 200/400/cursor pagination/Cache-Control/feed 混入防止を網羅

## Test plan

- 200: 既知 feedId の記事を返す
- 200: 存在しない feedId で空配列
- 400: feedId 空、limit 範囲外、limit 非数値、不正 cursor
- cursor pagination: 2 ページ合計が全件
- 異なる feed_id の記事が混入しない
- Cache-Control: public, max-age=300

Closes #181