### PR TITLE
feat(collector): add COLLECTOR_ALERT_WEBHOOK Slack/Discord alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ pnpm migrate:prod
 
 # 3. Admin Token を登録 (省略可)
 pnpm exec wrangler secret put ADMIN_TOKEN
+
+# 4. Collector アラート webhook を登録 (省略可)
+#    Slack / Discord の incoming webhook URL を設定すると、
+#    フィード取得失敗数が COLLECTOR_ALERT_THRESHOLD (default: 5) 以上のとき通知される
+pnpm exec wrangler secret put COLLECTOR_ALERT_WEBHOOK
 ```
 
 ### GitHub Actions による自動デプロイ

--- a/apps/web/tests/worker/collector/alert.test.ts
+++ b/apps/web/tests/worker/collector/alert.test.ts
@@ -1,13 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { env } from "cloudflare:test";
-import { maybeAlert, notifyCollectorFailure, sendAlert } from "../../../worker/collector/alert";
+import {
+  maybeAlert,
+  notifyCollectorFailure,
+  sendAlert,
+  type AlertRunResult,
+} from "../../../worker/collector/alert";
 import {
   getFeedStreaks,
   syncFeeds,
   recordFetchError,
   recordFetchSuccess,
 } from "../../../worker/db/feeds";
-import type { CollectAllResult, CollectResult } from "../../../worker/collector/index";
+import type { CollectResult } from "../../../worker/collector/index";
 import type { Env, FeedConfig } from "../../../worker/types";
 
 const WEBHOOK_URL = "https://hooks.example.com/webhook";
@@ -176,7 +181,7 @@ describe("maybeAlert", () => {
 });
 
 describe("sendAlert", () => {
-  const makeResult = (failed: number, total: number): CollectAllResult => {
+  const makeResult = (failed: number, total: number): AlertRunResult => {
     const results: CollectResult[] = [];
     for (let i = 0; i < failed; i++) {
       results.push(errResult(`feed-${i}`, `HTTP ${500 + i}`));
@@ -184,7 +189,7 @@ describe("sendAlert", () => {
     for (let i = failed; i < total; i++) {
       results.push(okResult(`feed-${i}`));
     }
-    return { total, inserted: total - failed, pruned: 0, results, durationMs: 100 };
+    return { total, results };
   };
 
   it("does not call webhook when COLLECTOR_ALERT_WEBHOOK is not set", async () => {

--- a/apps/web/tests/worker/collector/alert.test.ts
+++ b/apps/web/tests/worker/collector/alert.test.ts
@@ -1,14 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { env } from "cloudflare:test";
-import { maybeAlert, notifyCollectorFailure } from "../../../worker/collector/alert";
+import { maybeAlert, notifyCollectorFailure, sendAlert } from "../../../worker/collector/alert";
 import {
   getFeedStreaks,
   syncFeeds,
   recordFetchError,
   recordFetchSuccess,
 } from "../../../worker/db/feeds";
-import type { CollectResult } from "../../../worker/collector/index";
-import type { FeedConfig } from "../../../worker/types";
+import type { CollectAllResult, CollectResult } from "../../../worker/collector/index";
+import type { Env, FeedConfig } from "../../../worker/types";
 
 const WEBHOOK_URL = "https://hooks.example.com/webhook";
 
@@ -172,6 +172,107 @@ describe("maybeAlert", () => {
     await maybeAlert(WEBHOOK_URL, [okResult("feed-a")], streaks, 3, 5);
 
     expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe("sendAlert", () => {
+  const makeResult = (failed: number, total: number): CollectAllResult => {
+    const results: CollectResult[] = [];
+    for (let i = 0; i < failed; i++) {
+      results.push(errResult(`feed-${i}`, `HTTP ${500 + i}`));
+    }
+    for (let i = failed; i < total; i++) {
+      results.push(okResult(`feed-${i}`));
+    }
+    return { total, inserted: total - failed, pruned: 0, results, durationMs: 100 };
+  };
+
+  it("does not call webhook when COLLECTOR_ALERT_WEBHOOK is not set", async () => {
+    const spy = vi.spyOn(globalThis, "fetch");
+    const mockEnv = { ...env, COLLECTOR_ALERT_WEBHOOK: undefined } as unknown as Env;
+    await sendAlert(mockEnv, makeResult(10, 30));
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("does not call webhook when COLLECTOR_ALERT_WEBHOOK is empty string", async () => {
+    const spy = vi.spyOn(globalThis, "fetch");
+    const mockEnv = { ...env, COLLECTOR_ALERT_WEBHOOK: "" } as unknown as Env;
+    await sendAlert(mockEnv, makeResult(10, 30));
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("calls webhook when failed feeds >= threshold (default 5)", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    const mockEnv = { ...env, COLLECTOR_ALERT_WEBHOOK: WEBHOOK_URL } as unknown as Env;
+    await sendAlert(mockEnv, makeResult(5, 30));
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const [url, init] = spy.mock.calls[0];
+    expect(url).toBe(WEBHOOK_URL);
+    const body = JSON.parse(init?.body as string) as {
+      text: string;
+      blocks: { type: string; text: { type: string; text: string } }[];
+    };
+    expect(body.text).toContain("collector alert");
+    expect(body.blocks).toHaveLength(1);
+    expect(body.blocks[0].text.type).toBe("mrkdwn");
+    expect(body.blocks[0].text.text).toContain("Failed:");
+  });
+
+  it("does not call webhook when failed feeds < threshold (default 5)", async () => {
+    const spy = vi.spyOn(globalThis, "fetch");
+    const mockEnv = { ...env, COLLECTOR_ALERT_WEBHOOK: WEBHOOK_URL } as unknown as Env;
+    await sendAlert(mockEnv, makeResult(4, 30));
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("respects COLLECTOR_ALERT_THRESHOLD env var", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    const mockEnv = {
+      ...env,
+      COLLECTOR_ALERT_WEBHOOK: WEBHOOK_URL,
+      COLLECTOR_ALERT_THRESHOLD: "3",
+    } as unknown as Env;
+    await sendAlert(mockEnv, makeResult(3, 30));
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("limits top errors to 5 in the payload", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    const mockEnv = { ...env, COLLECTOR_ALERT_WEBHOOK: WEBHOOK_URL } as unknown as Env;
+    // 10 件失敗しても blocks には最大 5 件しか含まれない
+    await sendAlert(mockEnv, makeResult(10, 30));
+
+    const body = JSON.parse(spy.mock.calls[0][1]?.body as string) as {
+      blocks: { type: string; text: { type: string; text: string } }[];
+    };
+    const mrkdwn = body.blocks[0].text.text;
+    // "feed-5" 〜 "feed-9" は含まれないことを確認 (top 5 = feed-0 〜 feed-4)
+    expect(mrkdwn).toContain("feed-0");
+    expect(mrkdwn).toContain("feed-4");
+    expect(mrkdwn).not.toContain("feed-5");
+  });
+
+  it("does not throw on non-2xx webhook response", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(null, { status: 500 }));
+    const mockEnv = { ...env, COLLECTOR_ALERT_WEBHOOK: WEBHOOK_URL } as unknown as Env;
+    await expect(sendAlert(mockEnv, makeResult(5, 30))).resolves.toBeUndefined();
+  });
+
+  it("does not throw on network error", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(new TypeError("Failed to fetch"));
+    const mockEnv = { ...env, COLLECTOR_ALERT_WEBHOOK: WEBHOOK_URL } as unknown as Env;
+    await expect(sendAlert(mockEnv, makeResult(5, 30))).resolves.toBeUndefined();
   });
 });
 

--- a/apps/web/worker/collector/alert.ts
+++ b/apps/web/worker/collector/alert.ts
@@ -1,5 +1,5 @@
-import type { CollectResult } from "./index";
 import type { Env } from "../types";
+import type { CollectResult } from "./index";
 
 export interface AlertSummary {
   failedFeeds: { id: string; error: string }[];

--- a/apps/web/worker/collector/alert.ts
+++ b/apps/web/worker/collector/alert.ts
@@ -76,7 +76,10 @@ export async function sendAlert(env: Env, result: CollectAllResult): Promise<voi
     .map((r) => `${r.feedId} (${(r.error ?? "unknown").slice(0, 100)})`)
     .join(", ");
 
-  const mrkdwn = `*Failed:* ${feedsFailed} / ${result.total}\n*Time:* ${now}\n*Top errors:* ${topErrors}`;
+  const mrkdwn =
+    `*Failed:* ${feedsFailed} / ${result.total}\n` +
+    `*Time:* ${now}\n` +
+    `*Top errors:* ${topErrors}`;
 
   const payload = {
     text: "tech-news-bot collector alert",

--- a/apps/web/worker/collector/alert.ts
+++ b/apps/web/worker/collector/alert.ts
@@ -102,7 +102,9 @@ export async function sendAlert(env: Env, result: CollectAllResult): Promise<voi
       signal: controller.signal,
     });
     if (!res.ok) {
-      console.error(`[alert] sendAlert webhook returned non-2xx: ${res.status} ${res.statusText}`);
+      console.error(
+        `[alert] sendAlert webhook returned non-2xx: ${res.status} ${res.statusText}`,
+      );
     }
   } catch (err) {
     console.error(

--- a/apps/web/worker/collector/alert.ts
+++ b/apps/web/worker/collector/alert.ts
@@ -1,13 +1,16 @@
-import type { CollectResult } from "./index";
+import type { Env } from "../types";
+import type { CollectAllResult, CollectResult } from "./index";
 
 export interface AlertSummary {
   failedFeeds: { id: string; error: string }[];
   streakFeeds: { id: string; consecutiveFailures: number }[];
 }
 
+const TOP_ERRORS_MAX = 5;
+
 /**
  * Slack Incoming Webhook 互換の payload で失敗を通知する。
- * Discord は ?slack suffix を付けることで同じ {text} 形式を受け入れる。
+ * Discord は blocks を無視して text フィールドをメッセージとして表示する。
  * 通知失敗は console.error のみ。Cron を落とさないよう throw しない。
  */
 export async function notifyCollectorFailure(
@@ -47,6 +50,63 @@ export async function notifyCollectorFailure(
   } catch (err) {
     console.error(
       `[alert] failed to send webhook: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * collectAll の結果から Slack/Discord 互換の blocks 形式で通知する。
+ * COLLECTOR_ALERT_WEBHOOK が未設定なら no-op。fetch 失敗は console.error のみ。
+ */
+export async function sendAlert(env: Env, result: CollectAllResult): Promise<void> {
+  const webhookUrl = env.COLLECTOR_ALERT_WEBHOOK;
+  if (!webhookUrl) return;
+
+  const threshold = Number(env.COLLECTOR_ALERT_THRESHOLD ?? "5") || 5;
+  const feedsFailed = result.results.filter((r) => r.status === "error").length;
+
+  if (feedsFailed < threshold) return;
+
+  const now = new Date().toISOString();
+  const topErrors = result.results
+    .filter((r) => r.status === "error")
+    .slice(0, TOP_ERRORS_MAX)
+    .map((r) => `${r.feedId} (${(r.error ?? "unknown").slice(0, 100)})`)
+    .join(", ");
+
+  const mrkdwn = `*Failed:* ${feedsFailed} / ${result.total}\n*Time:* ${now}\n*Top errors:* ${topErrors}`;
+
+  const payload = {
+    text: "tech-news-bot collector alert",
+    blocks: [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: mrkdwn,
+        },
+      },
+    ],
+  };
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 5000);
+
+  try {
+    const res = await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      console.error(`[alert] sendAlert webhook returned non-2xx: ${res.status} ${res.statusText}`);
+    }
+  } catch (err) {
+    console.error(
+      `[alert] sendAlert failed: ${err instanceof Error ? err.message : String(err)}`,
     );
   } finally {
     clearTimeout(timer);

--- a/apps/web/worker/collector/alert.ts
+++ b/apps/web/worker/collector/alert.ts
@@ -109,14 +109,10 @@ export async function sendAlert(env: Env, result: AlertRunResult): Promise<void>
       signal: controller.signal,
     });
     if (!res.ok) {
-      console.error(
-        `[alert] sendAlert webhook returned non-2xx: ${res.status} ${res.statusText}`,
-      );
+      console.error(`[alert] sendAlert webhook returned non-2xx: ${res.status} ${res.statusText}`);
     }
   } catch (err) {
-    console.error(
-      `[alert] sendAlert failed: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    console.error(`[alert] sendAlert failed: ${err instanceof Error ? err.message : String(err)}`);
   } finally {
     clearTimeout(timer);
   }

--- a/apps/web/worker/collector/alert.ts
+++ b/apps/web/worker/collector/alert.ts
@@ -1,9 +1,15 @@
-import type { CollectAllResult, CollectResult } from "./index";
+import type { CollectResult } from "./index";
 import type { Env } from "../types";
 
 export interface AlertSummary {
   failedFeeds: { id: string; error: string }[];
   streakFeeds: { id: string; consecutiveFailures: number }[];
+}
+
+/** sendAlert に渡す run 結果のサブセット */
+export interface AlertRunResult {
+  total: number;
+  results: CollectResult[];
 }
 
 const TOP_ERRORS_MAX = 5;
@@ -60,7 +66,7 @@ export async function notifyCollectorFailure(
  * collectAll の結果から Slack/Discord 互換の blocks 形式で通知する。
  * COLLECTOR_ALERT_WEBHOOK が未設定なら no-op。fetch 失敗は console.error のみ。
  */
-export async function sendAlert(env: Env, result: CollectAllResult): Promise<void> {
+export async function sendAlert(env: Env, result: AlertRunResult): Promise<void> {
   const webhookUrl = env.COLLECTOR_ALERT_WEBHOOK;
   if (!webhookUrl) return;
 
@@ -76,20 +82,18 @@ export async function sendAlert(env: Env, result: CollectAllResult): Promise<voi
     .map((r) => `${r.feedId} (${(r.error ?? "unknown").slice(0, 100)})`)
     .join(", ");
 
-  const mrkdwn =
-    `*Failed:* ${feedsFailed} / ${result.total}\n` +
-    `*Time:* ${now}\n` +
-    `*Top errors:* ${topErrors}`;
+  const mrkdwn = [
+    `*Failed:* ${feedsFailed} / ${result.total}`,
+    `*Time:* ${now}`,
+    `*Top errors:* ${topErrors}`,
+  ].join("\n");
 
   const payload = {
     text: "tech-news-bot collector alert",
     blocks: [
       {
         type: "section",
-        text: {
-          type: "mrkdwn",
-          text: mrkdwn,
-        },
+        text: { type: "mrkdwn", text: mrkdwn },
       },
     ],
   };

--- a/apps/web/worker/collector/alert.ts
+++ b/apps/web/worker/collector/alert.ts
@@ -1,5 +1,5 @@
-import type { Env } from "../types";
 import type { CollectAllResult, CollectResult } from "./index";
+import type { Env } from "../types";
 
 export interface AlertSummary {
   failedFeeds: { id: string; error: string }[];

--- a/apps/web/worker/collector/index.ts
+++ b/apps/web/worker/collector/index.ts
@@ -4,7 +4,7 @@ import { parseFeed } from "./rssParser";
 import { parseXml, pickText, asArray } from "../utils/xml";
 import { buildGuids } from "./deduplicator";
 import { writeCollectorEvent } from "./metrics";
-import { maybeAlert } from "./alert";
+import { maybeAlert, sendAlert } from "./alert";
 import { deleteOlderThan, insertArticles, type InsertableArticle } from "../db/articles";
 import {
   getEnabledFeedIds,
@@ -538,5 +538,16 @@ export async function collectAll(
     }
   }
 
-  return { total: activeFeeds.length, inserted, pruned, results, durationMs };
+  const finalResult = { total: activeFeeds.length, inserted, pruned, results, durationMs };
+
+  // COLLECTOR_ALERT_WEBHOOK ベースのシンプルな閾値アラート (best-effort)
+  try {
+    await sendAlert(env, finalResult);
+  } catch (err) {
+    console.error(
+      `[collector] sendAlert failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  return finalResult;
 }

--- a/apps/web/worker/types.ts
+++ b/apps/web/worker/types.ts
@@ -17,6 +17,10 @@ export interface Env {
   ALERT_WEBHOOK_URL?: string;
   ALERT_MIN_FAILURES?: string;
   ALERT_FEED_STREAK?: string;
+  // Slack/Discord 互換 webhook URL (wrangler secret put COLLECTOR_ALERT_WEBHOOK)
+  COLLECTOR_ALERT_WEBHOOK?: string;
+  // 閾値: feeds_failed がこの値以上になったら通知する (default: "5")
+  COLLECTOR_ALERT_THRESHOLD?: string;
 }
 
 export type FeedCategory = "bigtech" | "ai" | "jp" | "zenn";

--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -30,6 +30,7 @@ RETENTION_DAYS = "90"
 CORS_ALLOWED_ORIGINS = "https://tech-news-bot.rikeda71.workers.dev"
 ALERT_MIN_FAILURES = "3"
 ALERT_FEED_STREAK = "5"
+COLLECTOR_ALERT_THRESHOLD = "5"
 
 [[analytics_engine_datasets]]
 binding = "COLLECTOR_AE"


### PR DESCRIPTION
## Summary

- `sendAlert(env, result)` を `alert.ts` に追加。Slack blocks + text ペイロード形式、top errors 最大 5 件、5 秒 timeout、best-effort (throw しない)
- `collectAll()` 末尾で `sendAlert` を呼び出し (既存の `maybeAlert` は維持)
- `Env` に `COLLECTOR_ALERT_WEBHOOK` (secret) と `COLLECTOR_ALERT_THRESHOLD` (var, default "5") を追加
- `wrangler.toml` に `COLLECTOR_ALERT_THRESHOLD = "5"` を追加
- `sendAlert` のユニットテスト追加 (threshold / 空 webhook / エラー耐性)
- README にセットアップ手順 (`wrangler secret put COLLECTOR_ALERT_WEBHOOK`) 追記

## Test plan

- [ ] `pnpm build` pass
- [ ] `pnpm test` pass (468 tests)
- [ ] `pnpm check` pass
- [ ] `COLLECTOR_ALERT_WEBHOOK` 未設定時は fetch が呼ばれない
- [ ] 失敗数 >= 閾値のとき webhook が呼ばれる

Closes #203

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic alerts for feed collection failures. Alerts trigger when failures reach a configurable threshold (default: 5) and are sent to a configured webhook endpoint compatible with services like Slack or Discord.

* **Documentation**
  * Setup guide updated with instructions for configuring alert webhooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->