### PR TITLE
feat: SPA に light/dark/system 3状態の dark mode toggle を実装

### DIFF
--- a/apps/web/client/components/Header.tsx
+++ b/apps/web/client/components/Header.tsx
@@ -1,3 +1,4 @@
+import { ThemeToggle } from "./ThemeToggle";
 import { useTheme } from "../hooks/useTheme";
 
 // "feed" は /feed/:id のフィード詳細ページで使用。nav タブには載せない
@@ -9,55 +10,8 @@ interface HeaderProps {
   onViewChange?: (view: AppView) => void;
 }
 
-function SunIcon() {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="16"
-      height="16"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      <circle cx="12" cy="12" r="5" />
-      <line x1="12" y1="1" x2="12" y2="3" />
-      <line x1="12" y1="21" x2="12" y2="23" />
-      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
-      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
-      <line x1="1" y1="12" x2="3" y2="12" />
-      <line x1="21" y1="12" x2="23" y2="12" />
-      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
-      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
-    </svg>
-  );
-}
-
-function MoonIcon() {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="16"
-      height="16"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
-    </svg>
-  );
-}
-
 export function Header({ view, onViewChange }: HeaderProps) {
-  const { theme, toggleTheme } = useTheme();
-  const label = theme === "dark" ? "Switch to light mode" : "Switch to dark mode";
+  const { theme, setTheme } = useTheme();
 
   return (
     <header className="app-header">
@@ -82,15 +36,7 @@ export function Header({ view, onViewChange }: HeaderProps) {
           </button>
         </nav>
       )}
-      <button
-        type="button"
-        className="theme-toggle"
-        onClick={toggleTheme}
-        aria-label={label}
-        title={label}
-      >
-        {theme === "dark" ? <SunIcon /> : <MoonIcon />}
-      </button>
+      <ThemeToggle theme={theme} onSetTheme={setTheme} />
     </header>
   );
 }

--- a/apps/web/client/components/ThemeToggle.tsx
+++ b/apps/web/client/components/ThemeToggle.tsx
@@ -1,15 +1,16 @@
+import type { Theme } from "../hooks/useTheme";
+
 interface Props {
-  theme: "light" | "dark";
-  onToggle: () => void;
+  theme: Theme;
+  onSetTheme: (t: Theme) => void;
 }
 
-// SVG アイコンをインラインで定義し、フォントへの依存を排除する
 function SunIcon() {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      width="16"
-      height="16"
+      width="14"
+      height="14"
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
@@ -35,8 +36,8 @@ function MoonIcon() {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      width="16"
-      height="16"
+      width="14"
+      height="14"
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
@@ -50,18 +51,60 @@ function MoonIcon() {
   );
 }
 
-export function ThemeToggle({ theme, onToggle }: Props) {
-  const label = theme === "dark" ? "ライトモードに切り替え" : "ダークモードに切り替え";
-
+function SystemIcon() {
   return (
-    <button
-      type="button"
-      className="theme-toggle"
-      onClick={onToggle}
-      aria-label={label}
-      title={label}
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
     >
-      {theme === "dark" ? <SunIcon /> : <MoonIcon />}
-    </button>
+      <rect x="2" y="3" width="20" height="14" rx="2" ry="2" />
+      <line x1="8" y1="21" x2="16" y2="21" />
+      <line x1="12" y1="17" x2="12" y2="21" />
+    </svg>
+  );
+}
+
+export function ThemeToggle({ theme, onSetTheme }: Props) {
+  return (
+    <div className="theme-toggle-group" role="group" aria-label="テーマ切替">
+      <button
+        type="button"
+        className={`theme-toggle-btn${theme === "light" ? " active" : ""}`}
+        aria-pressed={theme === "light"}
+        aria-label="ライトモード"
+        title="ライトモード"
+        onClick={() => onSetTheme("light")}
+      >
+        <SunIcon />
+      </button>
+      <button
+        type="button"
+        className={`theme-toggle-btn${theme === "system" ? " active" : ""}`}
+        aria-pressed={theme === "system"}
+        aria-label="OS設定に追従"
+        title="OS設定に追従"
+        onClick={() => onSetTheme("system")}
+      >
+        <SystemIcon />
+      </button>
+      <button
+        type="button"
+        className={`theme-toggle-btn${theme === "dark" ? " active" : ""}`}
+        aria-pressed={theme === "dark"}
+        aria-label="ダークモード"
+        title="ダークモード"
+        onClick={() => onSetTheme("dark")}
+      >
+        <MoonIcon />
+      </button>
+    </div>
   );
 }

--- a/apps/web/client/hooks/useTheme.ts
+++ b/apps/web/client/hooks/useTheme.ts
@@ -14,16 +14,6 @@ function getSystemTheme(): ResolvedTheme {
   }
 }
 
-function readStored(): Theme {
-  try {
-    const v = localStorage.getItem(STORAGE_KEY);
-    if (v === "light" || v === "dark" || v === "system") return v;
-  } catch {
-    // localStorage が無い環境
-  }
-  return "system";
-}
-
 function applyTheme(resolved: ResolvedTheme): void {
   try {
     document.documentElement.setAttribute("data-theme", resolved);

--- a/apps/web/client/hooks/useTheme.ts
+++ b/apps/web/client/hooks/useTheme.ts
@@ -1,41 +1,136 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useSyncExternalStore } from "react";
 
-type Theme = "light" | "dark";
+export type Theme = "light" | "dark" | "system";
+export type ResolvedTheme = "light" | "dark";
 
-const STORAGE_KEY = "tnb-theme";
+const STORAGE_KEY = "tnb:theme";
 
-function resolveInitialTheme(): Theme {
-  // localStorage の保存値を優先し、なければ OS 設定に従う
-  const stored = localStorage.getItem(STORAGE_KEY);
-  if (stored === "light" || stored === "dark") return stored;
-  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-}
-
-function applyTheme(theme: Theme): void {
-  const html = document.documentElement;
-  if (theme === "dark") {
-    html.setAttribute("data-theme", "dark");
-  } else {
-    html.removeAttribute("data-theme");
+// prefers-color-scheme の現在値を返す (window が無い環境でも crash しない)
+function getSystemTheme(): ResolvedTheme {
+  try {
+    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+  } catch {
+    return "light";
   }
 }
 
-export function useTheme(): { theme: Theme; toggleTheme: () => void } {
-  const [theme, setTheme] = useState<Theme>(() => {
-    const initial = resolveInitialTheme();
-    // 初期化時点でも HTML 属性に反映する (hydration 前のちらつき対策)
-    applyTheme(initial);
-    return initial;
-  });
+function readStored(): Theme {
+  try {
+    const v = localStorage.getItem(STORAGE_KEY);
+    if (v === "light" || v === "dark" || v === "system") return v;
+  } catch {
+    // localStorage が無い環境
+  }
+  return "system";
+}
+
+function applyTheme(resolved: ResolvedTheme): void {
+  try {
+    document.documentElement.setAttribute("data-theme", resolved);
+  } catch {
+    // SSR / テスト環境で document が無い場合
+  }
+}
+
+// --- useSyncExternalStore 用ストア ---
+type Listener = () => void;
+const listeners = new Set<Listener>();
+
+// getSnapshot は呼ばれるたびに localStorage を参照し、同一値なら同じ参照を返す
+let cachedRaw: string | null = "__uninitialized__";
+let cachedTheme: Theme = "system";
+
+function getSnapshot(): Theme {
+  let raw: string | null;
+  try {
+    raw = localStorage.getItem(STORAGE_KEY);
+  } catch {
+    raw = null;
+  }
+  if (raw === cachedRaw) return cachedTheme;
+  cachedRaw = raw;
+  cachedTheme = raw === "light" || raw === "dark" || raw === "system" ? raw : "system";
+  return cachedTheme;
+}
+
+function getServerSnapshot(): Theme {
+  return "system";
+}
+
+function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+
+  const onStorage = (e: StorageEvent) => {
+    if (e.key === STORAGE_KEY) {
+      cachedRaw = "__uninitialized__"; // キャッシュ無効化
+      listener();
+    }
+  };
+  window.addEventListener("storage", onStorage);
+
+  return () => {
+    listeners.delete(listener);
+    window.removeEventListener("storage", onStorage);
+  };
+}
+
+function notify(): void {
+  for (const l of listeners) l();
+}
+
+function setStoredTheme(next: Theme): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, next);
+  } catch {
+    // localStorage が無い環境では無視
+  }
+  cachedRaw = "__uninitialized__"; // キャッシュ無効化して次回 getSnapshot で再読み込み
+  const resolved = next === "system" ? getSystemTheme() : next;
+  applyTheme(resolved);
+  notify();
+}
+
+// --- system テーマ時の matchMedia リスナー ---
+let mediaQueryList: MediaQueryList | null = null;
+
+function ensureMediaListener(): void {
+  try {
+    if (mediaQueryList) return;
+    mediaQueryList = window.matchMedia("(prefers-color-scheme: dark)");
+    mediaQueryList.addEventListener("change", () => {
+      const current = getSnapshot();
+      if (current === "system") {
+        applyTheme(getSystemTheme());
+        notify();
+      }
+    });
+  } catch {
+    // window が無い環境では無視
+  }
+}
+
+// --- hook ---
+
+export interface ThemeAPI {
+  theme: Theme;
+  setTheme: (t: Theme) => void;
+  resolvedTheme: ResolvedTheme;
+}
+
+export function useTheme(): ThemeAPI {
+  const theme = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 
   useEffect(() => {
-    applyTheme(theme);
-    localStorage.setItem(STORAGE_KEY, theme);
-  }, [theme]);
-
-  const toggleTheme = useCallback(() => {
-    setTheme((prev) => (prev === "dark" ? "light" : "dark"));
+    // マウント時に matchMedia リスナーを登録する (SSR を避けるため useEffect 内)
+    ensureMediaListener();
   }, []);
 
-  return { theme, toggleTheme };
+  const setTheme = useCallback((next: Theme) => {
+    setStoredTheme(next);
+  }, []);
+
+  // system の場合は OS 設定を resolvedTheme として返す
+  const resolvedTheme: ResolvedTheme = theme === "system" ? getSystemTheme() : theme;
+
+  return { theme, setTheme, resolvedTheme };
 }

--- a/apps/web/client/index.css
+++ b/apps/web/client/index.css
@@ -107,24 +107,41 @@ a:hover {
   margin-bottom: 16px;
 }
 
-.theme-toggle {
+.theme-toggle-group {
   display: flex;
   align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  padding: 0;
-  background: var(--bg-elev);
-  color: var(--fg-muted);
   border: 1px solid var(--border);
   border-radius: 6px;
-  cursor: pointer;
+  overflow: hidden;
   flex-shrink: 0;
 }
 
-.theme-toggle:hover {
+.theme-toggle-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  background: var(--bg-elev);
+  color: var(--fg-muted);
+  border: none;
+  border-right: 1px solid var(--border);
+  cursor: pointer;
+}
+
+.theme-toggle-btn:last-child {
+  border-right: none;
+}
+
+.theme-toggle-btn:hover {
   color: var(--fg);
-  border-color: var(--accent);
+  background: var(--bg-elev-2);
+}
+
+.theme-toggle-btn.active {
+  background: var(--accent-soft);
+  color: var(--accent);
 }
 
 .header .subtitle {

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -12,6 +12,22 @@
     />
     <link rel="alternate" type="application/rss+xml" title="Tech News Bot (RSS)" href="/feed.xml" />
     <title>Tech News Bot</title>
+    <!-- FOUC 防止: React マウント前に data-theme を確定させる -->
+    <script>
+      (function () {
+        var v = "system";
+        try {
+          v = localStorage.getItem("tnb:theme") || "system";
+        } catch (_) {}
+        var resolved =
+          v === "system"
+            ? window.matchMedia("(prefers-color-scheme: dark)").matches
+              ? "dark"
+              : "light"
+            : v;
+        document.documentElement.setAttribute("data-theme", resolved);
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/web/tests/client/Header.test.tsx
+++ b/apps/web/tests/client/Header.test.tsx
@@ -1,47 +1,81 @@
 import { render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vite-plus/test";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
-// useTheme をモックして theme と toggleTheme を制御する
-const mockToggleTheme = vi.fn<() => void>();
-let mockTheme: "light" | "dark" = "light";
+// useTheme をモックして theme と setTheme を制御する
+const mockSetTheme = vi.fn<(t: "light" | "dark" | "system") => void>();
+let mockTheme: "light" | "dark" | "system" = "system";
 
 vi.mock("../../client/hooks/useTheme", () => ({
   useTheme: () => ({
     get theme() {
       return mockTheme;
     },
-    toggleTheme: mockToggleTheme,
+    setTheme: mockSetTheme,
+    resolvedTheme: mockTheme === "system" ? "light" : mockTheme,
   }),
 }));
 
 const { Header } = await import("../../client/components/Header");
 
 describe("Header", () => {
+  beforeEach(() => {
+    mockTheme = "system";
+    mockSetTheme.mockClear();
+  });
+
   it("renders the site name heading", () => {
-    mockTheme = "light";
     render(<Header />);
     expect(screen.getByRole("heading", { level: 1 })).toBeTruthy();
   });
 
-  it("shows 'Switch to dark mode' aria-label when theme is light", () => {
-    mockTheme = "light";
+  it("renders 3 theme toggle buttons", () => {
     render(<Header />);
-    expect(screen.getByRole("button", { name: "Switch to dark mode" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "ライトモード" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "OS設定に追従" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "ダークモード" })).toBeTruthy();
   });
 
-  it("shows 'Switch to light mode' aria-label when theme is dark", () => {
+  it("system button is aria-pressed=true when theme is system", () => {
+    mockTheme = "system";
+    render(<Header />);
+    const btn = screen.getByRole("button", { name: "OS設定に追従" });
+    expect(btn.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("light button is aria-pressed=true when theme is light", () => {
+    mockTheme = "light";
+    render(<Header />);
+    const btn = screen.getByRole("button", { name: "ライトモード" });
+    expect(btn.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("dark button is aria-pressed=true when theme is dark", () => {
     mockTheme = "dark";
     render(<Header />);
-    expect(screen.getByRole("button", { name: "Switch to light mode" })).toBeTruthy();
+    const btn = screen.getByRole("button", { name: "ダークモード" });
+    expect(btn.getAttribute("aria-pressed")).toBe("true");
   });
 
-  it("calls toggleTheme when the button is clicked", async () => {
-    mockTheme = "light";
-    mockToggleTheme.mockClear();
+  it("calls setTheme('light') when light button is clicked", async () => {
     const user = userEvent.setup();
     render(<Header />);
-    await user.click(screen.getByRole("button", { name: "Switch to dark mode" }));
-    expect(mockToggleTheme).toHaveBeenCalledTimes(1);
+    await user.click(screen.getByRole("button", { name: "ライトモード" }));
+    expect(mockSetTheme).toHaveBeenCalledWith("light");
+  });
+
+  it("calls setTheme('dark') when dark button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<Header />);
+    await user.click(screen.getByRole("button", { name: "ダークモード" }));
+    expect(mockSetTheme).toHaveBeenCalledWith("dark");
+  });
+
+  it("calls setTheme('system') when system button is clicked", async () => {
+    mockTheme = "light";
+    const user = userEvent.setup();
+    render(<Header />);
+    await user.click(screen.getByRole("button", { name: "OS設定に追従" }));
+    expect(mockSetTheme).toHaveBeenCalledWith("system");
   });
 });

--- a/apps/web/tests/client/ThemeToggle.test.tsx
+++ b/apps/web/tests/client/ThemeToggle.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const { ThemeToggle } = await import("../../client/components/ThemeToggle");
+
+describe("ThemeToggle", () => {
+  const mockSetTheme = vi.fn<(t: "light" | "dark" | "system") => void>();
+
+  beforeEach(() => {
+    mockSetTheme.mockClear();
+  });
+
+  it("renders 3 buttons (light, system, dark)", () => {
+    render(<ThemeToggle theme="system" onSetTheme={mockSetTheme} />);
+    expect(screen.getByRole("button", { name: "ライトモード" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "OS設定に追従" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "ダークモード" })).toBeTruthy();
+  });
+
+  it("light button has aria-pressed=true when theme is light", () => {
+    render(<ThemeToggle theme="light" onSetTheme={mockSetTheme} />);
+    expect(screen.getByRole("button", { name: "ライトモード" }).getAttribute("aria-pressed")).toBe(
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "OS設定に追従" }).getAttribute("aria-pressed")).toBe(
+      "false",
+    );
+    expect(screen.getByRole("button", { name: "ダークモード" }).getAttribute("aria-pressed")).toBe(
+      "false",
+    );
+  });
+
+  it("system button has aria-pressed=true when theme is system", () => {
+    render(<ThemeToggle theme="system" onSetTheme={mockSetTheme} />);
+    expect(screen.getByRole("button", { name: "OS設定に追従" }).getAttribute("aria-pressed")).toBe(
+      "true",
+    );
+  });
+
+  it("dark button has aria-pressed=true when theme is dark", () => {
+    render(<ThemeToggle theme="dark" onSetTheme={mockSetTheme} />);
+    expect(screen.getByRole("button", { name: "ダークモード" }).getAttribute("aria-pressed")).toBe(
+      "true",
+    );
+  });
+
+  it("calls onSetTheme('light') when light button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<ThemeToggle theme="system" onSetTheme={mockSetTheme} />);
+    await user.click(screen.getByRole("button", { name: "ライトモード" }));
+    expect(mockSetTheme).toHaveBeenCalledWith("light");
+  });
+
+  it("calls onSetTheme('system') when system button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<ThemeToggle theme="dark" onSetTheme={mockSetTheme} />);
+    await user.click(screen.getByRole("button", { name: "OS設定に追従" }));
+    expect(mockSetTheme).toHaveBeenCalledWith("system");
+  });
+
+  it("calls onSetTheme('dark') when dark button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<ThemeToggle theme="light" onSetTheme={mockSetTheme} />);
+    await user.click(screen.getByRole("button", { name: "ダークモード" }));
+    expect(mockSetTheme).toHaveBeenCalledWith("dark");
+  });
+
+  it("has role=group with aria-label", () => {
+    render(<ThemeToggle theme="system" onSetTheme={mockSetTheme} />);
+    expect(screen.getByRole("group", { name: "テーマ切替" })).toBeTruthy();
+  });
+});

--- a/apps/web/tests/client/useTheme.test.tsx
+++ b/apps/web/tests/client/useTheme.test.tsx
@@ -90,9 +90,7 @@ describe("useTheme", () => {
     expect(result.current.theme).toBe("system");
     act(() => {
       localStorage.setItem(STORAGE_KEY, "light");
-      window.dispatchEvent(
-        new StorageEvent("storage", { key: STORAGE_KEY, newValue: "light" }),
-      );
+      window.dispatchEvent(new StorageEvent("storage", { key: STORAGE_KEY, newValue: "light" }));
     });
     expect(result.current.theme).toBe("light");
   });

--- a/apps/web/tests/client/useTheme.test.tsx
+++ b/apps/web/tests/client/useTheme.test.tsx
@@ -1,0 +1,99 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vite-plus/test";
+
+const STORAGE_KEY = "tnb:theme";
+
+// localStorage.clear() だけではモジュールキャッシュ (cachedRaw) が残るため、
+// StorageEvent で STORAGE_KEY の変更を通知してキャッシュを無効化してからテストする
+function resetThemeStorage() {
+  localStorage.clear();
+  // キャッシュ無効化を強制するために StorageEvent を dispatch する
+  window.dispatchEvent(new StorageEvent("storage", { key: STORAGE_KEY, newValue: null }));
+}
+
+const { useTheme } = await import("../../client/hooks/useTheme");
+
+describe("useTheme", () => {
+  beforeEach(() => {
+    resetThemeStorage();
+    document.documentElement.removeAttribute("data-theme");
+  });
+
+  it("defaults to system when localStorage has no value", () => {
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.theme).toBe("system");
+  });
+
+  it("resolvedTheme is 'light' or 'dark' (never 'system') when theme is system", () => {
+    const { result } = renderHook(() => useTheme());
+    const resolved = result.current.resolvedTheme;
+    expect(resolved === "light" || resolved === "dark").toBe(true);
+  });
+
+  it("reads stored theme from localStorage when setTheme was called", () => {
+    const { result } = renderHook(() => useTheme());
+    act(() => {
+      result.current.setTheme("dark");
+    });
+    expect(result.current.theme).toBe("dark");
+    expect(result.current.resolvedTheme).toBe("dark");
+  });
+
+  it("setTheme persists to localStorage", () => {
+    const { result } = renderHook(() => useTheme());
+    act(() => {
+      result.current.setTheme("light");
+    });
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("light");
+  });
+
+  it("setTheme updates theme state", () => {
+    const { result } = renderHook(() => useTheme());
+    act(() => {
+      result.current.setTheme("dark");
+    });
+    expect(result.current.theme).toBe("dark");
+    expect(result.current.resolvedTheme).toBe("dark");
+  });
+
+  it("setTheme('light') sets resolvedTheme to 'light'", () => {
+    const { result } = renderHook(() => useTheme());
+    act(() => {
+      result.current.setTheme("light");
+    });
+    expect(result.current.resolvedTheme).toBe("light");
+  });
+
+  it("setTheme('system') sets theme to 'system'", () => {
+    const { result } = renderHook(() => useTheme());
+    act(() => {
+      result.current.setTheme("dark");
+    });
+    expect(result.current.theme).toBe("dark");
+    act(() => {
+      result.current.setTheme("system");
+    });
+    expect(result.current.theme).toBe("system");
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("system");
+  });
+
+  it("applies data-theme attribute to html element", () => {
+    const { result } = renderHook(() => useTheme());
+    act(() => {
+      result.current.setTheme("dark");
+    });
+    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+  });
+
+  it("syncs theme via StorageEvent (cross-tab simulation)", () => {
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.theme).toBe("system");
+    act(() => {
+      localStorage.setItem(STORAGE_KEY, "light");
+      window.dispatchEvent(
+        new StorageEvent("storage", { key: STORAGE_KEY, newValue: "light" }),
+      );
+    });
+    expect(result.current.theme).toBe("light");
+  });
+});


### PR DESCRIPTION
## Summary

- `useTheme.ts` を `light | dark | system` の 3 状態に書き換え (localStorage key: `tnb:theme`、デフォルト: `system`)
- `system` 時は `prefers-color-scheme` matchMedia を listen して `<html data-theme>` を切り替え
- 返り値に `resolvedTheme` を追加 (`system` → 実際の `light | dark` を返す)
- `ThemeToggle` を `<button aria-pressed>` 3 つ並べる方式に変更 (light / system / dark)
- `Header` で `ThemeToggle` コンポーネントを使用するように整理
- `index.html` の `<head>` に FOUC 防止のインライン script を追加
- `useTheme.test.tsx`, `ThemeToggle.test.tsx` を新規追加、`Header.test.tsx` を新 API に対応

## Test plan

- [ ] `pnpm check` pass (lint / typecheck)
- [ ] `pnpm test` pass (worker + client 計 423 tests)
- [ ] light / dark / system ボタンのクリックでテーマが切り替わること
- [ ] localStorage に `tnb:theme` が保存されること
- [ ] ページリロード後にテーマが復元されること (FOUC 無し)

Closes #194