### PR TITLE
fix: Categories の id/label 不整合と jp に混入した zenn 記事の修正

### DIFF
--- a/apps/web/tests/worker/api/categories.test.ts
+++ b/apps/web/tests/worker/api/categories.test.ts
@@ -48,7 +48,8 @@ function daysAgo(n: number): string {
 }
 
 interface CategorySummary {
-  category: FeedCategory;
+  id: FeedCategory;
+  label: string;
   feeds_count: number;
   articles_30d: number;
   last_published_at: string | null;
@@ -66,7 +67,7 @@ describe("GET /api/categories - DB 空の場合", () => {
     expect(Array.isArray(body.categories)).toBe(true);
     expect(body.categories).toHaveLength(4);
 
-    const cats = body.categories.map((c) => c.category).sort();
+    const cats = body.categories.map((c) => c.id).sort();
     expect(cats).toEqual([...ALL_CATEGORIES].sort());
   });
 
@@ -144,7 +145,7 @@ describe("GET /api/categories - テストデータあり", () => {
     const body = await res.json<CategoriesResponse>();
     expect(body.categories).toHaveLength(4);
 
-    const cats = body.categories.map((c) => c.category).sort();
+    const cats = body.categories.map((c) => c.id).sort();
     expect(cats).toEqual([...ALL_CATEGORIES].sort());
   });
 
@@ -152,7 +153,7 @@ describe("GET /api/categories - テストデータあり", () => {
     const res = await SELF.fetch("https://example.com/api/categories");
     const body = await res.json<CategoriesResponse>();
 
-    const byCategory = Object.fromEntries(body.categories.map((c) => [c.category, c]));
+    const byCategory = Object.fromEntries(body.categories.map((c) => [c.id, c]));
     expect(byCategory["ai"]!.feeds_count).toBe(2);
     expect(byCategory["bigtech"]!.feeds_count).toBe(1);
     expect(byCategory["zenn"]!.feeds_count).toBe(1);
@@ -164,7 +165,7 @@ describe("GET /api/categories - テストデータあり", () => {
     const res = await SELF.fetch("https://example.com/api/categories");
     const body = await res.json<CategoriesResponse>();
 
-    const byCategory = Object.fromEntries(body.categories.map((c) => [c.category, c]));
+    const byCategory = Object.fromEntries(body.categories.map((c) => [c.id, c]));
     // ai: daysAgo(5) + daysAgo(20) = 2件。daysAgo(31) は除外
     expect(byCategory["ai"]!.articles_30d).toBe(2);
     expect(byCategory["bigtech"]!.articles_30d).toBe(1);
@@ -174,7 +175,7 @@ describe("GET /api/categories - テストデータあり", () => {
     const res = await SELF.fetch("https://example.com/api/categories");
     const body = await res.json<CategoriesResponse>();
 
-    const byCategory = Object.fromEntries(body.categories.map((c) => [c.category, c]));
+    const byCategory = Object.fromEntries(body.categories.map((c) => [c.id, c]));
     expect(byCategory["jp"]!.articles_30d).toBe(0);
     expect(byCategory["zenn"]!.articles_30d).toBe(0);
   });
@@ -183,7 +184,7 @@ describe("GET /api/categories - テストデータあり", () => {
     const res = await SELF.fetch("https://example.com/api/categories");
     const body = await res.json<CategoriesResponse>();
 
-    const byCategory = Object.fromEntries(body.categories.map((c) => [c.category, c]));
+    const byCategory = Object.fromEntries(body.categories.map((c) => [c.id, c]));
 
     // ai: ai-1 (5d前) が最新
     expect(byCategory["ai"]!.last_published_at).not.toBeNull();

--- a/apps/web/worker/db/feeds.ts
+++ b/apps/web/worker/db/feeds.ts
@@ -295,7 +295,8 @@ export async function findFeedWithStats(db: D1Database, id: string): Promise<Fee
 }
 
 export interface CategorySummary {
-  category: "bigtech" | "ai" | "jp" | "zenn";
+  id: "bigtech" | "ai" | "jp" | "zenn";
+  label: string;
   feeds_count: number;
   articles_30d: number;
   last_published_at: string | null;
@@ -303,10 +304,19 @@ export interface CategorySummary {
 
 const ALL_CATEGORIES: Array<"bigtech" | "ai" | "jp" | "zenn"> = ["bigtech", "ai", "jp", "zenn"];
 
+// client 側の CategorySummary.label に対応するマッピング
+const CATEGORY_LABELS: Record<"bigtech" | "ai" | "jp" | "zenn", string> = {
+  bigtech: "ビッグテック",
+  ai: "AI",
+  jp: "日本企業",
+  zenn: "Zenn",
+};
+
 /**
  * カテゴリ別のサマリを 1 クエリで取得する。
  * feeds テーブルに articles を LEFT JOIN して GROUP BY category。
  * D1 の結果に含まれないカテゴリ (フィード 0 件) は TS 側で 0 埋めして必ず 4 件返す。
+ * client 側の CategorySummary 型に合わせて id / label を返す。
  */
 export async function getCategoriesSummary(db: D1Database): Promise<CategorySummary[]> {
   const threshold = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
@@ -330,22 +340,27 @@ export async function getCategoriesSummary(db: D1Database): Promise<CategorySumm
     }>();
 
   const dbMap = new Map(
-    (rows.results ?? []).map((r) => [
-      r.category,
-      {
-        category: r.category as CategorySummary["category"],
-        feeds_count: r.feeds_count,
-        articles_30d: r.articles_30d,
-        last_published_at: r.last_published_at,
-      },
-    ]),
+    (rows.results ?? []).map((r) => {
+      const id = r.category as CategorySummary["id"];
+      return [
+        id,
+        {
+          id,
+          label: CATEGORY_LABELS[id],
+          feeds_count: r.feeds_count,
+          articles_30d: r.articles_30d,
+          last_published_at: r.last_published_at,
+        },
+      ];
+    }),
   );
 
   // DB に存在しないカテゴリも 0 埋めして全 4 カテゴリを返す
   return ALL_CATEGORIES.map(
     (cat) =>
       dbMap.get(cat) ?? {
-        category: cat,
+        id: cat,
+        label: CATEGORY_LABELS[cat],
         feeds_count: 0,
         articles_30d: 0,
         last_published_at: null,

--- a/migrations/0009_fix_zenn_category.sql
+++ b/migrations/0009_fix_zenn_category.sql
@@ -1,0 +1,4 @@
+-- 過去に zenn フィードが category=jp で登録されていた頃の articles を zenn に修正
+UPDATE articles
+SET category = 'zenn'
+WHERE feed_id LIKE 'zenn-%' AND category != 'zenn';


### PR DESCRIPTION
## Summary
- CategorySummary を { id, label, ... } 形式に変更し client 型と整合
- migrations/0009_fix_zenn_category.sql: zenn-* feed_id の articles.category を修正
- categories.test.ts の型・参照を id/label ベースに更新

## Test plan
- [x] pnpm build pass
- [x] pnpm test pass (493 tests)
- [x] pnpm check pass (0 errors)

Closes #213