### PR TITLE
feat(api): add GET /api endpoint catalog

### DIFF
--- a/apps/web/tests/worker/api/index-page.test.ts
+++ b/apps/web/tests/worker/api/index-page.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vite-plus/test";
+import { SELF } from "cloudflare:test";
+
+describe("GET /api", () => {
+  it("returns 200", async () => {
+    const res = await SELF.fetch("https://example.com/api");
+    expect(res.status).toBe(200);
+  });
+
+  it("returns Content-Type: application/json", async () => {
+    const res = await SELF.fetch("https://example.com/api");
+    expect(res.headers.get("Content-Type")).toContain("application/json");
+  });
+
+  it("returns Cache-Control: public, max-age=3600", async () => {
+    const res = await SELF.fetch("https://example.com/api");
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=3600");
+  });
+
+  it("endpoints array is non-empty", async () => {
+    const res = await SELF.fetch("https://example.com/api");
+    const body = (await res.json()) as { endpoints: unknown[] };
+    expect(Array.isArray(body.endpoints)).toBe(true);
+    expect(body.endpoints.length).toBeGreaterThan(0);
+  });
+
+  it("syndication array is non-empty", async () => {
+    const res = await SELF.fetch("https://example.com/api");
+    const body = (await res.json()) as { syndication: unknown[] };
+    expect(Array.isArray(body.syndication)).toBe(true);
+    expect(body.syndication.length).toBeGreaterThan(0);
+  });
+
+  it("contains /api/articles endpoint", async () => {
+    const res = await SELF.fetch("https://example.com/api");
+    const body = (await res.json()) as { endpoints: Array<{ path: string }> };
+    const paths = body.endpoints.map((e) => e.path);
+    expect(paths).toContain("/api/articles");
+  });
+
+  it("contains /api/stats endpoint", async () => {
+    const res = await SELF.fetch("https://example.com/api");
+    const body = (await res.json()) as { endpoints: Array<{ path: string }> };
+    const paths = body.endpoints.map((e) => e.path);
+    expect(paths).toContain("/api/stats");
+  });
+
+  it("contains /api/health endpoint", async () => {
+    const res = await SELF.fetch("https://example.com/api");
+    const body = (await res.json()) as { endpoints: Array<{ path: string }> };
+    const paths = body.endpoints.map((e) => e.path);
+    expect(paths).toContain("/api/health");
+  });
+
+  it("admin endpoints have auth: admin", async () => {
+    const res = await SELF.fetch("https://example.com/api");
+    const body = (await res.json()) as {
+      endpoints: Array<{ path: string; auth: string }>;
+    };
+    const adminEndpoints = body.endpoints.filter((e) => e.path.startsWith("/api/admin"));
+    expect(adminEndpoints.length).toBeGreaterThan(0);
+    for (const ep of adminEndpoints) {
+      expect(ep.auth).toBe("admin");
+    }
+  });
+
+  it("non-admin public endpoints have auth: none", async () => {
+    const res = await SELF.fetch("https://example.com/api");
+    const body = (await res.json()) as {
+      endpoints: Array<{ path: string; auth: string }>;
+    };
+    const publicEndpoints = body.endpoints.filter((e) => !e.path.startsWith("/api/admin"));
+    expect(publicEndpoints.length).toBeGreaterThan(0);
+    for (const ep of publicEndpoints) {
+      expect(ep.auth).toBe("none");
+    }
+  });
+
+  it("name and version fields are present", async () => {
+    const res = await SELF.fetch("https://example.com/api");
+    const body = (await res.json()) as { name: string; version: string };
+    expect(typeof body.name).toBe("string");
+    expect(body.name.length).toBeGreaterThan(0);
+    expect(typeof body.version).toBe("string");
+  });
+});

--- a/apps/web/worker/api/catalog.ts
+++ b/apps/web/worker/api/catalog.ts
@@ -1,0 +1,178 @@
+import type { Context } from "hono";
+import type { Env } from "../types";
+
+type Auth = "none" | "admin";
+
+interface EndpointEntry {
+  method: string;
+  path: string;
+  description: string;
+  auth: Auth;
+}
+
+interface SyndicationEntry {
+  path: string;
+  format: string;
+}
+
+interface CatalogResponse {
+  name: string;
+  version: string;
+  description: string;
+  endpoints: EndpointEntry[];
+  syndication: SyndicationEntry[];
+  docs_url: string;
+}
+
+const CATALOG: CatalogResponse = {
+  name: "tech-news-bot API",
+  version: "1.0",
+  description: "Tech blog RSS/Atom aggregator API running on Cloudflare Workers",
+  endpoints: [
+    {
+      method: "GET",
+      path: "/api/articles",
+      description: "記事一覧 (cursor pagination)",
+      auth: "none",
+    },
+    {
+      method: "GET",
+      path: "/api/articles/:guid/related",
+      description: "関連記事",
+      auth: "none",
+    },
+    {
+      method: "GET",
+      path: "/api/articles/:guid/neighbors",
+      description: "前後の記事",
+      auth: "none",
+    },
+    {
+      method: "GET",
+      path: "/api/articles/by-author/:author",
+      description: "著者別記事 (cursor pagination)",
+      auth: "none",
+    },
+    {
+      method: "GET",
+      path: "/api/articles/by-feed/:feedId",
+      description: "フィード別記事 (cursor pagination)",
+      auth: "none",
+    },
+    {
+      method: "GET",
+      path: "/api/articles/calendar",
+      description: "日別記事数 (heatmap data)",
+      auth: "none",
+    },
+    {
+      method: "GET",
+      path: "/api/articles/random",
+      description: "ランダム記事",
+      auth: "none",
+    },
+    {
+      method: "GET",
+      path: "/api/articles/archive",
+      description: "月別アーカイブ",
+      auth: "none",
+    },
+    {
+      method: "GET",
+      path: "/api/articles/:id",
+      description: "記事 1 件",
+      auth: "none",
+    },
+    {
+      method: "GET",
+      path: "/api/feeds",
+      description: "フィード一覧 + 30d 統計",
+      auth: "none",
+    },
+    {
+      method: "GET",
+      path: "/api/feeds/:id",
+      description: "フィード詳細 + 直近記事",
+      auth: "none",
+    },
+    {
+      method: "GET",
+      path: "/api/categories",
+      description: "カテゴリ別サマリ",
+      auth: "none",
+    },
+    {
+      method: "GET",
+      path: "/api/stats",
+      description: "統計情報",
+      auth: "none",
+    },
+    {
+      method: "GET",
+      path: "/api/health",
+      description: "ヘルスチェック",
+      auth: "none",
+    },
+    {
+      method: "POST",
+      path: "/api/admin/collect",
+      description: "手動収集トリガ",
+      auth: "admin",
+    },
+    {
+      method: "POST",
+      path: "/api/admin/feeds/:id/enabled",
+      description: "フィード ON/OFF",
+      auth: "admin",
+    },
+    {
+      method: "POST",
+      path: "/api/admin/feeds/validate",
+      description: "フィード URL 検証",
+      auth: "admin",
+    },
+    {
+      method: "GET",
+      path: "/api/admin/runs",
+      description: "Cron 実行履歴",
+      auth: "admin",
+    },
+    {
+      method: "GET",
+      path: "/api/admin/cron-health",
+      description: "Cron 運用メトリクス",
+      auth: "admin",
+    },
+    {
+      method: "GET",
+      path: "/api/admin/feeds/diagnostics",
+      description: "フィード診断",
+      auth: "admin",
+    },
+  ],
+  syndication: [
+    { path: "/feeds.json", format: "JSON Feed v1.1" },
+    { path: "/feeds.xml", format: "RSS 2.0" },
+    { path: "/feeds.atom", format: "Atom 1.0" },
+    {
+      path: "/feeds/category/:cat.{xml,json,atom}",
+      format: "RSS / JSON Feed / Atom (category)",
+    },
+    {
+      path: "/feeds/lang/:lang.{xml,json,atom}",
+      format: "RSS / JSON Feed / Atom (lang)",
+    },
+    {
+      path: "/feeds/author/:author.{xml,json,atom}",
+      format: "RSS / JSON Feed / Atom (author)",
+    },
+    { path: "/feeds.opml", format: "OPML 2.0" },
+  ],
+  docs_url: "https://github.com/rikeda71/tech-news-bot",
+};
+
+// 変更頻度が低いため長めのキャッシュを設定する
+export function catalogHandler(c: Context<{ Bindings: Env }>) {
+  c.header("Cache-Control", "public, max-age=3600");
+  return c.json(CATALOG);
+}

--- a/apps/web/worker/api/router.ts
+++ b/apps/web/worker/api/router.ts
@@ -9,6 +9,7 @@ import health from "./health";
 import stats from "./stats";
 import admin from "./admin";
 import docs from "./docs";
+import { catalogHandler } from "./catalog";
 
 const api = new Hono<{ Bindings: Env }>();
 
@@ -28,6 +29,9 @@ const PUBLIC_PATHS = ["/articles/*", "/categories/*", "/feeds/*", "/stats/*", "/
 for (const path of PUBLIC_PATHS) {
   api.use(path, allowedOriginsCors);
 }
+
+// /api catalog — 他のルートより前に登録して確実に /api で捕捉する
+api.get("/", catalogHandler);
 
 api.route("/articles", articles);
 api.route("/categories", categories);


### PR DESCRIPTION
## Summary

- `GET /api` で全 public endpoint のメタ情報 (path, method, description, auth) を JSON で返す catalog エンドポイントを実装
- `worker/api/catalog.ts` に手動定義の endpoint 一覧を集約し、`Cache-Control: public, max-age=3600` を設定
- `worker/api/router.ts` に `api.get('/', catalogHandler)` を追加して `/api` を捕捉
- 統合テスト 11 cases を追加 (`tests/worker/api/index-page.test.ts`)

## Test plan

- [ ] `GET /api` → 200, `application/json`, `Cache-Control: public, max-age=3600`
- [ ] `endpoints` / `syndication` 配列が空でない
- [ ] `/api/articles`, `/api/stats`, `/api/health` が含まれる
- [ ] admin endpoint に `auth: "admin"` が付いている
- [ ] `pnpm build && pnpm test` pass (422 → 433 tests)

Closes #190