### PR TITLE
feat(spa): add Categories overview page at /categories

### DIFF
--- a/apps/web/client/App.tsx
+++ b/apps/web/client/App.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ArticleList } from "./components/ArticleList";
 import { AuthorDetail } from "./components/AuthorDetail";
+import { CategoriesOverview } from "./components/CategoriesOverview";
 import { FeedDetail } from "./components/FeedDetail";
 import { FilterBar } from "./components/FilterBar";
 import { type AppView, Header } from "./components/Header";
@@ -94,6 +95,7 @@ function readAuthorFromPath(): string | null {
 
 function readViewFromUrl(): AppView {
   if (window.location.pathname === "/stats") return "stats";
+  if (window.location.pathname === "/categories") return "categories";
   if (readFeedDetailFromPath() !== null) return "feed";
   if (readAuthorFromPath() !== null) return "author";
   return "articles";
@@ -129,7 +131,7 @@ function AppInner() {
     setView(next);
     setFeedDetailId("");
     setAuthorName("");
-    const path = next === "stats" ? "/stats" : "/";
+    const path = next === "stats" ? "/stats" : next === "categories" ? "/categories" : "/";
     if (window.location.pathname !== path) {
       window.history.pushState(null, "", path);
     }
@@ -149,6 +151,11 @@ function AppInner() {
       if (nextView === "author") {
         setAuthorName(readAuthorFromPath() ?? "");
         setFeedDetailId("");
+        return;
+      }
+      if (nextView === "categories") {
+        setFeedDetailId("");
+        setAuthorName("");
         return;
       }
       setFeedDetailId("");
@@ -334,6 +341,17 @@ function AppInner() {
     [pushFilter, lang, q, dateFrom, dateTo, unreadOnly, starredOnly],
   );
 
+  // Categories overview からカテゴリカードをクリックした際に articles ページへ遷移してフィルタを適用する
+  const handleSelectCategory = useCallback(
+    (id: FeedCategory) => {
+      window.history.pushState(null, "", "/");
+      window.dispatchEvent(new PopStateEvent("popstate"));
+      setView("articles");
+      pushFilter(id, lang, "", q, dateFrom, dateTo, unreadOnly, starredOnly);
+    },
+    [pushFilter, lang, q, dateFrom, dateTo, unreadOnly, starredOnly],
+  );
+
   // 記事カードの取得元クリックでフィード詳細へ drill-down する
   const handleGoToFeedDetail = useCallback((id: string) => {
     window.history.pushState(null, "", `/feed/${encodeURIComponent(id)}`);
@@ -451,6 +469,8 @@ function AppInner() {
 
       {view === "stats" ? (
         <StatsDashboard onNavigateToAuthor={handleGoToAuthorDetail} />
+      ) : view === "categories" ? (
+        <CategoriesOverview onSelectCategory={handleSelectCategory} />
       ) : view === "feed" && feedDetailId ? (
         <FeedDetail
           feedId={feedDetailId}

--- a/apps/web/client/components/CategoriesOverview.tsx
+++ b/apps/web/client/components/CategoriesOverview.tsx
@@ -1,0 +1,67 @@
+import type { FeedCategory } from "../types/api";
+import { useCategories } from "../hooks/useCategories";
+
+function formatRelative(iso: string): string {
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return iso;
+  const diffMs = Date.now() - t;
+  const min = Math.round(diffMs / 60_000);
+  if (min < 1) return "今";
+  if (min < 60) return `${min} 分前`;
+  const h = Math.round(min / 60);
+  if (h < 24) return `${h} 時間前`;
+  const d = Math.round(h / 24);
+  return `${d} 日前`;
+}
+
+interface Props {
+  onSelectCategory: (id: FeedCategory) => void;
+}
+
+export function CategoriesOverview({ onSelectCategory }: Props) {
+  const { categories, isLoading, error } = useCategories();
+
+  if (isLoading) {
+    return <div className="loader">読み込み中…</div>;
+  }
+
+  if (error) {
+    return <div className="error">取得エラー: {error}</div>;
+  }
+
+  if (!categories) return null;
+
+  return (
+    <div className="categories-overview">
+      <h2 className="categories-overview-title">カテゴリ一覧</h2>
+      <div className="categories-grid">
+        {categories.map((cat) => (
+          <button
+            key={cat.id}
+            type="button"
+            className={`category-card cat-${cat.id}`}
+            onClick={() => onSelectCategory(cat.id)}
+          >
+            <span className={`category-card-badge badge cat-${cat.id}`}>{cat.label}</span>
+            <div className="category-card-stats">
+              <div className="category-card-stat">
+                <span className="category-card-stat-label">フィード数</span>
+                <span className="category-card-stat-value">{cat.feeds_count}</span>
+              </div>
+              <div className="category-card-stat">
+                <span className="category-card-stat-label">30 日の記事数</span>
+                <span className="category-card-stat-value">{cat.articles_30d}</span>
+              </div>
+              <div className="category-card-stat">
+                <span className="category-card-stat-label">最終公開</span>
+                <span className="category-card-stat-value">
+                  {cat.last_published_at ? formatRelative(cat.last_published_at) : "—"}
+                </span>
+              </div>
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/client/components/Header.tsx
+++ b/apps/web/client/components/Header.tsx
@@ -3,7 +3,7 @@ import { useTheme } from "../hooks/useTheme";
 
 // "feed" は /feed/:id のフィード詳細ページで使用。nav タブには載せない
 // "author" は /author/:name の著者詳細ページで使用。nav タブには載せない
-export type AppView = "articles" | "stats" | "feed" | "author";
+export type AppView = "articles" | "stats" | "feed" | "author" | "categories";
 
 interface HeaderProps {
   view?: AppView;
@@ -33,6 +33,14 @@ export function Header({ view, onViewChange }: HeaderProps) {
             aria-current={view === "stats" ? "page" : undefined}
           >
             Stats
+          </button>
+          <button
+            type="button"
+            className={`app-nav-tab${view === "categories" ? " active" : ""}`}
+            onClick={() => onViewChange("categories")}
+            aria-current={view === "categories" ? "page" : undefined}
+          >
+            カテゴリ
           </button>
         </nav>
       )}

--- a/apps/web/client/hooks/useCategories.ts
+++ b/apps/web/client/hooks/useCategories.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+import type { CategorySummary } from "../types/api";
+
+export function useCategories() {
+  const [categories, setCategories] = useState<CategorySummary[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+    void (async () => {
+      try {
+        const res = await fetch("/api/categories");
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = (await res.json()) as { categories: CategorySummary[] };
+        if (alive) setCategories(data.categories);
+      } catch (err) {
+        if (alive) setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        if (alive) setIsLoading(false);
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  return { categories, error, isLoading };
+}

--- a/apps/web/client/index.css
+++ b/apps/web/client/index.css
@@ -1245,3 +1245,73 @@ kbd {
   padding: 16px;
   margin-top: 0;
 }
+
+/* Categories overview */
+
+.categories-overview {
+  padding: 16px 0;
+}
+
+.categories-overview-title {
+  font-size: 1.1rem;
+  margin: 0 0 16px;
+}
+
+.categories-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+}
+
+@media (min-width: 720px) {
+  .categories-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.category-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  cursor: pointer;
+  text-align: left;
+  color: var(--fg);
+  font-size: 0.9rem;
+  transition: background 0.15s;
+}
+
+.category-card:hover {
+  background: var(--bg-elev-2);
+}
+
+.category-card-badge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  align-self: flex-start;
+}
+
+.category-card-stats {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.category-card-stat {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.category-card-stat-label {
+  color: var(--fg-muted);
+  font-size: 0.8rem;
+}
+
+.category-card-stat-value {
+  font-weight: 600;
+}

--- a/apps/web/client/types/api.ts
+++ b/apps/web/client/types/api.ts
@@ -62,3 +62,15 @@ export interface CalendarDay {
 export interface CalendarResponse {
   days: CalendarDay[];
 }
+
+export interface CategorySummary {
+  id: FeedCategory;
+  label: string;
+  feeds_count: number;
+  articles_30d: number;
+  last_published_at: string | null;
+}
+
+export interface CategoriesResponse {
+  categories: CategorySummary[];
+}

--- a/apps/web/tests/client/CategoriesOverview.test.tsx
+++ b/apps/web/tests/client/CategoriesOverview.test.tsx
@@ -1,0 +1,159 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import type { CategoriesResponse } from "../../client/types/api";
+
+const { CategoriesOverview } = await import("../../client/components/CategoriesOverview");
+
+const sampleResponse: CategoriesResponse = {
+  categories: [
+    {
+      id: "bigtech",
+      label: "Big Tech",
+      feeds_count: 5,
+      articles_30d: 120,
+      last_published_at: "2024-01-15T10:00:00Z",
+    },
+    {
+      id: "ai",
+      label: "AI",
+      feeds_count: 8,
+      articles_30d: 200,
+      last_published_at: null,
+    },
+    {
+      id: "jp",
+      label: "日本企業",
+      feeds_count: 3,
+      articles_30d: 50,
+      last_published_at: "2024-01-14T12:00:00Z",
+    },
+    {
+      id: "zenn",
+      label: "Zenn",
+      feeds_count: 10,
+      articles_30d: 300,
+      last_published_at: "2024-01-15T08:00:00Z",
+    },
+  ],
+};
+
+const noop = () => {};
+
+describe("CategoriesOverview", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("ローディング中は読み込み中テキストを表示する", () => {
+    vi.stubGlobal("fetch", vi.fn().mockReturnValue(new Promise(() => {})));
+    render(<CategoriesOverview onSelectCategory={noop} />);
+    expect(screen.getByText("読み込み中…")).toBeTruthy();
+  });
+
+  it("4 カテゴリのカードを表示する", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(sampleResponse),
+      }),
+    );
+
+    render(<CategoriesOverview onSelectCategory={noop} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Big Tech")).toBeTruthy();
+    });
+
+    expect(screen.getByText("AI")).toBeTruthy();
+    expect(screen.getByText("日本企業")).toBeTruthy();
+    expect(screen.getByText("Zenn")).toBeTruthy();
+  });
+
+  it("feeds_count と articles_30d を表示する", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(sampleResponse),
+      }),
+    );
+
+    render(<CategoriesOverview onSelectCategory={noop} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Big Tech")).toBeTruthy();
+    });
+
+    // bigtech: feeds_count=5, articles_30d=120
+    const statValues = screen.getAllByText("5");
+    expect(statValues.length).toBeGreaterThan(0);
+    expect(screen.getByText("120")).toBeTruthy();
+  });
+
+  it("last_published_at が null の場合は「—」を表示する", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(sampleResponse),
+      }),
+    );
+
+    render(<CategoriesOverview onSelectCategory={noop} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("AI")).toBeTruthy();
+    });
+
+    // ai の last_published_at は null なので「—」が表示される
+    expect(screen.getByText("—")).toBeTruthy();
+  });
+
+  it("エラー時にエラーメッセージを表示する", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+      }),
+    );
+
+    render(<CategoriesOverview onSelectCategory={noop} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/取得エラー/)).toBeTruthy();
+    });
+  });
+
+  it("カードクリックで onSelectCategory が呼ばれる", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(sampleResponse),
+      }),
+    );
+
+    const onSelectCategory = vi.fn<(id: string) => void>();
+    const user = userEvent.setup();
+    render(<CategoriesOverview onSelectCategory={onSelectCategory} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Big Tech")).toBeTruthy();
+    });
+
+    // Big Tech カードをクリック
+    const bigTechCard = screen.getByText("Big Tech").closest("button");
+    expect(bigTechCard).toBeTruthy();
+    await user.click(bigTechCard!);
+
+    expect(onSelectCategory).toHaveBeenCalledWith("bigtech");
+  });
+});

--- a/apps/web/tests/client/useCategories.test.tsx
+++ b/apps/web/tests/client/useCategories.test.tsx
@@ -1,0 +1,99 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import type { CategoriesResponse } from "../../client/types/api";
+
+const { useCategories } = await import("../../client/hooks/useCategories");
+
+const sampleResponse: CategoriesResponse = {
+  categories: [
+    {
+      id: "bigtech",
+      label: "Big Tech",
+      feeds_count: 5,
+      articles_30d: 120,
+      last_published_at: "2024-01-15T10:00:00Z",
+    },
+    {
+      id: "ai",
+      label: "AI",
+      feeds_count: 8,
+      articles_30d: 200,
+      last_published_at: "2024-01-15T09:00:00Z",
+    },
+  ],
+};
+
+describe("useCategories", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("成功時に categories を返す", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(sampleResponse),
+      }),
+    );
+
+    const { result } = renderHook(() => useCategories());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.categories).toHaveLength(2);
+    expect(result.current.categories?.[0].id).toBe("bigtech");
+    expect(result.current.error).toBeNull();
+  });
+
+  it("HTTP エラー時に error を返す", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+      }),
+    );
+
+    const { result } = renderHook(() => useCategories());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBeTruthy();
+    expect(result.current.categories).toBeNull();
+  });
+
+  it("初期状態では isLoading が true", () => {
+    vi.stubGlobal("fetch", vi.fn().mockReturnValue(new Promise(() => {})));
+
+    const { result } = renderHook(() => useCategories());
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.categories).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("/api/categories を fetch する", async () => {
+    const mockFetch = vi.fn<() => Promise<Response>>().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(sampleResponse),
+    } as unknown as Response);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const { result } = renderHook(() => useCategories());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith("/api/categories");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `CategorySummary` / `CategoriesResponse` types to `client/types/api.ts`
- Add `useCategories` hook (fetches `GET /api/categories`, follows `useStats` pattern)
- Add `CategoriesOverview` component: 2-col grid (desktop) / 1-col (mobile), each card shows label, feeds_count, articles_30d, last_published_at (relative time)
- Extend `AppView` type with `'categories'`, add ナビリンク in `Header`
- Add `/categories` route in `App.tsx` with `handleSelectCategory` (navigates to articles with category filter)
- New tests: `useCategories.test.tsx`, `CategoriesOverview.test.tsx` (468 tests pass)

Closes #204