### PR TITLE
feat(api): add GET /api/articles/popular endpoint

### DIFF
--- a/apps/web/tests/worker/api/articles.test.ts
+++ b/apps/web/tests/worker/api/articles.test.ts
@@ -1451,3 +1451,208 @@ describe("GET /api/articles/by-category/:cat", () => {
     expect(res.headers.get("Cache-Control")).toBe("public, max-age=300");
   });
 });
+
+describe("GET /api/articles/popular", () => {
+  it("returns 200 with default days=7 and articles/window_days/total fields", async () => {
+    const today = new Date();
+    const todayStr = today.toISOString().slice(0, 10);
+    await insertArticles(env.DB, [
+      {
+        guid: "pop-today-1",
+        feed_id: "google-research",
+        title: "Popular Today 1",
+        url: "https://x.test/g/pop-today-1",
+        summary: null,
+        author: "Author Pop",
+        published_at: `${todayStr}T10:00:00.000Z`,
+        category: "bigtech",
+        lang: "en",
+      },
+    ]);
+
+    const res = await SELF.fetch("https://example.com/api/articles/popular");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ articles: unknown[]; window_days: number; total: number }>();
+    expect(Array.isArray(body.articles)).toBe(true);
+    expect(body.window_days).toBe(7);
+    expect(typeof body.total).toBe("number");
+    expect(body.total).toBe(body.articles.length);
+  });
+
+  it("returns only articles within the specified days window", async () => {
+    const today = new Date();
+    const todayStr = today.toISOString().slice(0, 10);
+    // 今日の記事 (days=1 の範囲内)
+    await insertArticles(env.DB, [
+      {
+        guid: "pop-in-range",
+        feed_id: "google-research",
+        title: "In Range",
+        url: "https://x.test/g/in-range",
+        summary: null,
+        author: "Author In",
+        published_at: `${todayStr}T10:00:00.000Z`,
+        category: "bigtech",
+        lang: "en",
+      },
+    ]);
+    // beforeEach の記事は 2024-04 のため days=1 の範囲外
+
+    const res = await SELF.fetch("https://example.com/api/articles/popular?days=1");
+    expect(res.status).toBe(200);
+    const body = await res.json<{
+      articles: { guid: string }[];
+      window_days: number;
+      total: number;
+    }>();
+    expect(body.window_days).toBe(1);
+    // 2024-04 の古い記事は含まれない
+    for (const a of body.articles) {
+      expect(a.guid).toBe("pop-in-range");
+    }
+  });
+
+  it("de-duplicates same feed_id + author, keeping only the newest", async () => {
+    const today = new Date();
+    const todayStr = today.toISOString().slice(0, 10);
+    const yesterday = new Date(today);
+    yesterday.setUTCDate(today.getUTCDate() - 1);
+    const yesterdayStr = yesterday.toISOString().slice(0, 10);
+
+    await insertArticles(env.DB, [
+      {
+        guid: "dup-newer",
+        feed_id: "openai-blog",
+        title: "Dup Newer",
+        url: "https://x.test/o/dup-newer",
+        summary: null,
+        author: "Dup Author",
+        published_at: `${todayStr}T12:00:00.000Z`,
+        category: "ai",
+        lang: "en",
+      },
+      {
+        guid: "dup-older",
+        feed_id: "openai-blog",
+        title: "Dup Older",
+        url: "https://x.test/o/dup-older",
+        summary: null,
+        author: "Dup Author",
+        published_at: `${yesterdayStr}T12:00:00.000Z`,
+        category: "ai",
+        lang: "en",
+      },
+    ]);
+
+    const res = await SELF.fetch("https://example.com/api/articles/popular?days=7");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ articles: { guid: string }[] }>();
+    const guids = body.articles.map((a) => a.guid);
+    // 同一 feed_id + author で 1 件のみ残る
+    expect(guids).toContain("dup-newer");
+    expect(guids).not.toContain("dup-older");
+  });
+
+  it("returns articles in published_at DESC order", async () => {
+    const today = new Date();
+    const todayStr = today.toISOString().slice(0, 10);
+    const yesterday = new Date(today);
+    yesterday.setUTCDate(today.getUTCDate() - 1);
+    const yesterdayStr = yesterday.toISOString().slice(0, 10);
+
+    await insertArticles(env.DB, [
+      {
+        guid: "ord-a",
+        feed_id: "google-research",
+        title: "Order A",
+        url: "https://x.test/g/ord-a",
+        summary: null,
+        author: "Author Ord A",
+        published_at: `${yesterdayStr}T10:00:00.000Z`,
+        category: "bigtech",
+        lang: "en",
+      },
+      {
+        guid: "ord-b",
+        feed_id: "openai-blog",
+        title: "Order B",
+        url: "https://x.test/o/ord-b",
+        summary: null,
+        author: "Author Ord B",
+        published_at: `${todayStr}T10:00:00.000Z`,
+        category: "ai",
+        lang: "en",
+      },
+    ]);
+
+    const res = await SELF.fetch("https://example.com/api/articles/popular?days=7");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ articles: { published_at: string }[] }>();
+    const dates = body.articles.map((a) => a.published_at);
+    const sorted = dates.toSorted((a, b) => b.localeCompare(a));
+    expect(dates).toEqual(sorted);
+  });
+
+  it("respects limit parameter", async () => {
+    const today = new Date();
+    const todayStr = today.toISOString().slice(0, 10);
+    const extra = Array.from({ length: 5 }, (_, i) => ({
+      guid: `pop-limit-${i}`,
+      feed_id: "google-research",
+      title: `Pop Limit ${i}`,
+      url: `https://x.test/g/pop-limit-${i}`,
+      summary: null,
+      author: `Pop Author ${i}`,
+      published_at: `${todayStr}T${String(i).padStart(2, "0")}:00:00.000Z`,
+      category: "bigtech" as const,
+      lang: "en" as const,
+    }));
+    await insertArticles(env.DB, extra);
+
+    const res = await SELF.fetch("https://example.com/api/articles/popular?days=7&limit=2");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ articles: unknown[]; total: number }>();
+    expect(body.articles.length).toBe(2);
+    expect(body.total).toBe(2);
+  });
+
+  it("returns 400 when days=0", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/popular?days=0");
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toBe("invalid days");
+  });
+
+  it("returns 400 when days=31", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/popular?days=31");
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toBe("invalid days");
+  });
+
+  it("returns 400 when limit=0", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/popular?limit=0");
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toBe("invalid limit");
+  });
+
+  it("returns 400 when limit=101", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/popular?limit=101");
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toBe("invalid limit");
+  });
+
+  it("returns Cache-Control: public, max-age=600", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/popular");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=600");
+  });
+
+  it("returns Content-Type: application/json", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/popular");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toMatch(/application\/json/);
+  });
+});

--- a/apps/web/worker/api/articles.ts
+++ b/apps/web/worker/api/articles.ts
@@ -10,6 +10,7 @@ import {
   getArticlesCalendar,
   getArticlesByMonth,
   getNeighbors,
+  getPopularArticles,
   getRandomArticles,
   getRelatedArticles,
   listArticles,
@@ -231,6 +232,26 @@ app.get("/calendar", async (c) => {
   const items = await getArticlesCalendar(c.env.DB, days, lang, category);
 
   return c.json({ days, items }, 200, {
+    "Cache-Control": "public, max-age=600",
+  });
+});
+
+app.get("/popular", async (c) => {
+  const daysRaw = c.req.query("days") ?? "7";
+  const days = parseInt(daysRaw, 10);
+  if (isNaN(days) || days < 1 || days > 30) {
+    return c.json({ error: "invalid days" }, 400);
+  }
+
+  const limitRaw = c.req.query("limit") ?? "30";
+  const limit = parseInt(limitRaw, 10);
+  if (isNaN(limit) || limit < 1 || limit > 100) {
+    return c.json({ error: "invalid limit" }, 400);
+  }
+
+  const result = await getPopularArticles(c.env.DB, days, limit);
+
+  return c.json(result, 200, {
     "Cache-Control": "public, max-age=600",
   });
 });

--- a/apps/web/worker/db/articles.ts
+++ b/apps/web/worker/db/articles.ts
@@ -765,6 +765,54 @@ export async function getArticlesByCategory(
   return { articles, nextCursor };
 }
 
+export interface PopularArticlesResult {
+  articles: Article[];
+  window_days: number;
+  total: number;
+}
+
+/**
+ * 直近 N 日の記事を feed_id + author 単位で de-dup し、published_at DESC で返す。
+ * 同一 feed/author の中で published_at が最大の記事 (= 最新記事) を代表として選ぶ。
+ * published_at が同一の場合は id の大きい方 (後から挿入された方) を選ぶ。
+ * author が NULL の記事は SQLite の GROUP BY NULL 挙動により feed_id ごとに 1 件残る。
+ */
+export async function getPopularArticles(
+  db: D1Database,
+  days: number,
+  limit: number,
+): Promise<PopularArticlesResult> {
+  const interval = `-${days} days`;
+  // 同一 feed_id + author グループの中で (published_at, id) の組が最大のものを選ぶ。
+  // サブクエリで MAX(published_at) を求め、同 published_at 内は MAX(id) で tie-break する。
+  const sql = `
+    SELECT a.id, a.guid, a.feed_id, f.name AS feed_name, a.title, a.url, a.summary,
+           a.author, a.published_at, a.fetched_at, a.category, a.lang
+    FROM articles a
+    LEFT JOIN feeds f ON f.id = a.feed_id
+    WHERE a.published_at >= datetime('now', ?1)
+      AND a.id IN (
+        SELECT MAX(id)
+        FROM articles
+        WHERE published_at >= datetime('now', ?1)
+          AND (feed_id, author, published_at) IN (
+            SELECT feed_id, author, MAX(published_at)
+            FROM articles
+            WHERE published_at >= datetime('now', ?1)
+            GROUP BY feed_id, author
+          )
+        GROUP BY feed_id, author
+      )
+    ORDER BY a.published_at DESC
+    LIMIT ?2
+  `;
+
+  const result = await db.prepare(sql).bind(interval, limit).all<Article>();
+
+  const articles = result.results ?? [];
+  return { articles, window_days: days, total: articles.length };
+}
+
 function escapeFtsQuery(input: string): string {
   // FTS5 で安全に扱うため、特殊記号を除去して各単語をフレーズ扱いにする
   const tokens = input


### PR DESCRIPTION
## Summary

- `GET /api/articles/popular?days=7&limit=30` エンドポイントを追加
- `days` (1-30, default 7) 以内の記事を対象に、feed_id + author 単位で de-dup して published_at DESC で返す
- SQLite 1 クエリ (相関サブクエリ) で完結し、D1 の 50ms 制約に収まる設計

## Test plan

- [x] 200 正常系: `window_days` / `total` / `articles` フィールドが返ること
- [x] days ウィンドウフィルタリング: 範囲外の古い記事が含まれないこと
- [x] de-dup: 同一 feed_id + author の最新 published_at の記事のみ残ること
- [x] published_at DESC ソート確認
- [x] limit パラメータの動作確認
- [x] 400 バリデーション: days=0, days=31, limit=0, limit=101
- [x] Cache-Control: public, max-age=600
- [x] vp check (lint + format + typecheck) pass
- [x] vp test run (445 tests) pass

Closes #200