### PR TITLE
feat(api): add GET /api/feeds/:id/health endpoint

### DIFF
--- a/apps/web/tests/worker/api/feeds.test.ts
+++ b/apps/web/tests/worker/api/feeds.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from "vite-plus/test";
 import { env, SELF } from "cloudflare:test";
 import { insertArticles } from "../../../worker/db/articles";
 import { syncFeeds } from "../../../worker/db/feeds";
+import { finishRun, recordRunFeed, startRun } from "../../../worker/db/runs";
 import type { Article, FeedConfig } from "../../../worker/types";
 
 const FEEDS: FeedConfig[] = [
@@ -337,5 +338,143 @@ describe("GET /api/feeds/:id", () => {
   it("returns Content-Type application/json", async () => {
     const res = await SELF.fetch("https://example.com/api/feeds/openai-blog");
     expect(res.headers.get("Content-Type")).toContain("application/json");
+  });
+});
+
+describe("GET /api/feeds/:id/health", () => {
+  // collector_runs + collector_run_feeds を挿入するヘルパ
+  async function insertRun(
+    feedId: string,
+    status: "ok" | "failed" | "skipped",
+    opts: {
+      daysAgoN?: number;
+      durationMs?: number;
+      articlesInserted?: number;
+      error?: string;
+    } = {},
+  ) {
+    const { daysAgoN = 0, durationMs = 200, articlesInserted = 3, error } = opts;
+    const startedAt = new Date(Date.now() - daysAgoN * 24 * 60 * 60 * 1000).toISOString();
+    const { run_id } = await startRun(env.DB, startedAt, 1);
+    await recordRunFeed(env.DB, run_id, feedId, status, articlesInserted, durationMs, error);
+    await finishRun(
+      env.DB,
+      run_id,
+      new Date(new Date(startedAt).getTime() + durationMs).toISOString(),
+      status === "ok" ? 1 : 0,
+      status === "failed" ? 1 : 0,
+      articlesInserted,
+      error,
+    );
+    return run_id;
+  }
+
+  beforeEach(async () => {
+    // 3 成功 + 1 失敗 を openai-blog に挿入
+    await insertRun("openai-blog", "ok", { daysAgoN: 1, durationMs: 300, articlesInserted: 5 });
+    await insertRun("openai-blog", "ok", { daysAgoN: 2, durationMs: 200, articlesInserted: 3 });
+    await insertRun("openai-blog", "ok", { daysAgoN: 3, durationMs: 400, articlesInserted: 10 });
+    await insertRun("openai-blog", "failed", {
+      daysAgoN: 4,
+      durationMs: 100,
+      articlesInserted: 0,
+      error: "Fetch error: timeout",
+    });
+  });
+
+  it("returns 404 for feed not in feeds.yaml", async () => {
+    const res = await SELF.fetch("https://example.com/api/feeds/no-such-feed/health");
+    expect(res.status).toBe(404);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toBe("feed not found");
+  });
+
+  it("returns 400 for invalid days param", async () => {
+    const res = await SELF.fetch("https://example.com/api/feeds/openai-blog/health?days=abc");
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toBe("invalid days");
+  });
+
+  it("returns 400 when days exceeds 30", async () => {
+    const res = await SELF.fetch("https://example.com/api/feeds/openai-blog/health?days=31");
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when days=0", async () => {
+    const res = await SELF.fetch("https://example.com/api/feeds/openai-blog/health?days=0");
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 with correct structure and counts", async () => {
+    const res = await SELF.fetch("https://example.com/api/feeds/openai-blog/health?days=7");
+    expect(res.status).toBe(200);
+    const body = await res.json<{
+      feed_id: string;
+      window_days: number;
+      total_runs: number;
+      successful_runs: number;
+      failed_runs: number;
+      success_rate: number | null;
+      last_run_at: string | null;
+      last_run_status: string | null;
+      last_error: { at: string; message: string | null } | null;
+      avg_duration_ms: number | null;
+      articles_inserted_total: number;
+    }>();
+    expect(body.feed_id).toBe("openai-blog");
+    expect(body.window_days).toBe(7);
+    expect(body.total_runs).toBe(4);
+    expect(body.successful_runs).toBe(3);
+    expect(body.failed_runs).toBe(1);
+    expect(body.success_rate).toBeCloseTo(0.75, 2);
+    expect(body.last_run_at).not.toBeNull();
+    // 最終実行は ok (1日前)
+    expect(body.last_run_status).toBe("success");
+    // 失敗が存在するので last_error は非 null
+    expect(body.last_error).not.toBeNull();
+    expect(body.last_error!.message).toContain("timeout");
+    expect(body.avg_duration_ms).not.toBeNull();
+    // 合計記事数: 5+3+10+0=18
+    expect(body.articles_inserted_total).toBe(18);
+  });
+
+  it("returns null last_error when no failures", async () => {
+    // google-research にはランを挿入していないため 0 件
+    // 成功のみのランを別フィードに挿入して確認
+    await insertRun("google-research", "ok", { daysAgoN: 1, durationMs: 150, articlesInserted: 2 });
+    const res = await SELF.fetch("https://example.com/api/feeds/google-research/health");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ last_error: null; last_run_status: string }>();
+    expect(body.last_error).toBeNull();
+    expect(body.last_run_status).toBe("success");
+  });
+
+  it("returns total_runs=0 when no runs in window", async () => {
+    // cyberagent-developers には run なし
+    const res = await SELF.fetch(
+      "https://example.com/api/feeds/cyberagent-developers/health?days=7",
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json<{
+      total_runs: number;
+      success_rate: number | null;
+      last_run_at: string | null;
+    }>();
+    expect(body.total_runs).toBe(0);
+    expect(body.success_rate).toBeNull();
+    expect(body.last_run_at).toBeNull();
+  });
+
+  it("uses default days=7 when days param is omitted", async () => {
+    const res = await SELF.fetch("https://example.com/api/feeds/openai-blog/health");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ window_days: number }>();
+    expect(body.window_days).toBe(7);
+  });
+
+  it("sets Cache-Control: public, max-age=300", async () => {
+    const res = await SELF.fetch("https://example.com/api/feeds/openai-blog/health");
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=300");
   });
 });

--- a/apps/web/worker/api/feeds.ts
+++ b/apps/web/worker/api/feeds.ts
@@ -1,6 +1,8 @@
 import { Hono } from "hono";
+import { loadAllFeeds } from "../feed-config";
 import type { Env, FeedCategory, FeedLang } from "../types";
 import { findFeedWithStats, getRecentArticlesByFeed, listFeedsWithStats } from "../db/feeds";
+import { getFeedHealth } from "../db/runs";
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -61,6 +63,67 @@ app.get("/:id", async (c) => {
 
   c.header("Cache-Control", "public, max-age=300");
   return c.json({ feed, recent_articles: recentArticles });
+});
+
+const DAYS_DEFAULT = 7;
+const DAYS_MAX = 30;
+
+app.get("/:id/health", async (c) => {
+  const id = c.req.param("id");
+  const daysRaw = c.req.query("days");
+
+  // days バリデーション
+  let days = DAYS_DEFAULT;
+  if (daysRaw !== undefined) {
+    const parsed = Number(daysRaw);
+    if (!Number.isInteger(parsed) || parsed < 1 || parsed > DAYS_MAX) {
+      return c.json({ error: "invalid days" }, 400);
+    }
+    days = parsed;
+  }
+
+  // feeds.yaml に存在しない id は 404
+  const allFeeds = loadAllFeeds();
+  const feedConfig = allFeeds.find((f) => f.id === id);
+  if (!feedConfig) {
+    return c.json({ error: "feed not found" }, 404);
+  }
+
+  const health = await getFeedHealth(c.env.DB, id, days);
+
+  const successRate =
+    health.total_runs > 0
+      ? Math.round((health.successful_runs / health.total_runs) * 1000) / 1000
+      : null;
+
+  const lastError =
+    health.last_error_at !== null
+      ? { at: health.last_error_at, message: health.last_error_message }
+      : null;
+
+  const lastRunStatus =
+    health.last_run_status === "ok"
+      ? "success"
+      : health.last_run_status === "failed"
+        ? "failed"
+        : health.last_run_status === "skipped"
+          ? "skipped"
+          : null;
+
+  c.header("Cache-Control", "public, max-age=300");
+  return c.json({
+    feed_id: id,
+    window_days: days,
+    total_runs: health.total_runs,
+    successful_runs: health.successful_runs,
+    failed_runs: health.failed_runs,
+    success_rate: successRate,
+    last_run_at: health.last_run_at,
+    last_run_status: lastRunStatus,
+    last_error: lastError,
+    avg_duration_ms: health.avg_duration_ms !== null ? Math.round(health.avg_duration_ms) : null,
+    articles_inserted_total: health.articles_inserted_total,
+  });
 });
 
 export default app;

--- a/apps/web/worker/db/runs.ts
+++ b/apps/web/worker/db/runs.ts
@@ -194,6 +194,66 @@ export async function getFeedFailures(
   return result.results ?? [];
 }
 
+export interface FeedHealthRow {
+  total_runs: number;
+  successful_runs: number;
+  failed_runs: number;
+  last_run_at: string | null;
+  last_run_status: string | null;
+  last_error_at: string | null;
+  last_error_message: string | null;
+  avg_duration_ms: number | null;
+  articles_inserted_total: number;
+}
+
+/**
+ * 指定フィードの直近 N 日間の健全性集計を 1 クエリで返す。
+ * collector_run_feeds と collector_runs を JOIN し SUM/COUNT/AVG/MAX で集計する。
+ */
+export async function getFeedHealth(
+  db: D1Database,
+  feedId: string,
+  days: number,
+): Promise<FeedHealthRow> {
+  const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+  const row = await db
+    .prepare(
+      `SELECT
+         COUNT(*) AS total_runs,
+         SUM(CASE WHEN crf.status = 'ok' THEN 1 ELSE 0 END) AS successful_runs,
+         SUM(CASE WHEN crf.status = 'failed' THEN 1 ELSE 0 END) AS failed_runs,
+         MAX(cr.started_at) AS last_run_at,
+         MAX(CASE WHEN cr.started_at = (
+           SELECT MAX(cr2.started_at)
+           FROM collector_run_feeds crf2
+           JOIN collector_runs cr2 ON cr2.id = crf2.run_id
+           WHERE crf2.feed_id = ?1 AND cr2.started_at >= ?2
+         ) THEN crf.status END) AS last_run_status,
+         MAX(CASE WHEN crf.status = 'failed' THEN cr.started_at END) AS last_error_at,
+         MAX(CASE WHEN crf.status = 'failed' THEN crf.error END) AS last_error_message,
+         AVG(CASE WHEN crf.status != 'skipped' THEN crf.duration_ms END) AS avg_duration_ms,
+         SUM(crf.articles_inserted) AS articles_inserted_total
+       FROM collector_run_feeds crf
+       JOIN collector_runs cr ON cr.id = crf.run_id
+       WHERE crf.feed_id = ?1
+         AND cr.started_at >= ?2`,
+    )
+    .bind(feedId, since)
+    .first<FeedHealthRow>();
+
+  return {
+    total_runs: row?.total_runs ?? 0,
+    successful_runs: row?.successful_runs ?? 0,
+    failed_runs: row?.failed_runs ?? 0,
+    last_run_at: row?.last_run_at ?? null,
+    last_run_status: row?.last_run_status ?? null,
+    last_error_at: row?.last_error_at ?? null,
+    last_error_message: row?.last_error_message ?? null,
+    avg_duration_ms: row?.avg_duration_ms ?? null,
+    articles_inserted_total: row?.articles_inserted_total ?? 0,
+  };
+}
+
 export async function getRun(
   db: D1Database,
   run_id: number,


### PR DESCRIPTION
## Summary
- フィード単体の健全性 (直近 N 日の取得成功率、最終取得時刻、最終エラー、平均所要時間) を返す `GET /api/feeds/:id/health?days=7` を追加
- public endpoint、`Cache-Control: public, max-age=300`
- feeds.yaml に存在しない id は 404、days 範囲外 (1〜30) は 400

Closes #198

## Test plan
- [x] `apps/web/tests/worker/api/feeds.test.ts` に handler テスト追加
- [x] `pnpm build` / `pnpm test` ローカル pass