### PR TITLE
feat: add GET /api/articles/search endpoint

### DIFF
--- a/apps/web/tests/worker/api/articles.test.ts
+++ b/apps/web/tests/worker/api/articles.test.ts
@@ -1904,3 +1904,173 @@ describe("GET /api/articles/by-day/:date", () => {
     expect(res.headers.get("Content-Type")).toMatch(/application\/json/);
   });
 });
+
+describe("GET /api/articles/search", () => {
+  // beforeEach で挿入される記事:
+  //   g-bt-1  title="BigTech Article One"  summary="Discusses LLM optimization"
+  //   o-ai-1  title="AI Article One"       summary="Discusses GPT"
+  //   o-ai-2  title="AI Article Two"       summary="Discusses DALL-E"
+
+  it("returns 400 when q is missing", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/search");
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toBe("missing q");
+  });
+
+  it("returns 400 when q is empty string", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/search?q=");
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toBe("missing q");
+  });
+
+  it("returns 400 when q has more than 5 tokens", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/search?q=a+b+c+d+e+f");
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toMatch(/token/);
+  });
+
+  it("returns 400 when a token exceeds 50 characters", async () => {
+    const longToken = "a".repeat(51);
+    const res = await SELF.fetch(`https://example.com/api/articles/search?q=${longToken}`);
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toMatch(/token/);
+  });
+
+  it("returns 400 when limit=0", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/search?q=ai&limit=0");
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toMatch(/limit/);
+  });
+
+  it("returns 400 when limit=101", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/search?q=ai&limit=101");
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toMatch(/limit/);
+  });
+
+  it("returns 400 when cursor is malformed", async () => {
+    const res = await SELF.fetch(
+      "https://example.com/api/articles/search?q=ai&cursor=not-valid-base64!!!",
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toMatch(/cursor/);
+  });
+
+  it("returns 200 with query/tokens/articles/next_cursor fields", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/search?q=article");
+    expect(res.status).toBe(200);
+    const body = await res.json<{
+      query: string;
+      tokens: string[];
+      articles: unknown[];
+      next_cursor: string | null;
+    }>();
+    expect(body.query).toBe("article");
+    expect(body.tokens).toEqual(["article"]);
+    expect(Array.isArray(body.articles)).toBe(true);
+    expect("next_cursor" in body).toBe(true);
+  });
+
+  it("matches articles whose title contains the keyword (case-insensitive)", async () => {
+    // "bigtech" は g-bt-1 の title に含まれる
+    const res = await SELF.fetch("https://example.com/api/articles/search?q=bigtech");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ articles: { guid: string }[] }>();
+    expect(body.articles.some((a) => a.guid === "g-bt-1")).toBe(true);
+    // ai 記事は含まれない
+    expect(body.articles.every((a) => a.guid !== "o-ai-1")).toBe(true);
+  });
+
+  it("matches articles whose summary contains the keyword", async () => {
+    // "gpt" は o-ai-1 の summary に含まれる
+    const res = await SELF.fetch("https://example.com/api/articles/search?q=gpt");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ articles: { guid: string }[] }>();
+    expect(body.articles.some((a) => a.guid === "o-ai-1")).toBe(true);
+    // g-bt-1 や o-ai-2 は含まれない
+    expect(body.articles.every((a) => a.guid !== "g-bt-1")).toBe(true);
+    expect(body.articles.every((a) => a.guid !== "o-ai-2")).toBe(true);
+  });
+
+  it("is case-insensitive (uppercase keyword matches lowercase content)", async () => {
+    // "DALL-E" → lowercase "dall-e" で o-ai-2 の summary "Discusses DALL-E" にマッチ
+    const res = await SELF.fetch("https://example.com/api/articles/search?q=DALL-E");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ articles: { guid: string }[] }>();
+    expect(body.articles.some((a) => a.guid === "o-ai-2")).toBe(true);
+  });
+
+  it("applies AND logic: both tokens must match", async () => {
+    // "ai" は全 ai 記事に, "gpt" は o-ai-1 にのみマッチ → AND で o-ai-1 のみ
+    const res = await SELF.fetch("https://example.com/api/articles/search?q=ai+gpt");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ articles: { guid: string }[] }>();
+    expect(body.articles.some((a) => a.guid === "o-ai-1")).toBe(true);
+    // o-ai-2 は "gpt" を含まない
+    expect(body.articles.every((a) => a.guid !== "o-ai-2")).toBe(true);
+  });
+
+  it("returns empty articles when no articles match", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/search?q=xxxxxxxxnotexist");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ articles: unknown[] }>();
+    expect(body.articles).toEqual([]);
+  });
+
+  it("returns results in published_at DESC, id DESC order", async () => {
+    // "article" は全 3 件の title に含まれる
+    const res = await SELF.fetch("https://example.com/api/articles/search?q=article");
+    expect(res.status).toBe(200);
+    const body = await res.json<{ articles: { published_at: string }[] }>();
+    const dates = body.articles.map((a) => a.published_at);
+    const sorted = dates.toSorted((a, b) => b.localeCompare(a));
+    expect(dates).toEqual(sorted);
+  });
+
+  it("paginates with cursor: first page + second page covers all articles", async () => {
+    // "article" が全 3 件にマッチ。limit=2 でページネーション確認
+    const res1 = await SELF.fetch("https://example.com/api/articles/search?q=article&limit=2");
+    expect(res1.status).toBe(200);
+    const body1 = await res1.json<{
+      articles: { guid: string }[];
+      next_cursor: string | null;
+    }>();
+    expect(body1.articles.length).toBe(2);
+    expect(body1.next_cursor).not.toBeNull();
+
+    const res2 = await SELF.fetch(
+      `https://example.com/api/articles/search?q=article&limit=2&cursor=${body1.next_cursor}`,
+    );
+    expect(res2.status).toBe(200);
+    const body2 = await res2.json<{
+      articles: { guid: string }[];
+      next_cursor: string | null;
+    }>();
+    expect(body2.articles.length).toBe(1);
+    expect(body2.next_cursor).toBeNull();
+
+    const allGuids = [...body1.articles.map((a) => a.guid), ...body2.articles.map((a) => a.guid)];
+    expect(allGuids).toContain("g-bt-1");
+    expect(allGuids).toContain("o-ai-1");
+    expect(allGuids).toContain("o-ai-2");
+  });
+
+  it("returns Cache-Control: public, max-age=120", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/search?q=ai");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=120");
+  });
+
+  it("returns Content-Type: application/json", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/search?q=ai");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toMatch(/application\/json/);
+  });
+});

--- a/apps/web/worker/api/articles.ts
+++ b/apps/web/worker/api/articles.ts
@@ -16,6 +16,7 @@ import {
   getRandomArticles,
   getRelatedArticles,
   listArticles,
+  searchArticles,
 } from "../db/articles";
 import { computeArticlesEtag } from "../utils/etag";
 import feedsYaml from "../feeds.yaml";
@@ -256,6 +257,49 @@ app.get("/popular", async (c) => {
   return c.json(result, 200, {
     "Cache-Control": "public, max-age=600",
   });
+});
+
+const MAX_SEARCH_TOKENS = 5;
+const MAX_TOKEN_LEN = 50;
+
+app.get("/search", async (c) => {
+  const qRaw = c.req.query("q");
+  if (!qRaw || !qRaw.trim()) return c.json({ error: "missing q" }, 400);
+
+  // lower-case + trim してトークン分割
+  const tokens = qRaw.trim().toLowerCase().split(/\s+/).filter(Boolean);
+
+  if (tokens.length === 0 || tokens.length > MAX_SEARCH_TOKENS) {
+    return c.json({ error: `q must have 1 to ${MAX_SEARCH_TOKENS} tokens` }, 400);
+  }
+  for (const token of tokens) {
+    if (token.length < 1 || token.length > MAX_TOKEN_LEN) {
+      return c.json({ error: `each token must be 1 to ${MAX_TOKEN_LEN} characters` }, 400);
+    }
+  }
+
+  const limitRaw = c.req.query("limit") ?? "50";
+  const limitNum = Number(limitRaw);
+  if (!Number.isInteger(limitNum) || limitNum < 1 || limitNum > 100) {
+    return c.json({ error: "limit must be an integer between 1 and 100" }, 400);
+  }
+
+  const cursorRaw = c.req.query("cursor");
+  const cursor = decodeCursor(cursorRaw);
+  if (cursorRaw && !cursor) return c.json({ error: "invalid cursor" }, 400);
+
+  const result = await searchArticles(c.env.DB, tokens, limitNum, cursor);
+
+  return c.json(
+    {
+      query: tokens.join(" "),
+      tokens,
+      articles: result.articles,
+      next_cursor: encodeCursor(result.nextCursor),
+    },
+    200,
+    { "Cache-Control": "public, max-age=120" },
+  );
 });
 
 app.get("/:guid/related", async (c) => {

--- a/apps/web/worker/db/articles.ts
+++ b/apps/web/worker/db/articles.ts
@@ -877,6 +877,69 @@ export async function countArticlesByDay(
   return row?.c ?? 0;
 }
 
+export interface SearchArticlesResult {
+  articles: Article[];
+  nextCursor: { publishedAt: string; id: number } | null;
+}
+
+/**
+ * LIKE ベースの全文検索。
+ * token ごとに LOWER(title || ' ' || COALESCE(summary, '')) LIKE '%token%' を AND で連鎖する。
+ * FTS5 への切替時はこの関数を差し替えるだけで済むようにクリーンに分離している。
+ */
+export async function searchArticles(
+  db: D1Database,
+  tokens: string[],
+  limit: number,
+  cursor: { publishedAt: string; id: number } | null,
+): Promise<SearchArticlesResult> {
+  const conds: string[] = [];
+  const binds: unknown[] = [];
+
+  for (const token of tokens) {
+    // LIKE のメタ文字をエスケープしてプレースホルダ経由で渡す
+    const escaped = token.replace(/[%_\\]/g, (ch) => `\\${ch}`);
+    conds.push(
+      `LOWER(a.title || ' ' || COALESCE(a.summary, '')) LIKE ?${binds.length + 1} ESCAPE '\\'`,
+    );
+    binds.push(`%${escaped}%`);
+  }
+
+  if (cursor) {
+    conds.push(
+      `(a.published_at < ?${binds.length + 1} OR (a.published_at = ?${binds.length + 1} AND a.id < ?${binds.length + 2}))`,
+    );
+    binds.push(cursor.publishedAt, cursor.id);
+  }
+
+  const where = conds.length > 0 ? `WHERE ${conds.join(" AND ")}` : "";
+  const sql = `
+    SELECT a.id, a.guid, a.feed_id, f.name AS feed_name, a.title, a.url, a.summary,
+           a.author, a.published_at, a.fetched_at, a.category, a.lang
+    FROM articles a
+    LEFT JOIN feeds f ON f.id = a.feed_id
+    ${where}
+    ORDER BY a.published_at DESC, a.id DESC
+    LIMIT ?${binds.length + 1}
+  `;
+  binds.push(limit + 1);
+
+  const result = await db
+    .prepare(sql)
+    .bind(...binds)
+    .all<Article>();
+
+  const rows = result.results ?? [];
+  let nextCursor: { publishedAt: string; id: number } | null = null;
+  let articles = rows;
+  if (rows.length > limit) {
+    articles = rows.slice(0, limit);
+    const last = articles[articles.length - 1];
+    nextCursor = { publishedAt: last.published_at, id: last.id };
+  }
+  return { articles, nextCursor };
+}
+
 function escapeFtsQuery(input: string): string {
   // FTS5 で安全に扱うため、特殊記号を除去して各単語をフレーズ扱いにする
   const tokens = input


### PR DESCRIPTION
## Summary
- `GET /api/articles/search?q=...` を実装
- SQLite LIKE による大文字小文字区別なし AND キーワード検索
- `searchArticles(db, tokens, limit, cursor)` を `db/articles.ts` に独立関数として追加し、将来の FTS5 切替に備えた

## Test plan
- [ ] `vp check` pass (既存と同一の 1 error / 9 warnings)
- [ ] `vp test run` pass (485 → 500 tests)
- [ ] バリデーション (q 未指定/空、token 数超過/長さ超過、limit/cursor 不正) → 400
- [ ] AND マッチ・大文字小文字区別なし・cursor ページネーション

Closes #210