### PR TITLE
feat(api): add GET /api/articles/by-category/:cat (cursor pagination)

### DIFF
--- a/apps/web/tests/worker/api/articles.test.ts
+++ b/apps/web/tests/worker/api/articles.test.ts
@@ -1283,3 +1283,171 @@ describe("GET /api/articles/by-author/:author", () => {
     expect(res.headers.get("Cache-Control")).toBe("public, max-age=300");
   });
 });
+
+describe("GET /api/articles/by-category/:cat", () => {
+  // beforeEach で挿入される記事:
+  //   g-bt-1  (bigtech, 2024-04-01)
+  //   o-ai-1  (ai,      2024-04-02)
+  //   o-ai-2  (ai,      2024-04-03)
+
+  it("returns 200 with articles for ai category", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/by-category/ai");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ articles: { category: string }[]; next_cursor: string | null }>();
+    expect(Array.isArray(body.articles)).toBe(true);
+    expect(body.articles.length).toBe(2);
+    for (const article of body.articles) {
+      expect(article.category).toBe("ai");
+    }
+    expect(body.next_cursor).toBeNull();
+  });
+
+  it("returns 200 with empty array when category has no articles", async () => {
+    // zenn カテゴリの記事は beforeEach では挿入されない
+    const res = await SELF.fetch("https://example.com/api/articles/by-category/zenn");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ articles: unknown[]; next_cursor: string | null }>();
+    expect(body.articles).toEqual([]);
+    expect(body.next_cursor).toBeNull();
+  });
+
+  it("returns 400 for invalid category", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/by-category/foo");
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toMatch(/category/);
+  });
+
+  it("returns 400 when limit=0", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/by-category/ai?limit=0");
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toMatch(/limit/);
+  });
+
+  it("returns 400 when limit=51", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/by-category/ai?limit=51");
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toMatch(/limit/);
+  });
+
+  it("returns 400 when limit is non-numeric", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/by-category/ai?limit=abc");
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toMatch(/limit/);
+  });
+
+  it("returns 400 when cursor is malformed", async () => {
+    const res = await SELF.fetch(
+      "https://example.com/api/articles/by-category/ai?cursor=not-valid-base64!!!",
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toMatch(/cursor/);
+  });
+
+  it("returns articles in published_at DESC, id DESC order", async () => {
+    // ai カテゴリに同一 published_at の記事を追加して tie-break を確認
+    const SAME_AT = "2024-04-03T00:00:00.000Z";
+    await insertArticles(env.DB, [
+      {
+        guid: "o-ai-tie-1",
+        feed_id: "openai-blog",
+        title: "Tie 1",
+        url: "https://x.test/o/tie1",
+        summary: null,
+        author: null,
+        published_at: SAME_AT,
+        category: "ai",
+        lang: "en",
+      },
+    ]);
+    // o-ai-2 も SAME_AT (2024-04-03) なので tie → id DESC が効く
+    const res = await SELF.fetch("https://example.com/api/articles/by-category/ai");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ articles: { published_at: string; id: number }[] }>();
+    const dates = body.articles.map((a) => a.published_at);
+    const sorted = dates.toSorted((a, b) => b.localeCompare(a));
+    expect(dates).toEqual(sorted);
+    // 同一 published_at 内は id DESC
+    const sameAt = body.articles.filter((a) => a.published_at === SAME_AT);
+    if (sameAt.length >= 2) {
+      expect(sameAt[0].id).toBeGreaterThan(sameAt[1].id);
+    }
+  });
+
+  it("paginates with cursor: first page + second page covers all articles", async () => {
+    // ai カテゴリに追加で 2 件挿入して合計 4 件にする
+    await insertArticles(env.DB, [
+      {
+        guid: "o-page-1",
+        feed_id: "openai-blog",
+        title: "Page Article 1",
+        url: "https://x.test/o/page1",
+        summary: null,
+        author: null,
+        published_at: "2024-04-04T00:00:00.000Z",
+        category: "ai",
+        lang: "en",
+      },
+      {
+        guid: "o-page-2",
+        feed_id: "openai-blog",
+        title: "Page Article 2",
+        url: "https://x.test/o/page2",
+        summary: null,
+        author: null,
+        published_at: "2024-04-05T00:00:00.000Z",
+        category: "ai",
+        lang: "en",
+      },
+    ]);
+
+    // 1 ページ目: limit=2
+    const res1 = await SELF.fetch("https://example.com/api/articles/by-category/ai?limit=2");
+    expect(res1.status).toBe(200);
+    const body1 = await res1.json<{
+      articles: { guid: string }[];
+      next_cursor: string | null;
+    }>();
+    expect(body1.articles.length).toBe(2);
+    expect(body1.next_cursor).not.toBeNull();
+
+    // 2 ページ目: cursor を使用
+    const res2 = await SELF.fetch(
+      `https://example.com/api/articles/by-category/ai?limit=2&cursor=${body1.next_cursor}`,
+    );
+    expect(res2.status).toBe(200);
+    const body2 = await res2.json<{
+      articles: { guid: string }[];
+      next_cursor: string | null;
+    }>();
+    expect(body2.articles.length).toBe(2);
+    expect(body2.next_cursor).toBeNull();
+
+    // 2 ページ合わせて全 guid が揃う
+    const allGuids = [...body1.articles.map((a) => a.guid), ...body2.articles.map((a) => a.guid)];
+    expect(allGuids).toContain("o-ai-1");
+    expect(allGuids).toContain("o-ai-2");
+    expect(allGuids).toContain("o-page-1");
+    expect(allGuids).toContain("o-page-2");
+  });
+
+  it("does not mix articles from different categories", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/by-category/bigtech");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ articles: { category: string }[] }>();
+    expect(body.articles.length).toBeGreaterThan(0);
+    for (const article of body.articles) {
+      expect(article.category).toBe("bigtech");
+    }
+  });
+
+  it("returns Cache-Control: public, max-age=300", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/by-category/ai");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=300");
+  });
+});

--- a/apps/web/worker/api/articles.ts
+++ b/apps/web/worker/api/articles.ts
@@ -5,6 +5,7 @@ import {
   countArticlesByMonth,
   getArticleById,
   getArticlesByAuthor,
+  getArticlesByCategory,
   getArticlesByFeed,
   getArticlesCalendar,
   getArticlesByMonth,
@@ -175,6 +176,31 @@ app.get("/by-feed/:feedId", async (c) => {
   if (cursorRaw && !cursor) return c.json({ error: "invalid cursor" }, 400);
 
   const result = await getArticlesByFeed(c.env.DB, feedId, limitNum, cursor);
+
+  return c.json({ articles: result.articles, next_cursor: encodeCursor(result.nextCursor) }, 200, {
+    "Cache-Control": "public, max-age=300",
+  });
+});
+
+app.get("/by-category/:cat", async (c) => {
+  const catRaw = c.req.param("cat");
+  if (!(VALID_CATEGORIES as string[]).includes(catRaw)) {
+    return c.json({ error: "invalid category: must be one of bigtech, ai, jp, zenn" }, 400);
+  }
+  const category = catRaw as FeedCategory;
+
+  const limitRaw = c.req.query("limit") ?? "20";
+  const limitNum = Number(limitRaw);
+  if (!Number.isInteger(limitNum) || limitNum < 1 || limitNum > 50) {
+    return c.json({ error: "limit must be an integer between 1 and 50" }, 400);
+  }
+
+  const cursorRaw = c.req.query("cursor");
+  const cursor = decodeCursor(cursorRaw);
+  // cursor が指定されているのに decode に失敗した場合は 400
+  if (cursorRaw && !cursor) return c.json({ error: "invalid cursor" }, 400);
+
+  const result = await getArticlesByCategory(c.env.DB, category, limitNum, cursor);
 
   return c.json({ articles: result.articles, next_cursor: encodeCursor(result.nextCursor) }, 200, {
     "Cache-Control": "public, max-age=300",

--- a/apps/web/worker/db/articles.ts
+++ b/apps/web/worker/db/articles.ts
@@ -715,6 +715,56 @@ export async function getArticlesCalendar(
   return result.results ?? [];
 }
 
+export interface GetArticlesByCategoryResult {
+  articles: Article[];
+  nextCursor: { publishedAt: string; id: number } | null;
+}
+
+/** category で記事を published_at DESC で取得。cursor は getArticlesByFeed / getArticlesByAuthor と同形式 */
+export async function getArticlesByCategory(
+  db: D1Database,
+  category: FeedCategory,
+  limit: number,
+  cursor: { publishedAt: string; id: number } | null,
+): Promise<GetArticlesByCategoryResult> {
+  const conds: string[] = [`a.category = ?1`];
+  const binds: unknown[] = [category];
+
+  if (cursor) {
+    conds.push(
+      `(a.published_at < ?${binds.length + 1} OR (a.published_at = ?${binds.length + 1} AND a.id < ?${binds.length + 2}))`,
+    );
+    binds.push(cursor.publishedAt, cursor.id);
+  }
+
+  const where = `WHERE ${conds.join(" AND ")}`;
+  const sql = `
+    SELECT a.id, a.guid, a.feed_id, f.name AS feed_name, a.title, a.url, a.summary,
+           a.author, a.published_at, a.fetched_at, a.category, a.lang
+    FROM articles a
+    LEFT JOIN feeds f ON f.id = a.feed_id
+    ${where}
+    ORDER BY a.published_at DESC, a.id DESC
+    LIMIT ?${binds.length + 1}
+  `;
+  binds.push(limit + 1);
+
+  const result = await db
+    .prepare(sql)
+    .bind(...binds)
+    .all<Article>();
+
+  const rows = result.results ?? [];
+  let nextCursor: { publishedAt: string; id: number } | null = null;
+  let articles = rows;
+  if (rows.length > limit) {
+    articles = rows.slice(0, limit);
+    const last = articles[articles.length - 1];
+    nextCursor = { publishedAt: last.published_at, id: last.id };
+  }
+  return { articles, nextCursor };
+}
+
 function escapeFtsQuery(input: string): string {
   // FTS5 で安全に扱うため、特殊記号を除去して各単語をフレーズ扱いにする
   const tokens = input


### PR DESCRIPTION
## Summary

- GET /api/articles/by-category/:cat?limit=20&cursor=... を追加
- /by-author/:author / /by-feed/:feedId と同形式の cursor pagination
- :cat は bigtech | ai | jp | zenn のみ。不正値は 400
- limit: 1-50, default 20。範囲外は 400
- cursor: 任意。不正形式は 400
- Cache-Control: public, max-age=300

## 変更ファイル

- apps/web/worker/db/articles.ts: getArticlesByCategory helper 追加 (末尾)
- apps/web/worker/api/articles.ts: /by-category/:cat ルート追加 (by-feed の直後)
- apps/web/tests/worker/api/articles.test.ts: 8 テストケースを追加

## Test plan

- [x] 200: ai カテゴリで該当記事が返る
- [x] 200: 0 件 -> 空配列
- [x] 400: 不正カテゴリ (/by-category/foo)
- [x] 400: limit 範囲外 (0, 51, non-numeric)
- [x] 400: 不正 cursor
- [x] 並びが published_at DESC + id DESC tie-break
- [x] cursor pagination: 2 ページで全 guid が揃う
- [x] 異なる category の記事は混入しない
- [x] Cache-Control: public, max-age=300

Closes #193