### PR TITLE
feat(admin): add GET /api/admin/feeds/diagnostics

### DIFF
--- a/apps/web/tests/worker/api/admin-feeds-diagnostics.test.ts
+++ b/apps/web/tests/worker/api/admin-feeds-diagnostics.test.ts
@@ -1,0 +1,217 @@
+import { beforeEach, describe, expect, it } from "vite-plus/test";
+import { env, SELF } from "cloudflare:test";
+import {
+  recordFetchError,
+  recordFetchSuccess,
+  syncFeeds,
+  updateFeedHeaders,
+} from "../../../worker/db/feeds";
+import type { FeedConfig } from "../../../worker/types";
+
+const AUTH_HEADER = { authorization: "Bearer test-admin-token" };
+
+const FEED_A: FeedConfig = {
+  id: "feed-alpha",
+  name: "Feed Alpha",
+  url: "https://example.com/alpha.xml",
+  category: "bigtech",
+  lang: "en",
+  enabled: true,
+};
+
+const FEED_B: FeedConfig = {
+  id: "feed-beta",
+  name: "Feed Beta",
+  url: "https://example.com/beta.xml",
+  category: "ai",
+  lang: "ja",
+  enabled: false,
+};
+
+beforeEach(async () => {
+  // setup.ts の beforeEach で reset + applyD1Migrations が実行される
+});
+
+describe("GET /api/admin/feeds/diagnostics", () => {
+  it("401: token なし → 401", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/feeds/diagnostics");
+    expect(res.status).toBe(401);
+  });
+
+  it("401: 不正 token → 401", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/feeds/diagnostics", {
+      headers: { authorization: "Bearer wrong-token" },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("200: 空 DB でも { feeds: [], count: 0 } を返す", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/feeds/diagnostics", {
+      headers: AUTH_HEADER,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { feeds: unknown[]; count: number };
+    expect(Array.isArray(body.feeds)).toBe(true);
+    expect(body.feeds).toHaveLength(0);
+    expect(body.count).toBe(0);
+  });
+
+  it("200: Cache-Control が private, max-age=30", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/feeds/diagnostics", {
+      headers: AUTH_HEADER,
+    });
+    expect(res.status).toBe(200);
+    const cc = res.headers.get("cache-control") ?? "";
+    expect(cc).toContain("private");
+    expect(cc).toContain("max-age=30");
+  });
+
+  it("200: enabled / disabled 両方のフィードが含まれる", async () => {
+    await syncFeeds(env.DB, [FEED_A, FEED_B]);
+
+    const res = await SELF.fetch("https://example.com/api/admin/feeds/diagnostics", {
+      headers: AUTH_HEADER,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      feeds: { id: string; enabled: boolean }[];
+      count: number;
+    };
+    expect(body.count).toBe(2);
+    const ids = body.feeds.map((f) => f.id);
+    expect(ids).toContain("feed-alpha");
+    expect(ids).toContain("feed-beta");
+    const alpha = body.feeds.find((f) => f.id === "feed-alpha");
+    const beta = body.feeds.find((f) => f.id === "feed-beta");
+    expect(alpha!.enabled).toBe(true);
+    expect(beta!.enabled).toBe(false);
+  });
+
+  it("200: 各フィールドが正しく返る (last_fetched_at, last_etag, last_status, last_error)", async () => {
+    await syncFeeds(env.DB, [FEED_A]);
+
+    const fetchedAt = "2026-04-01T00:00:00.000Z";
+    // 成功記録 + ETag/Last-Modified 更新
+    await recordFetchSuccess(env.DB, "feed-alpha", fetchedAt, 5);
+    await updateFeedHeaders(env.DB, "feed-alpha", "etag-abc", "Mon, 01 Apr 2026 00:00:00 GMT");
+
+    const res = await SELF.fetch("https://example.com/api/admin/feeds/diagnostics", {
+      headers: AUTH_HEADER,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      feeds: {
+        id: string;
+        name: string;
+        url: string;
+        category: string;
+        lang: string;
+        enabled: boolean;
+        last_fetched_at: string | null;
+        last_status: string | null;
+        last_error: string | null;
+        last_etag: string | null;
+        last_modified: string | null;
+        fetch_error_count: number;
+        articles_total: number;
+        articles_30d: number;
+        last_published_at: string | null;
+      }[];
+      count: number;
+    };
+    expect(body.count).toBe(1);
+    const f = body.feeds[0];
+    expect(f.id).toBe("feed-alpha");
+    expect(f.name).toBe("Feed Alpha");
+    expect(f.url).toBe("https://example.com/alpha.xml");
+    expect(f.category).toBe("bigtech");
+    expect(f.lang).toBe("en");
+    expect(f.enabled).toBe(true);
+    expect(f.last_fetched_at).toBe(fetchedAt);
+    expect(f.last_status).toBe("ok:5");
+    expect(f.last_error).toBeNull();
+    expect(f.last_etag).toBe("etag-abc");
+    expect(f.last_modified).toBe("Mon, 01 Apr 2026 00:00:00 GMT");
+    expect(f.fetch_error_count).toBe(0);
+    expect(f.articles_total).toBe(0); // articles は未挿入
+    expect(f.articles_30d).toBe(0);
+    expect(f.last_published_at).toBeNull();
+  });
+
+  it("200: エラー後は last_error / fetch_error_count が反映される", async () => {
+    await syncFeeds(env.DB, [FEED_A]);
+
+    const fetchedAt = "2026-04-02T00:00:00.000Z";
+    await recordFetchError(env.DB, "feed-alpha", fetchedAt, "connection refused");
+
+    const res = await SELF.fetch("https://example.com/api/admin/feeds/diagnostics", {
+      headers: AUTH_HEADER,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      feeds: {
+        id: string;
+        last_status: string | null;
+        last_error: string | null;
+        fetch_error_count: number;
+      }[];
+    };
+    const f = body.feeds[0];
+    expect(f.last_status).toBe("error");
+    expect(f.last_error).toBe("connection refused");
+    expect(f.fetch_error_count).toBe(1);
+  });
+
+  it("200: articles 投入後に articles_total / articles_30d / last_published_at が反映される", async () => {
+    await syncFeeds(env.DB, [FEED_A]);
+
+    // articles を直接挿入
+    const recentAt = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString();
+    const oldAt = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString();
+    await env.DB.batch([
+      env.DB.prepare(
+        `INSERT INTO articles (guid, feed_id, title, url, published_at, fetched_at, category, lang)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)`,
+      ).bind(
+        "guid-recent",
+        "feed-alpha",
+        "Recent Article",
+        "https://example.com/r",
+        recentAt,
+        recentAt,
+        "bigtech",
+        "en",
+      ),
+      env.DB.prepare(
+        `INSERT INTO articles (guid, feed_id, title, url, published_at, fetched_at, category, lang)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)`,
+      ).bind(
+        "guid-old",
+        "feed-alpha",
+        "Old Article",
+        "https://example.com/o",
+        oldAt,
+        oldAt,
+        "bigtech",
+        "en",
+      ),
+    ]);
+
+    const res = await SELF.fetch("https://example.com/api/admin/feeds/diagnostics", {
+      headers: AUTH_HEADER,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      feeds: {
+        id: string;
+        articles_total: number;
+        articles_30d: number;
+        last_published_at: string | null;
+      }[];
+    };
+    const f = body.feeds[0];
+    expect(f.articles_total).toBe(2);
+    expect(f.articles_30d).toBe(1); // recentAt のみが 30d 以内
+    expect(f.last_published_at).toBe(recentAt);
+  });
+});

--- a/apps/web/worker/api/admin.ts
+++ b/apps/web/worker/api/admin.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import type { Env } from "../types";
 import { collectAll, collectFeeds, validateFeedUrl } from "../collector";
 import { loadAllFeeds } from "../feed-config";
-import { setFeedEnabled } from "../db/feeds";
+import { getFeedsDiagnostics, setFeedEnabled } from "../db/feeds";
 import { getCronHealth, getFeedFailures, getRun, listRuns, startRun } from "../db/runs";
 
 const app = new Hono<{ Bindings: Env }>();
@@ -297,6 +297,23 @@ app.get("/runs/:id", async (c) => {
     return c.json({ error: "not found" }, 404);
   }
   return c.json(detail);
+});
+
+app.get("/feeds/diagnostics", async (c) => {
+  const current = c.env.ADMIN_TOKEN;
+  const next = c.env.ADMIN_TOKEN_NEXT;
+  if (!current) {
+    return c.json({ error: "ADMIN_TOKEN is not configured" }, 503);
+  }
+  const auth = c.req.header("authorization") ?? "";
+  const token = auth.replace(/^Bearer\s+/i, "");
+  if (!token || !isValidAdminToken(token, current, next)) {
+    return c.json({ error: "unauthorized" }, 401);
+  }
+
+  const feeds = await getFeedsDiagnostics(c.env.DB);
+  c.header("Cache-Control", "private, max-age=30");
+  return c.json({ feeds, count: feeds.length });
 });
 
 app.get("/cron-health", async (c) => {

--- a/apps/web/worker/db/feeds.ts
+++ b/apps/web/worker/db/feeds.ts
@@ -1,4 +1,11 @@
-import type { Article, FeedCategory, FeedConfig, FeedHealth, FeedLang } from "../types";
+import type {
+  Article,
+  FeedCategory,
+  FeedConfig,
+  FeedDiagnostic,
+  FeedHealth,
+  FeedLang,
+} from "../types";
 
 export interface FeedHeaders {
   last_etag: string | null;
@@ -344,6 +351,76 @@ export async function getCategoriesSummary(db: D1Database): Promise<CategorySumm
         last_published_at: null,
       },
   );
+}
+
+/**
+ * 全フィードの運用診断情報を 1 クエリで返す。
+ * feeds テーブルの全カラム + articles の累積件数・30d 件数・最終公開日時を JOIN する。
+ * enabled の有無に関わらず全フィードを返す (運用ダッシュボード用)。
+ */
+export async function getFeedsDiagnostics(db: D1Database): Promise<FeedDiagnostic[]> {
+  const threshold = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+
+  const rows = await db
+    .prepare(
+      `SELECT f.id,
+              f.name,
+              f.url,
+              f.category,
+              f.lang,
+              f.enabled,
+              f.last_fetched_at,
+              f.last_status,
+              f.last_error,
+              f.last_etag,
+              f.last_modified,
+              f.consecutive_failures AS fetch_error_count,
+              COUNT(a.id) AS articles_total,
+              COUNT(CASE WHEN a.published_at >= ?1 THEN 1 END) AS articles_30d,
+              MAX(a.published_at) AS last_published_at
+       FROM feeds f
+       LEFT JOIN articles a ON a.feed_id = f.id
+       GROUP BY f.id, f.name, f.url, f.category, f.lang, f.enabled,
+                f.last_fetched_at, f.last_status, f.last_error,
+                f.last_etag, f.last_modified, f.consecutive_failures
+       ORDER BY f.id ASC`,
+    )
+    .bind(threshold)
+    .all<{
+      id: string;
+      name: string;
+      url: string;
+      category: string;
+      lang: string;
+      enabled: number;
+      last_fetched_at: string | null;
+      last_status: string | null;
+      last_error: string | null;
+      last_etag: string | null;
+      last_modified: string | null;
+      fetch_error_count: number;
+      articles_total: number;
+      articles_30d: number;
+      last_published_at: string | null;
+    }>();
+
+  return (rows.results ?? []).map((r) => ({
+    id: r.id,
+    name: r.name,
+    url: r.url,
+    category: r.category as FeedCategory,
+    lang: r.lang as FeedLang,
+    enabled: r.enabled === 1,
+    last_fetched_at: r.last_fetched_at,
+    last_status: r.last_status,
+    last_error: r.last_error,
+    last_etag: r.last_etag,
+    last_modified: r.last_modified,
+    fetch_error_count: r.fetch_error_count,
+    articles_total: r.articles_total,
+    articles_30d: r.articles_30d,
+    last_published_at: r.last_published_at,
+  }));
 }
 
 /**

--- a/apps/web/worker/types.ts
+++ b/apps/web/worker/types.ts
@@ -120,3 +120,21 @@ export interface FeedFailure {
   last_error: string | null;
   last_attempted_at: string | null;
 }
+
+export interface FeedDiagnostic {
+  id: string;
+  name: string;
+  url: string;
+  category: FeedCategory;
+  lang: FeedLang;
+  enabled: boolean;
+  last_fetched_at: string | null;
+  last_status: string | null;
+  last_error: string | null;
+  last_etag: string | null;
+  last_modified: string | null;
+  fetch_error_count: number;
+  articles_total: number;
+  articles_30d: number;
+  last_published_at: string | null;
+}


### PR DESCRIPTION
## 概要

全フィードの運用状態を一覧で取得できる診断用 API エンドポイントを追加する。

PR #66 で feeds テーブルに `last_etag` / `last_modified` が追加され、PR #95 で `enabled` の runtime override、PR #130 で collector_runs が記録されているが、これらを横断的に確認できる単一の API がなかった。
PR #166 の `/api/admin/cron-health` は集計値、PR #156 の `/api/feeds/:id` は単体のため、全フィードの運用ダッシュボード用途として本 API を追加する。

## 変更内容

- `apps/web/worker/types.ts`: `FeedDiagnostic` インターフェースを追加
- `apps/web/worker/db/feeds.ts`: `getFeedsDiagnostics()` を追加 — feeds + articles を 1 クエリで集計
- `apps/web/worker/api/admin.ts`: `GET /api/admin/feeds/diagnostics` を追加
  - ADMIN_TOKEN 認証 (既存パターン)
  - レスポンス: `{ feeds: FeedDiagnostic[], count: number }`
  - `Cache-Control: private, max-age=30`
- `apps/web/tests/worker/api/admin-feeds-diagnostics.test.ts`: テスト追加 (7ケース)

## テスト

- [x] 401: token なし / 不正 token → 401
- [x] 200: 空 DB → `{ feeds: [], count: 0 }`
- [x] 200: Cache-Control が `private, max-age=30`
- [x] 200: enabled / disabled 両方のフィードが含まれる
- [x] 200: `last_fetched_at`, `last_etag`, `last_status` フィールドが正しく返る
- [x] 200: エラー後は `last_error` / `fetch_error_count` が反映される
- [x] 200: articles 投入後に `articles_total` / `articles_30d` / `last_published_at` が反映される
- [x] `pnpm build && pnpm test` 全 395 件パス
- [x] `pnpm check` エラー 0 件

Closes #184

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin endpoint to retrieve feed diagnostics with status, error counts, HTTP cache metadata, and 30-day article statistics.

* **Tests**
  * Added comprehensive test coverage validating authentication, cache headers, error handling, and article metrics aggregation for the diagnostics endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->