### PR TITLE
feat(collector): add D1 cost observability via Analytics Engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,30 @@ feeds:
 
 YAML は `@modyfi/vite-plugin-yaml` により build 時に JSON へ変換され Worker bundle に inline されます (runtime 依存なし)。設定変更は再デプロイで反映されます。
 
+## D1 コスト監視 (Analytics Engine)
+
+Cron 収集が完了するたびに、D1 読み書き回数と実行時間を Cloudflare Analytics Engine (dataset: `tnb_collector_events`) に記録します。
+
+Cloudflare Dashboard でクエリする手順:
+
+1. Dashboard → Workers & Pages → Analytics Engine → SQL Console を開く
+2. 以下の SQL を実行して直近の集計を確認する:
+
+```sql
+SELECT
+  toStartOfHour(timestamp) AS hour,
+  SUM(_sample_interval * double1) AS rows_read,
+  SUM(_sample_interval * double2) AS rows_written,
+  SUM(_sample_interval * double4) AS articles_inserted
+FROM tnb_collector_events
+WHERE index1 = 'd1_cost'
+  AND timestamp > NOW() - INTERVAL '7' DAY
+GROUP BY hour
+ORDER BY hour DESC
+```
+
+> `double1` = rows_read, `double2` = rows_written, `double3` = duration_total_ms, `double4` = articles_inserted
+
 ## 無料枠と制約
 
 | 項目               | 無料上限  | 想定使用量                     |

--- a/apps/web/tests/worker/collector/metrics.test.ts
+++ b/apps/web/tests/worker/collector/metrics.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vite-plus/test";
-import { D1CostAccumulator, writeCollectorEvent, writeD1CostEvent } from "../../../worker/collector/metrics";
+import {
+  D1CostAccumulator,
+  writeCollectorEvent,
+  writeD1CostEvent,
+} from "../../../worker/collector/metrics";
 import type { Env } from "../../../worker/types";
 
 function makeEnv(writeDataPoint?: ReturnType<typeof vi.fn>): Env {

--- a/apps/web/tests/worker/collector/metrics.test.ts
+++ b/apps/web/tests/worker/collector/metrics.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vite-plus/test";
-import { writeCollectorEvent } from "../../../worker/collector/metrics";
+import { D1CostAccumulator, writeCollectorEvent, writeD1CostEvent } from "../../../worker/collector/metrics";
 import type { Env } from "../../../worker/types";
 
 function makeEnv(writeDataPoint?: ReturnType<typeof vi.fn>): Env {
@@ -81,6 +81,95 @@ describe("writeCollectorEvent", () => {
 
     expect(() => {
       writeCollectorEvent(env, { feedId: "feed-e", status: "error", ms: 99, statusCode: 0 });
+    }).not.toThrow();
+  });
+});
+
+describe("D1CostAccumulator", () => {
+  it("accumulates rows_read, rows_written, duration across multiple add() calls", () => {
+    const acc = new D1CostAccumulator();
+
+    acc.add({ rows_read: 10, rows_written: 2, duration: 5 });
+    acc.add({ rows_read: 20, rows_written: 3, duration: 8 });
+    acc.add({ rows_read: 5, rows_written: 1, duration: 2 });
+
+    const stats = acc.toStats();
+    expect(stats.rowsRead).toBe(35);
+    expect(stats.rowsWritten).toBe(6);
+    expect(stats.durationTotalMs).toBe(15);
+  });
+
+  it("treats null/undefined meta as zero", () => {
+    const acc = new D1CostAccumulator();
+    acc.add(null);
+    acc.add(undefined);
+
+    const stats = acc.toStats();
+    expect(stats.rowsRead).toBe(0);
+    expect(stats.rowsWritten).toBe(0);
+    expect(stats.durationTotalMs).toBe(0);
+  });
+
+  it("treats missing fields in meta as zero", () => {
+    const acc = new D1CostAccumulator();
+    acc.add({});
+
+    const stats = acc.toStats();
+    expect(stats.rowsRead).toBe(0);
+    expect(stats.rowsWritten).toBe(0);
+    expect(stats.durationTotalMs).toBe(0);
+  });
+});
+
+describe("writeD1CostEvent", () => {
+  it("calls writeDataPoint with correct blobs/doubles/indexes", () => {
+    const writeDataPoint = vi.fn<() => void>();
+    const env = makeEnv(writeDataPoint);
+
+    writeD1CostEvent(env, {
+      rowsRead: 100,
+      rowsWritten: 20,
+      durationTotalMs: 500,
+      feedsCount: 40,
+      articlesInserted: 15,
+    });
+
+    expect(writeDataPoint).toHaveBeenCalledTimes(1);
+    expect(writeDataPoint).toHaveBeenCalledWith({
+      blobs: ["collect_run_d1"],
+      doubles: [100, 20, 500, 15],
+      indexes: ["d1_cost"],
+    });
+  });
+
+  it("does not throw when COLLECTOR_AE binding is undefined", () => {
+    const env = makeEnv(undefined);
+
+    expect(() => {
+      writeD1CostEvent(env, {
+        rowsRead: 0,
+        rowsWritten: 0,
+        durationTotalMs: 0,
+        feedsCount: 0,
+        articlesInserted: 0,
+      });
+    }).not.toThrow();
+  });
+
+  it("does not throw when writeDataPoint throws internally", () => {
+    const writeDataPoint = vi.fn<() => void>().mockImplementation(() => {
+      throw new Error("AE unavailable");
+    });
+    const env = makeEnv(writeDataPoint);
+
+    expect(() => {
+      writeD1CostEvent(env, {
+        rowsRead: 10,
+        rowsWritten: 5,
+        durationTotalMs: 100,
+        feedsCount: 3,
+        articlesInserted: 2,
+      });
     }).not.toThrow();
   });
 });

--- a/apps/web/worker/collector/index.ts
+++ b/apps/web/worker/collector/index.ts
@@ -3,7 +3,7 @@ import { loadEnabledFeeds } from "../feed-config";
 import { parseFeed } from "./rssParser";
 import { parseXml, pickText, asArray } from "../utils/xml";
 import { buildGuids } from "./deduplicator";
-import { writeCollectorEvent } from "./metrics";
+import { D1CostAccumulator, writeCollectorEvent, writeD1CostEvent } from "./metrics";
 import { maybeAlert, sendAlert } from "./alert";
 import { deleteOlderThan, insertArticles, type InsertableArticle } from "../db/articles";
 import {
@@ -444,12 +444,15 @@ export async function collectAll(
   const maxRetries = Number(env.COLLECTOR_RETRIES ?? "2") || 2;
   const summaryMax = Number(env.SUMMARY_MAX_LENGTH ?? "500") || 500;
 
+  const d1Acc = new D1CostAccumulator();
+
   // run_id が外から渡された場合はそれを使い、渡されなければここで startRun する
   let runId: number | null = opts?.runId ?? null;
   if (runId === null) {
     try {
-      const { run_id } = await startRun(env.DB, startedAt, activeFeeds.length);
+      const { run_id, d1Meta } = await startRun(env.DB, startedAt, activeFeeds.length);
       runId = run_id;
+      d1Acc.add(d1Meta);
     } catch (err) {
       console.error(
         `[collector] startRun failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -467,7 +470,7 @@ export async function collectAll(
       const status =
         result.status === "error" ? "failed" : result.status === "not_modified" ? "skipped" : "ok";
       try {
-        await recordRunFeed(
+        const meta = await recordRunFeed(
           env.DB,
           runId,
           feed.id,
@@ -476,6 +479,7 @@ export async function collectAll(
           durationMs,
           result.error,
         );
+        d1Acc.add(meta);
       } catch (err) {
         console.error(
           `[collector] recordRunFeed(${feed.id}) failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -507,7 +511,8 @@ export async function collectAll(
   // run の完了を記録する
   if (runId !== null) {
     try {
-      await finishRun(env.DB, runId, completedAt, feedsOk, feedsFailed, inserted);
+      const meta = await finishRun(env.DB, runId, completedAt, feedsOk, feedsFailed, inserted);
+      d1Acc.add(meta);
     } catch (err) {
       console.error(
         `[collector] finishRun failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -518,6 +523,22 @@ export async function collectAll(
   console.log(
     `[collector] feeds=${activeFeeds.length} skipped304=${skipped304} inserted=${inserted} pruned=${pruned} retentionDays=${retentionDays} duration=${durationMs}ms`,
   );
+
+  // D1 コスト集計を AE に送信する (best-effort)
+  try {
+    const d1Stats = d1Acc.toStats();
+    writeD1CostEvent(env, {
+      rowsRead: d1Stats.rowsRead,
+      rowsWritten: d1Stats.rowsWritten,
+      durationTotalMs: d1Stats.durationTotalMs,
+      feedsCount: activeFeeds.length,
+      articlesInserted: inserted,
+    });
+  } catch (err) {
+    console.warn(
+      `[collector] writeD1CostEvent failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
   for (const r of results) {
     if (r.status === "error") {
       console.warn(`[collector] ${r.feedId} ERROR: ${r.error}`);

--- a/apps/web/worker/collector/metrics.ts
+++ b/apps/web/worker/collector/metrics.ts
@@ -19,3 +19,70 @@ export function writeCollectorEvent(env: Env, ev: CollectorEvent): void {
     console.warn("[collector] AE writeDataPoint failed", e);
   }
 }
+
+/** collector 1 run 分の D1 アクセスコスト集計 */
+export interface D1RunStats {
+  rowsRead: number;
+  rowsWritten: number;
+  durationTotalMs: number;
+}
+
+/** D1 クエリの meta からコスト統計を累積するカウンター */
+export class D1CostAccumulator {
+  rowsRead = 0;
+  rowsWritten = 0;
+  durationTotalMs = 0;
+
+  /** D1Result.meta オブジェクトを受け取り統計に加算する */
+  add(meta: { rows_read?: number; rows_written?: number; duration?: number } | null | undefined): void {
+    if (!meta) return;
+    this.rowsRead += meta.rows_read ?? 0;
+    this.rowsWritten += meta.rows_written ?? 0;
+    this.durationTotalMs += meta.duration ?? 0;
+  }
+
+  toStats(): D1RunStats {
+    return {
+      rowsRead: this.rowsRead,
+      rowsWritten: this.rowsWritten,
+      durationTotalMs: this.durationTotalMs,
+    };
+  }
+}
+
+export interface D1CostEvent {
+  rowsRead: number;
+  rowsWritten: number;
+  durationTotalMs: number;
+  feedsCount: number;
+  articlesInserted: number;
+}
+
+/**
+ * collector 1 run 分の D1 コスト集計値を AE に送信する。
+ * 送信失敗は best-effort でログのみ (collector を止めない)。
+ */
+export function writeD1CostEvent(env: Env, ev: D1CostEvent): void {
+  // 構造化ログ (1 run 1 行)
+  console.log(
+    JSON.stringify({
+      event: "collect_run_d1",
+      rows_read: ev.rowsRead,
+      rows_written: ev.rowsWritten,
+      duration_total_ms: ev.durationTotalMs,
+      feeds_count: ev.feedsCount,
+      articles_inserted: ev.articlesInserted,
+    }),
+  );
+
+  if (!env.COLLECTOR_AE) return;
+  try {
+    env.COLLECTOR_AE.writeDataPoint({
+      blobs: ["collect_run_d1"],
+      doubles: [ev.rowsRead, ev.rowsWritten, ev.durationTotalMs, ev.articlesInserted],
+      indexes: ["d1_cost"],
+    });
+  } catch (e) {
+    console.warn("[collector] AE writeDataPoint (d1_cost) failed", e);
+  }
+}

--- a/apps/web/worker/collector/metrics.ts
+++ b/apps/web/worker/collector/metrics.ts
@@ -34,7 +34,9 @@ export class D1CostAccumulator {
   durationTotalMs = 0;
 
   /** D1Result.meta オブジェクトを受け取り統計に加算する */
-  add(meta: { rows_read?: number; rows_written?: number; duration?: number } | null | undefined): void {
+  add(
+    meta: { rows_read?: number; rows_written?: number; duration?: number } | null | undefined,
+  ): void {
     if (!meta) return;
     this.rowsRead += meta.rows_read ?? 0;
     this.rowsWritten += meta.rows_written ?? 0;

--- a/apps/web/worker/db/runs.ts
+++ b/apps/web/worker/db/runs.ts
@@ -22,7 +22,7 @@ export async function startRun(
   db: D1Database,
   started_at: string,
   feeds_total: number,
-): Promise<{ run_id: number }> {
+): Promise<{ run_id: number; d1Meta: D1Result["meta"] }> {
   const result = await db
     .prepare(
       `INSERT INTO collector_runs (started_at, feeds_total)
@@ -31,7 +31,7 @@ export async function startRun(
     .bind(started_at, feeds_total)
     .run();
   const run_id = result.meta.last_row_id as number;
-  return { run_id };
+  return { run_id, d1Meta: result.meta };
 }
 
 export async function recordRunFeed(
@@ -42,16 +42,17 @@ export async function recordRunFeed(
   articles_inserted: number,
   duration_ms: number,
   error?: string,
-): Promise<void> {
+): Promise<D1Result["meta"]> {
   // 200 文字で切り詰め。長いスタックトレースを D1 に書かないため。
   const errorTruncated = error ? error.slice(0, 200) : null;
-  await db
+  const result = await db
     .prepare(
       `INSERT INTO collector_run_feeds (run_id, feed_id, status, articles_inserted, duration_ms, error)
        VALUES (?1, ?2, ?3, ?4, ?5, ?6)`,
     )
     .bind(run_id, feed_id, status, articles_inserted, duration_ms, errorTruncated)
     .run();
+  return result.meta;
 }
 
 export async function finishRun(
@@ -62,9 +63,9 @@ export async function finishRun(
   feeds_failed: number,
   articles_inserted: number,
   error?: string,
-): Promise<void> {
+): Promise<D1Result["meta"]> {
   const errorTruncated = error ? error.slice(0, 200) : null;
-  await db
+  const result = await db
     .prepare(
       `UPDATE collector_runs
        SET completed_at = ?1,
@@ -76,6 +77,7 @@ export async function finishRun(
     )
     .bind(completed_at, feeds_ok, feeds_failed, articles_inserted, errorTruncated, run_id)
     .run();
+  return result.meta;
 }
 
 export async function getLatestCompletedRun(db: D1Database): Promise<RunRow | null> {


### PR DESCRIPTION
## Summary
- collector の `collectAll()` 完了時に D1 の `meta.rows_read` / `meta.rows_written` / `duration` を集計し、Analytics Engine (`COLLECTOR_AE`) にデータポイントとして書き込み
- 構造化ログを 1 run あたり 1 行 (JSON) で `console.log` 出力。Cloudflare Logs から `wrangler tail` でも確認可能
- AE への書き込みは best-effort (try/catch でログのみ、collector 主処理は壊さない)
- README にダッシュボードでの確認方法を追記

Closes #38

## Test plan
- [x] `apps/web/tests/worker/collector/*.test.ts` で集計とログ出力をテスト
- [x] `pnpm build` / `pnpm test` ローカル pass