### PR TITLE
feat(syndication): 言語別 feed /feeds/lang/:lang.{xml,json,atom} を追加

### DIFF
--- a/apps/web/tests/worker/api/syndication.test.ts
+++ b/apps/web/tests/worker/api/syndication.test.ts
@@ -602,3 +602,162 @@ describe("/feeds/author/:author.atom (author Atom)", () => {
     expect(res2.status).toBe(304);
   });
 });
+
+describe("/feeds/lang/:lang.xml (lang RSS)", () => {
+  it("returns 200 with application/rss+xml for ja", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/lang/ja.xml");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("application/rss+xml");
+    const text = await res.text();
+    expect(text.startsWith("<?xml")).toBe(true);
+    expect(text).toContain('<rss version="2.0"');
+    // title に「日本語」を含む
+    expect(text).toContain("日本語");
+    // ja 記事のみ
+    expect(text).toContain("g-jp");
+    expect(text).not.toContain("g-ai");
+    expect(text).not.toContain("g-bigtech");
+  });
+
+  it("returns 200 with application/rss+xml for en", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/lang/en.xml");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("application/rss+xml");
+    const text = await res.text();
+    // en 記事のみ
+    expect(text).toContain("g-ai");
+    expect(text).toContain("g-bigtech");
+    expect(text).not.toContain("g-jp");
+  });
+
+  it("returns 404 for invalid lang (fr)", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/lang/fr.xml");
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for uppercase lang (JA)", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/lang/JA.xml");
+    expect(res.status).toBe(404);
+  });
+
+  it("returns Cache-Control: public, max-age=600", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/lang/ja.xml");
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=600");
+  });
+
+  it("returns ETag header and supports 304 round-trip", async () => {
+    const res1 = await SELF.fetch("https://example.com/feeds/lang/ja.xml");
+    expect(res1.status).toBe(200);
+    const etag = res1.headers.get("ETag")!;
+    expect(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
+
+    const res2 = await SELF.fetch("https://example.com/feeds/lang/ja.xml", {
+      headers: { "If-None-Match": etag },
+    });
+    expect(res2.status).toBe(304);
+    expect(res2.headers.get("ETag")).toBe(etag);
+  });
+
+  it("returns articles in published_at DESC order", async () => {
+    // ja 記事を追加して並び順を確認
+    await insertArticles(env.DB, [
+      {
+        guid: "g-jp-newer",
+        feed_id: "cyberagent-developers",
+        title: "新しい日本語記事",
+        url: "https://x.test/m/newer",
+        summary: null,
+        author: null,
+        published_at: "2024-04-10T00:00:00.000Z",
+        category: "jp",
+        lang: "ja",
+      },
+    ]);
+    const res = await SELF.fetch("https://example.com/feeds/lang/ja.xml");
+    const text = await res.text();
+    const pos1 = text.indexOf("g-jp-newer");
+    const pos2 = text.indexOf("g-jp");
+    expect(pos1).toBeLessThan(pos2);
+  });
+});
+
+describe("/feeds/lang/:lang.json (lang JSON Feed)", () => {
+  it("returns 200 with application/feed+json for ja with correct item count", async () => {
+    // beforeEach: ja=1 (g-jp), en=2 (g-ai, g-bigtech)
+    const res = await SELF.fetch("https://example.com/feeds/lang/ja.json");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("application/feed+json");
+    const body = (await res.json()) as {
+      version: string;
+      title: string;
+      items: { id: string }[];
+    };
+    expect(body.version).toBe("https://jsonfeed.org/version/1.1");
+    expect(body.items.length).toBe(1);
+    expect(body.items.map((i) => i.id)).toContain("g-jp");
+  });
+
+  it("returns correct item count for en (2 articles)", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/lang/en.json");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { items: { id: string }[] };
+    expect(body.items.length).toBe(2);
+    expect(body.items.map((i) => i.id)).toContain("g-ai");
+    expect(body.items.map((i) => i.id)).toContain("g-bigtech");
+  });
+
+  it("returns 404 for invalid lang", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/lang/fr.json");
+    expect(res.status).toBe(404);
+  });
+
+  it("returns Cache-Control: public, max-age=600", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/lang/en.json");
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=600");
+  });
+
+  it("ETag differs between ja and en", async () => {
+    const resJa = await SELF.fetch("https://example.com/feeds/lang/ja.json");
+    const resEn = await SELF.fetch("https://example.com/feeds/lang/en.json");
+    const etagJa = resJa.headers.get("ETag");
+    const etagEn = resEn.headers.get("ETag");
+    expect(etagJa).not.toBeNull();
+    expect(etagEn).not.toBeNull();
+    expect(etagJa).not.toBe(etagEn);
+  });
+});
+
+describe("/feeds/lang/:lang.atom (lang Atom)", () => {
+  it("returns 200 with application/atom+xml for ja", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/lang/ja.atom");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("application/atom+xml");
+    const text = await res.text();
+    expect(text.startsWith("<?xml")).toBe(true);
+    expect(text).toContain('<feed xmlns="http://www.w3.org/2005/Atom">');
+    expect(text).toContain("g-jp");
+    expect(text).not.toContain("g-ai");
+  });
+
+  it("returns 404 for invalid lang", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/lang/fr.atom");
+    expect(res.status).toBe(404);
+  });
+
+  it("returns Cache-Control: public, max-age=600", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/lang/ja.atom");
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=600");
+  });
+
+  it("returns ETag header and supports 304 round-trip", async () => {
+    const res1 = await SELF.fetch("https://example.com/feeds/lang/en.atom");
+    expect(res1.status).toBe(200);
+    const etag = res1.headers.get("ETag")!;
+    expect(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
+
+    const res2 = await SELF.fetch("https://example.com/feeds/lang/en.atom", {
+      headers: { "If-None-Match": etag },
+    });
+    expect(res2.status).toBe(304);
+  });
+});

--- a/apps/web/tests/worker/api/syndication.test.ts
+++ b/apps/web/tests/worker/api/syndication.test.ts
@@ -659,10 +659,11 @@ describe("/feeds/lang/:lang.xml (lang RSS)", () => {
   });
 
   it("returns articles in published_at DESC order", async () => {
-    // ja 記事を追加して並び順を確認
+    // ja 記事を追加して並び順を確認。g-jp という prefix を含む guid を避けるため
+    // 別の名前を使い indexOf のマッチ重複を防ぐ。
     await insertArticles(env.DB, [
       {
-        guid: "g-jp-newer",
+        guid: "lang-ja-newest",
         feed_id: "cyberagent-developers",
         title: "新しい日本語記事",
         url: "https://x.test/m/newer",
@@ -675,7 +676,7 @@ describe("/feeds/lang/:lang.xml (lang RSS)", () => {
     ]);
     const res = await SELF.fetch("https://example.com/feeds/lang/ja.xml");
     const text = await res.text();
-    const pos1 = text.indexOf("g-jp-newer");
+    const pos1 = text.indexOf("lang-ja-newest");
     const pos2 = text.indexOf("g-jp");
     expect(pos1).toBeLessThan(pos2);
   });

--- a/apps/web/worker/api/syndication.ts
+++ b/apps/web/worker/api/syndication.ts
@@ -22,6 +22,12 @@ const CATEGORY_DISPLAY_NAMES: Record<FeedCategory, string> = {
   zenn: "Zenn",
 };
 
+// 言語ごとの表示名 mapping
+const LANG_DISPLAY_NAMES: Record<FeedLang, string> = {
+  ja: "日本語のテック記事 - tech-news-bot",
+  en: "English Tech Articles - tech-news-bot",
+};
+
 const app = new Hono<{ Bindings: Env }>();
 
 function parseFilters(c: { req: { query: (k: string) => string | undefined } }) {
@@ -493,6 +499,199 @@ async function buildAuthorAtomFeed(
     `<feed xmlns="http://www.w3.org/2005/Atom">` +
     `<title>${escapeXml(title)}</title>` +
     `<subtitle>${escapeXml(description)}</subtitle>` +
+    `<link href="${escapeXml(origin)}/" rel="alternate"/>` +
+    `<link href="${escapeXml(feedUrl)}" rel="self"/>` +
+    `<id>tag:${escapeXml(hostname)},${year}:${escapeXml(feedPath)}</id>` +
+    `<updated>${updated}</updated>` +
+    `<generator uri="https://github.com/rikeda71/tech-news-bot">tech-news-bot</generator>` +
+    entries +
+    `</feed>`;
+
+  c.header("Content-Type", "application/atom+xml; charset=utf-8");
+  c.header("ETag", etag);
+  c.header("Cache-Control", "public, max-age=600");
+  return c.body(xml);
+}
+
+// 言語別 syndication エンドポイント
+// :lang は "ja" / "en" のみ受け付け、それ以外は 404。
+// /feeds/category/* / /feeds/author/* と同様、/feeds/:filename より前に登録する。
+app.get("/feeds/lang/*", async (c) => {
+  const pathname = new URL(c.req.url).pathname;
+  const basename = pathname.replace(/^.*\/feeds\/lang\//, "");
+
+  let lang: FeedLang;
+  let format: "json" | "xml" | "atom";
+
+  if (basename.endsWith(".json")) {
+    lang = basename.slice(0, -5) as FeedLang;
+    format = "json";
+  } else if (basename.endsWith(".xml")) {
+    lang = basename.slice(0, -4) as FeedLang;
+    format = "xml";
+  } else if (basename.endsWith(".atom")) {
+    lang = basename.slice(0, -5) as FeedLang;
+    format = "atom";
+  } else {
+    return c.json({ error: "Not Found" }, 404);
+  }
+
+  if (!(VALID_LANGS as string[]).includes(lang)) {
+    return c.json({ error: "Not Found" }, 404);
+  }
+
+  const titleOverride = LANG_DISPLAY_NAMES[lang];
+
+  if (format === "json") {
+    return buildLangJsonFeed(c, lang, titleOverride);
+  }
+  if (format === "atom") {
+    return buildLangAtomFeed(c, lang, titleOverride);
+  }
+  return buildLangRssFeed(c, lang, titleOverride);
+});
+
+async function buildLangRssFeed(
+  c: Context<{ Bindings: Env }>,
+  lang: FeedLang,
+  title: string,
+): Promise<Response> {
+  const etag = await computeSyndicationEtag(c.env.DB, FEEDS_VERSION, { lang });
+  if (c.req.header("If-None-Match") === etag) {
+    c.header("ETag", etag);
+    c.header("Cache-Control", "public, max-age=600");
+    return c.body(null, 304);
+  }
+
+  const result = await listArticles(c.env.DB, { lang, limit: FEED_LIMIT, cursor: null });
+  const origin = siteOrigin(c.req.url);
+  const feedUrl = new URL(c.req.url).toString();
+  const lastBuild = result.articles[0]?.published_at ?? new Date().toISOString();
+  const description = title;
+
+  const items = result.articles
+    .map((a) => {
+      const parts = [
+        `<item>`,
+        `<title>${escapeXml(a.title)}</title>`,
+        `<link>${escapeXml(a.url)}</link>`,
+        `<guid isPermaLink="false">${escapeXml(a.guid)}</guid>`,
+        `<pubDate>${toRfc822(a.published_at)}</pubDate>`,
+        `<category>${escapeXml(a.category)}</category>`,
+      ];
+      if (a.feed_name) parts.push(`<source>${escapeXml(a.feed_name)}</source>`);
+      if (a.author) parts.push(`<author>${escapeXml(a.author)}</author>`);
+      if (a.summary) parts.push(`<description>${escapeXml(a.summary)}</description>`);
+      parts.push(`</item>`);
+      return parts.join("");
+    })
+    .join("");
+
+  const xml =
+    `<?xml version="1.0" encoding="UTF-8"?>` +
+    `<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">` +
+    `<channel>` +
+    `<title>${escapeXml(title)}</title>` +
+    `<link>${escapeXml(origin)}</link>` +
+    `<description>${escapeXml(description)}</description>` +
+    `<language>${escapeXml(lang)}</language>` +
+    `<lastBuildDate>${toRfc822(lastBuild)}</lastBuildDate>` +
+    `<atom:link href="${escapeXml(feedUrl)}" rel="self" type="application/rss+xml"/>` +
+    items +
+    `</channel></rss>`;
+
+  c.header("Content-Type", "application/rss+xml; charset=utf-8");
+  c.header("ETag", etag);
+  c.header("Cache-Control", "public, max-age=600");
+  return c.body(xml);
+}
+
+async function buildLangJsonFeed(
+  c: Context<{ Bindings: Env }>,
+  lang: FeedLang,
+  title: string,
+): Promise<Response> {
+  const etag = await computeSyndicationEtag(c.env.DB, FEEDS_VERSION, { lang });
+  if (c.req.header("If-None-Match") === etag) {
+    c.header("ETag", etag);
+    c.header("Cache-Control", "public, max-age=600");
+    return c.body(null, 304);
+  }
+
+  const result = await listArticles(c.env.DB, { lang, limit: FEED_LIMIT, cursor: null });
+  const origin = siteOrigin(c.req.url);
+  const feedUrl = new URL(c.req.url).toString();
+
+  const json = {
+    version: "https://jsonfeed.org/version/1.1",
+    title,
+    description: title,
+    home_page_url: origin || undefined,
+    feed_url: feedUrl,
+    language: lang,
+    items: result.articles.map((a) => ({
+      id: a.guid,
+      url: a.url,
+      title: a.title,
+      content_text: a.summary ?? "",
+      summary: a.summary ?? undefined,
+      date_published: a.published_at,
+      authors: a.author ? [{ name: a.author }] : undefined,
+      tags: [a.category, a.lang, ...(a.feed_name ? [a.feed_name] : [])],
+      _feed_id: a.feed_id,
+    })),
+  };
+
+  c.header("Content-Type", "application/feed+json; charset=utf-8");
+  c.header("ETag", etag);
+  c.header("Cache-Control", "public, max-age=600");
+  return c.body(JSON.stringify(json));
+}
+
+async function buildLangAtomFeed(
+  c: Context<{ Bindings: Env }>,
+  lang: FeedLang,
+  title: string,
+): Promise<Response> {
+  const etag = await computeSyndicationEtag(c.env.DB, FEEDS_VERSION, { lang });
+  if (c.req.header("If-None-Match") === etag) {
+    c.header("ETag", etag);
+    c.header("Cache-Control", "public, max-age=600");
+    return c.body(null, 304);
+  }
+
+  const result = await listArticles(c.env.DB, { lang, limit: FEED_LIMIT, cursor: null });
+  const origin = siteOrigin(c.req.url);
+  const feedUrl = new URL(c.req.url).toString();
+  const feedPath = new URL(c.req.url).pathname;
+  const hostname = new URL(c.req.url).hostname || "example.com";
+  const year = new Date().getFullYear();
+  const updated = result.articles[0]?.published_at ?? new Date().toISOString();
+
+  const entries = result.articles
+    .map((a) => {
+      const authorName = a.author ?? a.feed_name ?? "";
+      const parts = [
+        `<entry>`,
+        `<title>${escapeXml(a.title)}</title>`,
+        `<id>${escapeXml(a.guid)}</id>`,
+        `<link href="${escapeXml(a.url)}" rel="alternate"/>`,
+        `<updated>${a.published_at}</updated>`,
+        `<published>${a.published_at}</published>`,
+      ];
+      if (authorName) parts.push(`<author><name>${escapeXml(authorName)}</name></author>`);
+      parts.push(`<category term="${escapeXml(a.category)}"/>`);
+      if (a.summary) parts.push(`<summary type="html">${escapeXml(a.summary)}</summary>`);
+      parts.push(`</entry>`);
+      return parts.join("");
+    })
+    .join("");
+
+  const xml =
+    `<?xml version="1.0" encoding="utf-8"?>` +
+    `<feed xmlns="http://www.w3.org/2005/Atom">` +
+    `<title>${escapeXml(title)}</title>` +
+    `<subtitle>${escapeXml(title)}</subtitle>` +
     `<link href="${escapeXml(origin)}/" rel="alternate"/>` +
     `<link href="${escapeXml(feedUrl)}" rel="self"/>` +
     `<id>tag:${escapeXml(hostname)},${year}:${escapeXml(feedPath)}</id>` +


### PR DESCRIPTION
## Summary

- `/feeds/lang/ja.{xml,json,atom}` および `/feeds/lang/en.{xml,json,atom}` エンドポイントを追加
- `:lang` は `ja` / `en` のみ受け付け、それ以外 (例: `fr`, `JA`) は 404 を返す
- 直近 50 件を `published_at DESC` で返す
- `Cache-Control: public, max-age=600`、ETag による 304 に対応
- `/feeds/category/*` / `/feeds/author/*` と同様のパターンで実装

## Test plan

- [x] `/feeds/lang/ja.xml` → 200, `application/rss+xml`, title に「日本語」を含む
- [x] `/feeds/lang/en.json` → 200, `application/feed+json`, items 配列
- [x] `/feeds/lang/ja.atom` → 200, `application/atom+xml`
- [x] `/feeds/lang/fr.xml` → 404
- [x] `/feeds/lang/JA.xml` → 404 (大文字小文字区別)
- [x] ja=1, en=2 で items.length が正しい
- [x] `Cache-Control: public, max-age=600`
- [x] ETag が ja / en で異なる値を持つ
- [x] `published_at DESC` 順

Closes #186