### PR TITLE
feat(client): FeedDetail に cursor pagination「もっと見る」を追加

### DIFF
--- a/apps/web/client/components/FeedDetail.tsx
+++ b/apps/web/client/components/FeedDetail.tsx
@@ -1,3 +1,4 @@
+import { useFeedArticles } from "../hooks/useFeedArticles";
 import { useFeedDetail } from "../hooks/useFeedDetail";
 import type { FeedCategory } from "../types/api";
 import { ArticleCard } from "./ArticleCard";
@@ -17,7 +18,20 @@ interface Props {
 }
 
 export function FeedDetail({ feedId, onBack, onFilterByFeedId, onFilterByCategory }: Props) {
-  const { feed, articles, isLoading, error } = useFeedDetail(feedId);
+  // feed メタ (name, url, category, lang, articles_30d) のみ useFeedDetail で取得
+  const { feed, isLoading: metaLoading, error: metaError } = useFeedDetail(feedId);
+  // 記事一覧は cursor pagination 対応の hook で管理
+  const {
+    articles,
+    isLoading: articlesLoading,
+    error: articlesError,
+    hasMore,
+    loadMore,
+    loadingMore,
+  } = useFeedArticles(feedId);
+
+  const isLoading = metaLoading || articlesLoading;
+  const error = metaError;
 
   if (isLoading) {
     return <div className="loader">読み込み中…</div>;
@@ -72,7 +86,8 @@ export function FeedDetail({ feedId, onBack, onFilterByFeedId, onFilterByCategor
 
       <section className="feed-detail-articles">
         <h3 className="feed-detail-articles-title">直近の記事</h3>
-        {articles.length === 0 ? (
+        {articlesError && <div className="error">取得エラー: {articlesError}</div>}
+        {!articlesError && articles.length === 0 ? (
           <div className="empty">記事がありません</div>
         ) : (
           <div className="article-list">
@@ -85,6 +100,11 @@ export function FeedDetail({ feedId, onBack, onFilterByFeedId, onFilterByCategor
               />
             ))}
           </div>
+        )}
+        {hasMore && (
+          <button type="button" className="load-more" onClick={loadMore} disabled={loadingMore}>
+            {loadingMore ? "読み込み中…" : "もっと見る"}
+          </button>
         )}
       </section>
     </div>

--- a/apps/web/client/hooks/useFeedArticles.ts
+++ b/apps/web/client/hooks/useFeedArticles.ts
@@ -1,0 +1,92 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Article, ArticlesResponse } from "../types/api";
+
+interface State {
+  articles: Article[];
+  nextCursor: string | null;
+  isLoading: boolean;
+  loadingMore: boolean;
+  error: string | null;
+}
+
+const initial: State = {
+  articles: [],
+  nextCursor: null,
+  isLoading: false,
+  loadingMore: false,
+  error: null,
+};
+
+function buildUrl(feedId: string, limit: number, cursor?: string | null): string {
+  const params = new URLSearchParams();
+  params.set("limit", String(limit));
+  if (cursor) params.set("cursor", cursor);
+  return `/api/articles/by-feed/${encodeURIComponent(feedId)}?${params.toString()}`;
+}
+
+export function useFeedArticles(feedId: string, limit = 20) {
+  const [state, setState] = useState<State>(initial);
+  const reqIdRef = useRef(0);
+
+  const fetchInitial = useCallback(async () => {
+    if (!feedId) return;
+    const reqId = ++reqIdRef.current;
+    setState((s) => ({ ...s, isLoading: true, error: null }));
+    try {
+      const res = await fetch(buildUrl(feedId, limit));
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = (await res.json()) as ArticlesResponse;
+      if (reqId !== reqIdRef.current) return;
+      setState({
+        articles: data.articles,
+        nextCursor: data.nextCursor,
+        isLoading: false,
+        loadingMore: false,
+        error: null,
+      });
+    } catch (err) {
+      if (reqId !== reqIdRef.current) return;
+      setState({
+        articles: [],
+        nextCursor: null,
+        isLoading: false,
+        loadingMore: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }, [feedId, limit]);
+
+  useEffect(() => {
+    void fetchInitial();
+  }, [fetchInitial]);
+
+  const loadMore = useCallback(async () => {
+    if (!state.nextCursor || state.loadingMore) return;
+    const cursor = state.nextCursor;
+    const reqId = reqIdRef.current;
+    setState((s) => ({ ...s, loadingMore: true }));
+    try {
+      const res = await fetch(buildUrl(feedId, limit, cursor));
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = (await res.json()) as ArticlesResponse;
+      if (reqId !== reqIdRef.current) return;
+      setState((s) => ({
+        articles: [...s.articles, ...data.articles],
+        nextCursor: data.nextCursor,
+        isLoading: false,
+        loadingMore: false,
+        error: null,
+      }));
+    } catch (err) {
+      if (reqId !== reqIdRef.current) return;
+      setState((s) => ({
+        ...s,
+        loadingMore: false,
+        error: err instanceof Error ? err.message : String(err),
+      }));
+    }
+  }, [feedId, limit, state.nextCursor, state.loadingMore]);
+
+  const hasMore = state.nextCursor !== null;
+  return { ...state, hasMore, loadMore };
+}

--- a/apps/web/tests/client/FeedDetail.test.tsx
+++ b/apps/web/tests/client/FeedDetail.test.tsx
@@ -35,21 +35,34 @@ const makeArticle = (id: number): Article => ({
   lang: "en",
 });
 
-describe("FeedDetail", () => {
-  const originalFetch = globalThis.fetch;
+function makeFeedMetaResponse() {
+  return {
+    ok: true,
+    json: () => Promise.resolve(baseFeedResponse),
+  };
+}
 
+function makeArticlesResponse(articles: Article[], nextCursor: string | null = null) {
+  return {
+    ok: true,
+    json: () => Promise.resolve({ articles, nextCursor }),
+  };
+}
+
+describe("FeedDetail", () => {
   beforeEach(() => {
     localStorage.clear();
+    vi.clearAllMocks();
   });
 
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
   it("ローディング中は読み込み中テキストを表示する", () => {
     // fetch を pending のままにして loading 状態を維持する
-    globalThis.fetch = vi.fn<() => Promise<Response>>(() => new Promise(() => {}));
+    vi.stubGlobal("fetch", vi.fn<() => Promise<Response>>().mockReturnValue(new Promise(() => {})));
     render(
       <FeedDetail
         feedId="test-feed"
@@ -62,10 +75,14 @@ describe("FeedDetail", () => {
   });
 
   it("フィード名・URL・articles_30d を表示する", async () => {
-    globalThis.fetch = vi.fn<() => Promise<Response>>().mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve(baseFeedResponse),
-    } as unknown as Response);
+    // 1 回目: /api/feeds/:id (feed meta), 2 回目: /api/articles/by-feed/:id
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn<() => Promise<Response>>()
+        .mockResolvedValueOnce(makeFeedMetaResponse() as unknown as Response)
+        .mockResolvedValueOnce(makeArticlesResponse([]) as unknown as Response),
+    );
 
     render(
       <FeedDetail
@@ -86,10 +103,13 @@ describe("FeedDetail", () => {
 
   it("記事 5 件の場合に 5 枚のカードが表示される", async () => {
     const articles = Array.from({ length: 5 }, (_, i) => makeArticle(i + 1));
-    globalThis.fetch = vi.fn<() => Promise<Response>>().mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve({ ...baseFeedResponse, recent_articles: articles }),
-    } as unknown as Response);
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn<() => Promise<Response>>()
+        .mockResolvedValueOnce(makeFeedMetaResponse() as unknown as Response)
+        .mockResolvedValueOnce(makeArticlesResponse(articles) as unknown as Response),
+    );
 
     render(
       <FeedDetail
@@ -111,10 +131,13 @@ describe("FeedDetail", () => {
   });
 
   it("記事 0 件のとき空状態メッセージを表示する", async () => {
-    globalThis.fetch = vi.fn<() => Promise<Response>>().mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve({ ...baseFeedResponse, recent_articles: [] }),
-    } as unknown as Response);
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn<() => Promise<Response>>()
+        .mockResolvedValueOnce(makeFeedMetaResponse() as unknown as Response)
+        .mockResolvedValueOnce(makeArticlesResponse([]) as unknown as Response),
+    );
 
     render(
       <FeedDetail
@@ -131,10 +154,13 @@ describe("FeedDetail", () => {
   });
 
   it("404 エラーのとき「フィードが見つかりません」を表示する", async () => {
-    globalThis.fetch = vi.fn<() => Promise<Response>>().mockResolvedValueOnce({
-      ok: false,
-      status: 404,
-    } as unknown as Response);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<() => Promise<Response>>().mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+      } as unknown as Response),
+    );
 
     render(
       <FeedDetail
@@ -151,10 +177,13 @@ describe("FeedDetail", () => {
   });
 
   it("「← 一覧に戻る」ボタンクリックで onBack が呼ばれる", async () => {
-    globalThis.fetch = vi.fn<() => Promise<Response>>().mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve(baseFeedResponse),
-    } as unknown as Response);
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn<() => Promise<Response>>()
+        .mockResolvedValueOnce(makeFeedMetaResponse() as unknown as Response)
+        .mockResolvedValueOnce(makeArticlesResponse([]) as unknown as Response),
+    );
 
     const onBack = vi.fn<() => void>();
     render(
@@ -176,22 +205,97 @@ describe("FeedDetail", () => {
     expect(onBack).toHaveBeenCalledTimes(1);
   });
 
+  it("「もっと見る」ボタンクリックで次ページが追加表示される", async () => {
+    const page1 = Array.from({ length: 20 }, (_, i) => makeArticle(i + 1));
+    const page2 = Array.from({ length: 5 }, (_, i) => makeArticle(i + 21));
+
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn<() => Promise<Response>>()
+        .mockResolvedValueOnce(makeFeedMetaResponse() as unknown as Response)
+        .mockResolvedValueOnce(makeArticlesResponse(page1, "cursor-next") as unknown as Response)
+        .mockResolvedValueOnce(makeArticlesResponse(page2, null) as unknown as Response),
+    );
+
+    const user = userEvent.setup();
+    render(
+      <FeedDetail
+        feedId="test-feed"
+        onBack={() => {}}
+        onFilterByFeedId={() => {}}
+        onFilterByCategory={() => {}}
+      />,
+    );
+
+    // フィードメタが表示されるまで待つ
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Test Feed" })).toBeTruthy();
+    });
+
+    // 初期 20 件が表示される
+    await waitFor(() => {
+      expect(screen.getByText("Article 1")).toBeTruthy();
+      expect(screen.getByText("Article 20")).toBeTruthy();
+    });
+
+    // 「もっと見る」ボタンが表示される
+    const loadMoreBtn = await screen.findByRole("button", { name: /もっと見る/ });
+    expect(loadMoreBtn).toBeTruthy();
+
+    // クリックで次ページが追加される
+    await user.click(loadMoreBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText("Article 25")).toBeTruthy();
+    });
+
+    // nextCursor=null で「もっと見る」ボタンが消える
+    expect(screen.queryByRole("button", { name: /もっと見る/ })).toBeNull();
+  });
+
+  it("hasMore=false (nextCursor=null) のとき「もっと見る」ボタンが表示されない", async () => {
+    const articles = Array.from({ length: 5 }, (_, i) => makeArticle(i + 1));
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn<() => Promise<Response>>()
+        .mockResolvedValueOnce(makeFeedMetaResponse() as unknown as Response)
+        .mockResolvedValueOnce(makeArticlesResponse(articles, null) as unknown as Response),
+    );
+
+    render(
+      <FeedDetail
+        feedId="test-feed"
+        onBack={() => {}}
+        onFilterByFeedId={() => {}}
+        onFilterByCategory={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Article 5")).toBeTruthy();
+    });
+
+    expect(screen.queryByRole("button", { name: /もっと見る/ })).toBeNull();
+  });
+
   it("feedId が変わると再 fetch する", async () => {
-    const fetchMock = vi.fn<() => Promise<Response>>();
-    fetchMock
+    const feedMeta2 = {
+      ...baseFeedResponse,
+      feed: { ...baseFeedResponse.feed, id: "other-feed", name: "Other Feed" },
+    };
+
+    const fetchMock = vi
+      .fn<() => Promise<Response>>()
+      .mockResolvedValueOnce(makeFeedMetaResponse() as unknown as Response)
+      .mockResolvedValueOnce(makeArticlesResponse([]) as unknown as Response)
       .mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve(baseFeedResponse),
+        json: () => Promise.resolve(feedMeta2),
       } as unknown as Response)
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            ...baseFeedResponse,
-            feed: { ...baseFeedResponse.feed, id: "other-feed", name: "Other Feed" },
-          }),
-      } as unknown as Response);
-    globalThis.fetch = fetchMock;
+      .mockResolvedValueOnce(makeArticlesResponse([]) as unknown as Response);
+    vi.stubGlobal("fetch", fetchMock);
 
     const { rerender } = render(
       <FeedDetail
@@ -219,8 +323,17 @@ describe("FeedDetail", () => {
       expect(screen.getByRole("heading", { name: "Other Feed" })).toBeTruthy();
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // feed meta と articles で各 2 回ずつ、計 4 回 fetch
+    expect(fetchMock).toHaveBeenCalledTimes(4);
     expect(fetchMock).toHaveBeenNthCalledWith(1, "/api/feeds/test-feed?recent=20");
-    expect(fetchMock).toHaveBeenNthCalledWith(2, "/api/feeds/other-feed?recent=20");
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("/api/articles/by-feed/test-feed"),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(3, "/api/feeds/other-feed?recent=20");
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      4,
+      expect.stringContaining("/api/articles/by-feed/other-feed"),
+    );
   });
 });

--- a/apps/web/tests/client/useFeedArticles.test.tsx
+++ b/apps/web/tests/client/useFeedArticles.test.tsx
@@ -1,0 +1,171 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import type { Article } from "../../client/types/api";
+
+const { useFeedArticles } = await import("../../client/hooks/useFeedArticles");
+
+function makeArticle(id: number): Article {
+  return {
+    id,
+    guid: `guid-${id}`,
+    feed_id: "test-feed",
+    feed_name: "Test Feed",
+    title: `Article ${id}`,
+    url: `https://example.com/article/${id}`,
+    summary: `Summary ${id}`,
+    author: "Author",
+    published_at: "2024-01-15T10:00:00Z",
+    fetched_at: "2024-01-15T11:00:00Z",
+    category: "ai",
+    lang: "en",
+  };
+}
+
+function makeArticlesResponse(articles: Article[], nextCursor: string | null = null) {
+  return {
+    ok: true,
+    json: () => Promise.resolve({ articles, nextCursor }),
+  };
+}
+
+describe("useFeedArticles", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("初期状態でローディングが true になる", () => {
+    vi.stubGlobal("fetch", vi.fn().mockReturnValue(new Promise(() => {})));
+    const { result } = renderHook(() => useFeedArticles("test-feed"));
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.articles).toEqual([]);
+  });
+
+  it("fetch 成功時に記事が返される", async () => {
+    const articles = Array.from({ length: 5 }, (_, i) => makeArticle(i + 1));
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeArticlesResponse(articles)));
+
+    const { result } = renderHook(() => useFeedArticles("test-feed"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.articles).toHaveLength(5);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("nextCursor が null のとき hasMore が false になる", async () => {
+    const articles = [makeArticle(1)];
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeArticlesResponse(articles, null)));
+
+    const { result } = renderHook(() => useFeedArticles("test-feed"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it("nextCursor がある場合 hasMore が true になる", async () => {
+    const articles = Array.from({ length: 20 }, (_, i) => makeArticle(i + 1));
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeArticlesResponse(articles, "cursor-abc")));
+
+    const { result } = renderHook(() => useFeedArticles("test-feed"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.hasMore).toBe(true);
+  });
+
+  it("fetch URL に feedId が含まれる", async () => {
+    const mockFetch = vi
+      .fn<() => Promise<Response>>()
+      .mockResolvedValue(makeArticlesResponse([]) as unknown as Response);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const { result } = renderHook(() => useFeedArticles("my-feed-id"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/articles/by-feed/my-feed-id"),
+    );
+  });
+
+  it("loadMore で次ページが追加される", async () => {
+    const page1 = Array.from({ length: 20 }, (_, i) => makeArticle(i + 1));
+    const page2 = Array.from({ length: 10 }, (_, i) => makeArticle(i + 21));
+
+    const mockFetch = vi
+      .fn<() => Promise<Response>>()
+      .mockResolvedValueOnce(makeArticlesResponse(page1, "cursor-next") as unknown as Response)
+      .mockResolvedValueOnce(makeArticlesResponse(page2, null) as unknown as Response);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const { result } = renderHook(() => useFeedArticles("test-feed"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.articles).toHaveLength(20);
+    expect(result.current.hasMore).toBe(true);
+
+    await act(async () => {
+      await result.current.loadMore();
+    });
+
+    await waitFor(() => {
+      expect(result.current.articles).toHaveLength(30);
+    });
+
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it("loadMore の URL に cursor が含まれる", async () => {
+    const page1 = Array.from({ length: 20 }, (_, i) => makeArticle(i + 1));
+    const mockFetch = vi
+      .fn<() => Promise<Response>>()
+      .mockResolvedValueOnce(makeArticlesResponse(page1, "cursor-xyz") as unknown as Response)
+      .mockResolvedValueOnce(makeArticlesResponse([], null) as unknown as Response);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const { result } = renderHook(() => useFeedArticles("test-feed"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.loadMore();
+    });
+
+    await waitFor(() => {
+      expect(result.current.loadingMore).toBe(false);
+    });
+
+    expect(mockFetch).toHaveBeenNthCalledWith(2, expect.stringContaining("cursor=cursor-xyz"));
+  });
+
+  it("fetch エラー時に error が設定される", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+
+    const { result } = renderHook(() => useFeedArticles("test-feed"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBeTruthy();
+    expect(result.current.articles).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #188

## Summary
- PR #183 の /api/articles/by-feed/:feedId を使い FeedDetail の記事を cursor pagination に対応
- useFeedArticles hook を新規追加 (useAuthorArticles と同パターン)
- FeedDetail に「もっと見る」ボタンを実装 (PR #179 AuthorDetail と同じ UX)

## Test plan
- useFeedArticles.test.tsx: hook 単体テスト 8 ケース
- FeedDetail.test.tsx: もっと見る / hasMore ケースを追加
- pnpm check pass
- pnpm --filter @tnb/web run test:client pass (165 tests)