### PR TITLE
feat(client): Stats Dashboard に活動カレンダー (heatmap) を追加

### DIFF
--- a/apps/web/client/components/CalendarHeatmap.tsx
+++ b/apps/web/client/components/CalendarHeatmap.tsx
@@ -1,0 +1,186 @@
+import { useState } from "react";
+import { useArticlesCalendar } from "../hooks/useArticlesCalendar";
+
+type Period = 30 | 90 | 365;
+
+const PERIODS: Period[] = [30, 90, 365];
+
+// count 値からヒートマップレベル (0〜4) を算出する
+function countToLevel(count: number): 0 | 1 | 2 | 3 | 4 {
+  if (count === 0) return 0;
+  if (count <= 2) return 1;
+  if (count <= 5) return 2;
+  if (count <= 10) return 3;
+  return 4;
+}
+
+// YYYY-MM-DD 文字列を UTC 日付として Date オブジェクトに変換する
+function parseDate(dateStr: string): Date {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  return new Date(Date.UTC(y, m - 1, d));
+}
+
+// "YYYY-MM-DD" を "M月D日" 形式に変換する
+function formatDateLabel(dateStr: string): string {
+  const [, m, d] = dateStr.split("-").map(Number);
+  return `${m}月${d}日`;
+}
+
+const DAY_LABELS = ["日", "月", "火", "水", "木", "金", "土"];
+
+interface Props {
+  days?: Period;
+}
+
+export function CalendarHeatmap({ days: initialDays = 90 }: Props) {
+  const [period, setPeriod] = useState<Period>(initialDays);
+  const { items, isLoading, error } = useArticlesCalendar(period);
+
+  if (error) {
+    return (
+      <section className="stats-section">
+        <h2 className="stats-section-title">活動カレンダー</h2>
+        <p className="error calendar-heatmap-error">ヒートマップを取得できませんでした</p>
+      </section>
+    );
+  }
+
+  // date→count のマップを構築する
+  const countMap = new Map<string, number>(items.map((d) => [d.date, d.count]));
+
+  // 表示範囲: 今日から period 日前まで (UTC 基準)
+  const today = new Date();
+  today.setUTCHours(0, 0, 0, 0);
+  const startDate = new Date(today);
+  startDate.setUTCDate(today.getUTCDate() - (period - 1));
+
+  // グリッドは日曜始まりの週単位。開始週の日曜まで遡る
+  const startDow = startDate.getUTCDay(); // 0=日
+  const gridStart = new Date(startDate);
+  gridStart.setUTCDate(startDate.getUTCDate() - startDow);
+
+  // セルを生成する。日数でループすることで oxlint の no-unmodified-loop-condition を回避する
+  const totalDays = Math.round((today.getTime() - gridStart.getTime()) / 86_400_000) + 1;
+  const cells: Array<{ dateStr: string | null; count: number; inRange: boolean }> = [];
+  for (let offset = 0; offset < totalDays; offset++) {
+    const cur = new Date(gridStart);
+    cur.setUTCDate(gridStart.getUTCDate() + offset);
+    const dateStr = cur.toISOString().slice(0, 10);
+    const inRange = cur >= startDate && cur <= today;
+    cells.push({
+      dateStr: inRange ? dateStr : null,
+      count: inRange ? (countMap.get(dateStr) ?? 0) : 0,
+      inRange,
+    });
+  }
+
+  // 末尾を土曜まで埋める
+  const lastDow = today.getUTCDay();
+  if (lastDow < 6) {
+    for (let i = lastDow + 1; i <= 6; i++) {
+      cells.push({ dateStr: null, count: 0, inRange: false });
+    }
+  }
+
+  const totalWeeks = Math.ceil(cells.length / 7);
+
+  // 月ラベル: 各週の最初の日が月初 (1日) なら表示する
+  const monthLabels: Array<{ weekIndex: number; label: string }> = [];
+  for (let w = 0; w < totalWeeks; w++) {
+    const cellIndex = w * 7;
+    const cell = cells[cellIndex];
+    if (!cell?.inRange || !cell.dateStr) continue;
+    const date = parseDate(cell.dateStr);
+    // 月の最初の週のみラベルを付ける (日付が 1〜7 の範囲なら月初周辺)
+    if (date.getUTCDate() <= 7) {
+      const month = date.getUTCMonth() + 1;
+      monthLabels.push({ weekIndex: w, label: `${month}月` });
+    }
+  }
+
+  return (
+    <section className="stats-section">
+      <div className="calendar-heatmap-header">
+        <h2 className="stats-section-title">活動カレンダー</h2>
+        <div className="calendar-heatmap-period-toggle" role="group" aria-label="表示期間">
+          {PERIODS.map((p) => (
+            <button
+              key={p}
+              type="button"
+              className={`calendar-heatmap-period-btn${period === p ? " active" : ""}`}
+              onClick={() => setPeriod(p)}
+              aria-pressed={period === p}
+            >
+              {p}日
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className="loader calendar-heatmap-loader">読み込み中…</div>
+      ) : (
+        <div className="calendar-heatmap-wrapper">
+          {/* 月ラベル行 */}
+          <div
+            className="calendar-heatmap-months"
+            style={{ gridTemplateColumns: `repeat(${totalWeeks}, 1fr)` }}
+          >
+            {Array.from({ length: totalWeeks }, (_, w) => {
+              const label = monthLabels.find((m) => m.weekIndex === w);
+              return (
+                <div key={w} className="calendar-heatmap-month-label">
+                  {label?.label ?? ""}
+                </div>
+              );
+            })}
+          </div>
+
+          <div className="calendar-heatmap-body">
+            {/* 曜日ラベル列 */}
+            <div className="calendar-heatmap-days">
+              {DAY_LABELS.map((label, i) => (
+                <div key={i} className="calendar-heatmap-day-label">
+                  {/* 月・水・金のみ表示してスペースを節約する */}
+                  {i % 2 === 1 ? label : ""}
+                </div>
+              ))}
+            </div>
+
+            {/* ヒートマップグリッド: 縦 7 行 (曜日) × 横 N 週 */}
+            <div
+              className="calendar-heatmap"
+              style={{ gridTemplateColumns: `repeat(${totalWeeks}, 1fr)` }}
+            >
+              {cells.map((cell, idx) => {
+                const level = cell.inRange ? countToLevel(cell.count) : -1;
+                const label = cell.dateStr
+                  ? `${formatDateLabel(cell.dateStr)}: ${cell.count}件`
+                  : "";
+                return (
+                  <div
+                    key={idx}
+                    className="calendar-heatmap-cell"
+                    data-level={level >= 0 ? level : undefined}
+                    aria-label={label || undefined}
+                    title={label || undefined}
+                    aria-hidden={!cell.inRange}
+                  />
+                );
+              })}
+            </div>
+          </div>
+
+          {/* 凡例 */}
+          <div className="calendar-heatmap-legend">
+            <span className="calendar-heatmap-legend-label">少</span>
+            {[0, 1, 2, 3, 4].map((level) => (
+              <div key={level} className="calendar-heatmap-cell" data-level={level} aria-hidden />
+            ))}
+            <span className="calendar-heatmap-legend-label">多</span>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/client/components/StatsDashboard.tsx
+++ b/apps/web/client/components/StatsDashboard.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { CalendarHeatmap } from "./CalendarHeatmap";
 import type { AuthorCount, PublisherCount, Stats } from "../hooks/useStats";
 
 function SummaryCard({ label, value }: { label: string; value: number }) {
@@ -170,6 +171,8 @@ export function StatsDashboard({ onNavigateToAuthor }: StatsDashboardProps = {})
         <SummaryCard label="直近 7 日" value={articles7d} />
         <SummaryCard label="直近 30 日" value={articles30d} />
       </div>
+
+      <CalendarHeatmap days={90} />
 
       {stats.top_authors_30d && stats.top_authors_30d.length > 0 && (
         <AuthorsSection authors={stats.top_authors_30d} onAuthorClick={onNavigateToAuthor} />

--- a/apps/web/client/hooks/useArticlesCalendar.ts
+++ b/apps/web/client/hooks/useArticlesCalendar.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from "react";
+import type { CalendarDay } from "../types/api";
+
+export function useArticlesCalendar(days: 30 | 90 | 365 = 90) {
+  const [items, setItems] = useState<CalendarDay[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    setIsLoading(true);
+    setError(null);
+    void (async () => {
+      try {
+        const res = await fetch(`/api/articles/calendar?days=${days}`);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = (await res.json()) as { days: CalendarDay[] };
+        if (alive) {
+          setItems(data.days ?? []);
+          setIsLoading(false);
+        }
+      } catch (err) {
+        if (alive) {
+          setError(err instanceof Error ? err.message : String(err));
+          setIsLoading(false);
+        }
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [days]);
+
+  return { items, isLoading, error };
+}

--- a/apps/web/client/index.css
+++ b/apps/web/client/index.css
@@ -15,6 +15,12 @@
   --badge-jp: #1a7f37;
   --badge-zenn: #0550ae;
   --mark-bg: #fff3b0;
+  /* ヒートマップの 5 段階カラー (GitHub contribution graph 準拠の緑系) */
+  --heatmap-l0: #ebedf0;
+  --heatmap-l1: #9be9a8;
+  --heatmap-l2: #40c463;
+  --heatmap-l3: #30a14e;
+  --heatmap-l4: #216e39;
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", "Hiragino Sans", "Noto Sans JP", Roboto,
     sans-serif;
@@ -1084,4 +1090,141 @@ kbd {
   margin: 0 0 12px;
   color: var(--fg-muted);
   font-weight: 500;
+}
+
+/* 活動カレンダー (CalendarHeatmap) */
+.calendar-heatmap-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.calendar-heatmap-period-toggle {
+  display: flex;
+  gap: 4px;
+}
+
+.calendar-heatmap-period-btn {
+  padding: 3px 10px;
+  background: var(--bg-elev-2);
+  color: var(--fg-muted);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 0.8rem;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.calendar-heatmap-period-btn:hover {
+  border-color: var(--accent);
+  color: var(--fg);
+}
+
+.calendar-heatmap-period-btn.active {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.calendar-heatmap-wrapper {
+  overflow-x: auto;
+  padding-bottom: 4px;
+}
+
+.calendar-heatmap-months {
+  display: grid;
+  gap: 3px;
+  margin-left: 24px; /* 曜日ラベル列の幅に合わせる */
+  margin-bottom: 2px;
+}
+
+.calendar-heatmap-month-label {
+  font-size: 0.7rem;
+  color: var(--fg-muted);
+  white-space: nowrap;
+}
+
+.calendar-heatmap-body {
+  display: flex;
+  gap: 4px;
+  align-items: flex-start;
+}
+
+.calendar-heatmap-days {
+  display: grid;
+  grid-template-rows: repeat(7, 12px);
+  gap: 3px;
+  flex-shrink: 0;
+  width: 20px;
+}
+
+.calendar-heatmap-day-label {
+  font-size: 0.65rem;
+  color: var(--fg-muted);
+  line-height: 12px;
+  text-align: right;
+}
+
+/* グリッド: 縦 7 行 (曜日) × 横 N 週 */
+.calendar-heatmap {
+  display: grid;
+  grid-template-rows: repeat(7, 12px);
+  grid-auto-flow: column;
+  gap: 3px;
+  flex-shrink: 0;
+}
+
+.calendar-heatmap-cell {
+  width: 12px;
+  height: 12px;
+  border-radius: 2px;
+  background: var(--heatmap-l0);
+}
+
+.calendar-heatmap-cell[data-level="0"] {
+  background: var(--heatmap-l0);
+}
+
+.calendar-heatmap-cell[data-level="1"] {
+  background: var(--heatmap-l1);
+}
+
+.calendar-heatmap-cell[data-level="2"] {
+  background: var(--heatmap-l2);
+}
+
+.calendar-heatmap-cell[data-level="3"] {
+  background: var(--heatmap-l3);
+}
+
+.calendar-heatmap-cell[data-level="4"] {
+  background: var(--heatmap-l4);
+}
+
+/* 範囲外のセル (inRange=false) は非表示にする */
+.calendar-heatmap-cell:not([data-level]) {
+  visibility: hidden;
+}
+
+.calendar-heatmap-legend {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  margin-top: 8px;
+  justify-content: flex-end;
+}
+
+.calendar-heatmap-legend-label {
+  font-size: 0.7rem;
+  color: var(--fg-muted);
+  margin: 0 2px;
+}
+
+.calendar-heatmap-loader {
+  padding: 16px;
+  margin-top: 0;
 }

--- a/apps/web/client/types/api.ts
+++ b/apps/web/client/types/api.ts
@@ -53,3 +53,12 @@ export interface FeedDetailResponse {
   feed: FeedDetail;
   recent_articles: Article[];
 }
+
+export interface CalendarDay {
+  date: string;
+  count: number;
+}
+
+export interface CalendarResponse {
+  days: CalendarDay[];
+}

--- a/apps/web/tests/client/CalendarHeatmap.test.tsx
+++ b/apps/web/tests/client/CalendarHeatmap.test.tsx
@@ -1,0 +1,173 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { CalendarHeatmap } from "../../client/components/CalendarHeatmap";
+
+// テスト用: 今日から N 日前までのカレンダーデータを生成する
+function makeCalendarDays(count: number, baseCount = 3) {
+  const today = new Date();
+  today.setUTCHours(0, 0, 0, 0);
+  return Array.from({ length: count }, (_, i) => {
+    const d = new Date(today);
+    d.setUTCDate(today.getUTCDate() - (count - 1 - i));
+    return { date: d.toISOString().slice(0, 10), count: baseCount };
+  });
+}
+
+function mockFetch(days: ReturnType<typeof makeCalendarDays>) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ days }),
+    }),
+  );
+}
+
+function mockFetchError() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+    }),
+  );
+}
+
+describe("CalendarHeatmap", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("ローディング状態を表示する", () => {
+    vi.stubGlobal("fetch", vi.fn().mockReturnValue(new Promise(() => {})));
+    render(<CalendarHeatmap days={90} />);
+    expect(screen.getByText(/読み込み中/)).toBeTruthy();
+  });
+
+  it("エラー時にエラーメッセージを表示する", async () => {
+    mockFetchError();
+    render(<CalendarHeatmap days={90} />);
+    const err = await screen.findByText(/ヒートマップを取得できませんでした/);
+    expect(err).toBeTruthy();
+  });
+
+  it("90日分のデータからセルが render される", async () => {
+    const days = makeCalendarDays(90);
+    mockFetch(days);
+    const { container } = render(<CalendarHeatmap days={90} />);
+    // セルが描画されるまで待つ
+    await screen.findByText("活動カレンダー");
+    const cells = container.querySelectorAll(".calendar-heatmap-cell[data-level]");
+    // 90セル分 (range内) + 凡例の5セル = 95以上
+    expect(cells.length).toBeGreaterThanOrEqual(90);
+  });
+
+  it("各セルに data-level 属性が付与される (count=3 → level=2)", async () => {
+    const days = makeCalendarDays(90, 3);
+    mockFetch(days);
+    const { container } = render(<CalendarHeatmap days={90} />);
+    await screen.findByText("活動カレンダー");
+    // count=3 → level=2 のセルが存在する
+    const level2Cells = container.querySelectorAll('.calendar-heatmap-cell[data-level="2"]');
+    expect(level2Cells.length).toBeGreaterThan(0);
+  });
+
+  it("aria-label に日付と件数が含まれる", async () => {
+    const days = makeCalendarDays(90, 5);
+    mockFetch(days);
+    const { container } = render(<CalendarHeatmap days={90} />);
+    await screen.findByText("活動カレンダー");
+    // aria-label="M月D日: 5件" の形式のセルが存在する
+    const cells = container.querySelectorAll(".calendar-heatmap-cell[aria-label]");
+    expect(cells.length).toBeGreaterThan(0);
+    const labels = Array.from(cells).map((c) => c.getAttribute("aria-label") ?? "");
+    expect(labels.some((l) => l.includes("5件"))).toBe(true);
+    expect(labels.some((l) => l.includes("月") && l.includes("日"))).toBe(true);
+  });
+
+  it("count=0 のセルは data-level=0 が付与される", async () => {
+    const days = makeCalendarDays(90, 0);
+    mockFetch(days);
+    const { container } = render(<CalendarHeatmap days={90} />);
+    await screen.findByText("活動カレンダー");
+    const level0Cells = container.querySelectorAll('.calendar-heatmap-cell[data-level="0"]');
+    // 90セル (range内) + 凡例1セル
+    expect(level0Cells.length).toBeGreaterThanOrEqual(90);
+  });
+
+  it("count=11以上のセルは data-level=4 が付与される", async () => {
+    const days = makeCalendarDays(90, 15);
+    mockFetch(days);
+    const { container } = render(<CalendarHeatmap days={90} />);
+    await screen.findByText("活動カレンダー");
+    const level4Cells = container.querySelectorAll('.calendar-heatmap-cell[data-level="4"]');
+    // 90セル (range内) + 凡例1セル
+    expect(level4Cells.length).toBeGreaterThanOrEqual(90);
+  });
+
+  it("30日切替ボタンをクリックすると fetch URL が変わる", async () => {
+    const days90 = makeCalendarDays(90);
+    const days30 = makeCalendarDays(30);
+    // fetch 呼び出し先 URL を記録するため手動 mock を使う
+    const calledUrls: string[] = [];
+    let callCount = 0;
+    vi.stubGlobal("fetch", (url: string) => {
+      calledUrls.push(url);
+      callCount++;
+      const data = callCount === 1 ? days90 : days30;
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ days: data }),
+      });
+    });
+
+    render(<CalendarHeatmap days={90} />);
+    await screen.findByText("活動カレンダー");
+
+    const btn30 = screen.getByRole("button", { name: "30日" });
+    fireEvent.click(btn30);
+
+    // 2回目の fetch が ?days=30 で呼ばれることを確認
+    await vi.waitFor(() => {
+      expect(calledUrls.length).toBe(2);
+    });
+    expect(calledUrls[1]).toContain("days=30");
+  });
+
+  it("365日切替ボタンをクリックすると fetch URL が変わる", async () => {
+    const days90 = makeCalendarDays(90);
+    const days365 = makeCalendarDays(365);
+    const calledUrls: string[] = [];
+    let callCount = 0;
+    vi.stubGlobal("fetch", (url: string) => {
+      calledUrls.push(url);
+      callCount++;
+      const data = callCount === 1 ? days90 : days365;
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ days: data }),
+      });
+    });
+
+    render(<CalendarHeatmap days={90} />);
+    await screen.findByText("活動カレンダー");
+
+    const btn365 = screen.getByRole("button", { name: "365日" });
+    fireEvent.click(btn365);
+
+    await vi.waitFor(() => {
+      expect(calledUrls.length).toBe(2);
+    });
+    expect(calledUrls[1]).toContain("days=365");
+  });
+
+  it("活動カレンダーの見出しが表示される", async () => {
+    mockFetch(makeCalendarDays(90));
+    render(<CalendarHeatmap days={90} />);
+    await screen.findByText("活動カレンダー");
+  });
+});

--- a/apps/web/tests/client/StatsDashboard.test.tsx
+++ b/apps/web/tests/client/StatsDashboard.test.tsx
@@ -38,12 +38,21 @@ const MOCK_STATS_RESPONSE = {
   feed_activity: [],
 };
 
+// CalendarHeatmap の fetch をモックするため URL ごとにレスポンスを分岐する
 function mockFetchSuccess() {
   vi.stubGlobal(
     "fetch",
-    vi.fn().mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve(MOCK_STATS_RESPONSE),
+    vi.fn().mockImplementation((url: string) => {
+      if ((url as string).includes("/api/articles/calendar")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ days: [] }),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(MOCK_STATS_RESPONSE),
+      });
     }),
   );
 }
@@ -153,5 +162,13 @@ describe("StatsDashboard", () => {
     expect(screen.getByText("ai")).toBeTruthy();
     expect(screen.getByText("jp")).toBeTruthy();
     expect(screen.getByText("zenn")).toBeTruthy();
+  });
+
+  it("活動カレンダーセクションが描画される", async () => {
+    mockFetchSuccess();
+    render(<StatsDashboard />);
+    // CalendarHeatmap の見出しが表示されることを確認 (空データでも OK)
+    const heading = await screen.findByText("活動カレンダー");
+    expect(heading).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

- useArticlesCalendar hook を追加 (30/90/365 日切替対応)
- CalendarHeatmap コンポーネントを追加 (GitHub contribution graph 風)
- StatsDashboard にヒートマップセクションを追加
- index.css にヒートマップスタイル追加
- 376 テスト全通過

Closes #182