### PR TITLE
feat: GET /api/admin/runs/:id の仕様準拠 (Cache-Control・duration_ms・エラーメッセージ)

### DIFF
--- a/apps/web/tests/worker/api/admin.test.ts
+++ b/apps/web/tests/worker/api/admin.test.ts
@@ -314,7 +314,7 @@ describe("GET /api/admin/runs", () => {
 });
 
 describe("GET /api/admin/runs/:id", () => {
-  it("200: returns run detail with feeds", async () => {
+  it("200: returns run detail with feeds, duration_ms, and Cache-Control", async () => {
     const { run_id } = await startRun(env.DB, "2024-04-05T00:00:00.000Z", 2);
     await recordRunFeed(env.DB, run_id, "feed-a", "ok", 10, 800);
     await recordRunFeed(env.DB, run_id, "feed-b", "failed", 0, 200, "HTTP 500");
@@ -324,22 +324,46 @@ describe("GET /api/admin/runs/:id", () => {
       headers: AUTH_HEADER,
     });
     expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("private, max-age=30");
     const body = (await res.json()) as {
-      run: { id: number; feeds_ok: number };
-      feeds: { feed_id: string; status: string }[];
+      run: { id: number; feeds_ok: number; duration_ms: number | null };
+      feeds: { feed_id: string; status: string; error: string | null }[];
     };
     expect(body.run.id).toBe(run_id);
     expect(body.run.feeds_ok).toBe(1);
+    // 5s = 5000ms
+    expect(body.run.duration_ms).toBe(5000);
     expect(body.feeds).toHaveLength(2);
     const feedA = body.feeds.find((f) => f.feed_id === "feed-a");
     expect(feedA!.status).toBe("ok");
+    const feedB = body.feeds.find((f) => f.feed_id === "feed-b");
+    expect(feedB!.status).toBe("failed");
+    expect(feedB!.error).toBe("HTTP 500");
   });
 
-  it("404: returns not found for unknown id", async () => {
+  it("200: duration_ms is null when run is not yet completed", async () => {
+    const { run_id } = await startRun(env.DB, "2024-04-05T00:00:00.000Z", 2);
+
+    const res = await SELF.fetch(`https://example.com/api/admin/runs/${run_id}`, {
+      headers: AUTH_HEADER,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      run: { id: number; duration_ms: number | null };
+      feeds: unknown[];
+    };
+    expect(body.run.id).toBe(run_id);
+    expect(body.run.duration_ms).toBeNull();
+    expect(body.feeds).toHaveLength(0);
+  });
+
+  it("404: returns 'run not found' for unknown id", async () => {
     const res = await SELF.fetch("https://example.com/api/admin/runs/99999", {
       headers: AUTH_HEADER,
     });
     expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("run not found");
   });
 
   it("401: rejects unauthenticated request", async () => {

--- a/apps/web/worker/api/admin.ts
+++ b/apps/web/worker/api/admin.ts
@@ -294,9 +294,18 @@ app.get("/runs/:id", async (c) => {
   }
   const detail = await getRun(c.env.DB, idParam);
   if (!detail) {
-    return c.json({ error: "not found" }, 404);
+    return c.json({ error: "run not found" }, 404);
   }
-  return c.json(detail);
+
+  const { run, feeds } = detail;
+  // started_at / completed_at から duration_ms を計算する
+  const duration_ms =
+    run.completed_at !== null
+      ? Math.round(new Date(run.completed_at).getTime() - new Date(run.started_at).getTime())
+      : null;
+
+  c.header("Cache-Control", "private, max-age=30");
+  return c.json({ run: { ...run, duration_ms }, feeds });
 });
 
 app.get("/feeds/diagnostics", async (c) => {


### PR DESCRIPTION
## Summary

- `GET /api/admin/runs/:id` に `Cache-Control: private, max-age=30` を追加
- 404 時のエラーメッセージを `"not found"` → `"run not found"` に修正
- `started_at` / `completed_at` から `duration_ms` を計算してレスポンスに含める
- テストに Cache-Control・duration_ms・エラーメッセージの検証を追加（未完了 run の `duration_ms: null` ケースも追加）

Closes #195

## Test plan

- [ ] `GET /api/admin/runs/:id` で 200 + `Cache-Control: private, max-age=30`
- [ ] `run.duration_ms` が計算値 (ms) で返る
- [ ] 未完了 run は `run.duration_ms: null`
- [ ] 存在しない id で 404 + `{ "error": "run not found" }`
- [ ] 認証なしで 401
- [ ] `vp test run` 全 423 件 pass