### PR TITLE
refactor: TypeScript 型強化 — D1 Row 型集約・API Response 型・discriminated union・branded types

### DIFF
--- a/apps/web/client/hooks/useArticlesCalendar.ts
+++ b/apps/web/client/hooks/useArticlesCalendar.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import type { CalendarDay } from "../types/api";
+import type { CalendarDay, CalendarResponse } from "../types/api";
 
 export function useArticlesCalendar(days: 30 | 90 | 365 = 90) {
   const [items, setItems] = useState<CalendarDay[]>([]);
@@ -14,9 +14,9 @@ export function useArticlesCalendar(days: 30 | 90 | 365 = 90) {
       try {
         const res = await fetch(`/api/articles/calendar?days=${days}`);
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const data = (await res.json()) as { days: CalendarDay[] };
+        const data = (await res.json()) as CalendarResponse;
         if (alive) {
-          setItems(data.days ?? []);
+          setItems(data.items ?? []);
           setIsLoading(false);
         }
       } catch (err) {

--- a/apps/web/client/types/api.ts
+++ b/apps/web/client/types/api.ts
@@ -21,6 +21,7 @@ export interface ArticlesResponse {
   nextCursor: string | null;
 }
 
+/** /api/feeds が返す FeedWithStats と shape を一致させること */
 export interface FeedSummary {
   id: string;
   name: string;
@@ -28,14 +29,12 @@ export interface FeedSummary {
   category: FeedCategory;
   lang: FeedLang;
   enabled: boolean;
-  last_fetched_at: string | null;
-  last_status: string | null;
-  article_count: number;
+  articles_30d: number;
+  last_published_at: string | null;
 }
 
 export interface FeedsResponse {
   feeds: FeedSummary[];
-  nextCursor: string | null;
 }
 
 export interface FeedDetail {
@@ -54,13 +53,16 @@ export interface FeedDetailResponse {
   recent_articles: Article[];
 }
 
+/** /api/articles/calendar の 1 日分エントリ (/api/articles の CalendarItem と同形) */
 export interface CalendarDay {
   date: string;
   count: number;
 }
 
+/** /api/articles/calendar レスポンス shape */
 export interface CalendarResponse {
-  days: CalendarDay[];
+  days: number;
+  items: CalendarDay[];
 }
 
 export interface CategorySummary {

--- a/apps/web/tests/client/AuthorDetail.test.tsx
+++ b/apps/web/tests/client/AuthorDetail.test.tsx
@@ -111,8 +111,11 @@ describe("AuthorDetail", () => {
   });
 
   it("「← 一覧に戻る」ボタン click で onBack が呼ばれる", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeArticlesResponse([])));
-    const onBack = vi.fn();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<() => Promise<unknown>>().mockResolvedValue(makeArticlesResponse([])),
+    );
+    const onBack = vi.fn<() => void>();
     const user = userEvent.setup();
     render(
       <AuthorDetail
@@ -129,7 +132,7 @@ describe("AuthorDetail", () => {
   });
 
   it("fetch の URL に著者名が URL エンコードされて含まれる", async () => {
-    const mockFetch = vi.fn().mockResolvedValue(makeArticlesResponse([]));
+    const mockFetch = vi.fn<() => Promise<unknown>>().mockResolvedValue(makeArticlesResponse([]));
     vi.stubGlobal("fetch", mockFetch);
     render(
       <AuthorDetail

--- a/apps/web/tests/client/CalendarHeatmap.test.tsx
+++ b/apps/web/tests/client/CalendarHeatmap.test.tsx
@@ -13,12 +13,12 @@ function makeCalendarDays(count: number, baseCount = 3) {
   });
 }
 
-function mockFetch(days: ReturnType<typeof makeCalendarDays>) {
+function mockFetch(items: ReturnType<typeof makeCalendarDays>) {
   vi.stubGlobal(
     "fetch",
     vi.fn().mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ days }),
+      json: () => Promise.resolve({ days: items.length, items }),
     }),
   );
 }
@@ -121,7 +121,7 @@ describe("CalendarHeatmap", () => {
       const data = callCount === 1 ? days90 : days30;
       return Promise.resolve({
         ok: true,
-        json: () => Promise.resolve({ days: data }),
+        json: () => Promise.resolve({ days: data.length, items: data }),
       });
     });
 
@@ -149,7 +149,7 @@ describe("CalendarHeatmap", () => {
       const data = callCount === 1 ? days90 : days365;
       return Promise.resolve({
         ok: true,
-        json: () => Promise.resolve({ days: data }),
+        json: () => Promise.resolve({ days: data.length, items: data }),
       });
     });
 

--- a/apps/web/tests/client/TrendingArticles.test.tsx
+++ b/apps/web/tests/client/TrendingArticles.test.tsx
@@ -118,7 +118,7 @@ describe("TrendingArticles", () => {
   });
 
   it("14 日ボタンをクリックすると aria-pressed=true に変わる", async () => {
-    const mockFetch = vi.fn().mockResolvedValue(makePopularResponse([]));
+    const mockFetch = vi.fn<() => Promise<unknown>>().mockResolvedValue(makePopularResponse([]));
     vi.stubGlobal("fetch", mockFetch);
 
     const user = userEvent.setup();

--- a/apps/web/tests/worker/api/admin.test.ts
+++ b/apps/web/tests/worker/api/admin.test.ts
@@ -164,7 +164,7 @@ describe("POST /api/admin/collector/run", () => {
     });
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
-    expect(body.error).toBe("feed_ids must be an array");
+    expect(body.error).toBe("feed_ids must be an array of strings");
   });
 });
 

--- a/apps/web/tests/worker/api/categories.test.ts
+++ b/apps/web/tests/worker/api/categories.test.ts
@@ -67,8 +67,8 @@ describe("GET /api/categories - DB 空の場合", () => {
     expect(Array.isArray(body.categories)).toBe(true);
     expect(body.categories).toHaveLength(4);
 
-    const cats = body.categories.map((c) => c.id).sort();
-    expect(cats).toEqual([...ALL_CATEGORIES].sort());
+    const cats = body.categories.map((c) => c.id).toSorted();
+    expect(cats).toEqual(ALL_CATEGORIES.toSorted());
   });
 
   it("DB 空の場合は全カテゴリで feeds_count=0, articles_30d=0, last_published_at=null", async () => {
@@ -145,8 +145,8 @@ describe("GET /api/categories - テストデータあり", () => {
     const body = await res.json<CategoriesResponse>();
     expect(body.categories).toHaveLength(4);
 
-    const cats = body.categories.map((c) => c.id).sort();
-    expect(cats).toEqual([...ALL_CATEGORIES].sort());
+    const cats = body.categories.map((c) => c.id).toSorted();
+    expect(cats).toEqual(ALL_CATEGORIES.toSorted());
   });
 
   it("feeds_count が正しい (ai=2, bigtech=1, zenn=1, jp=0)", async () => {

--- a/apps/web/worker/api/admin.ts
+++ b/apps/web/worker/api/admin.ts
@@ -233,7 +233,7 @@ app.post("/collector/run", async (c) => {
     feed_id: r.feedId,
     status: r.status,
     new_articles: r.inserted,
-    ...(r.error !== undefined ? { error: r.error } : {}),
+    ...(r.status === "error" ? { error: r.error } : {}),
   }));
 
   return c.json<AdminCollectorRunResponse>({

--- a/apps/web/worker/api/admin.ts
+++ b/apps/web/worker/api/admin.ts
@@ -4,6 +4,15 @@ import { collectAll, collectFeeds, validateFeedUrl } from "../collector";
 import { loadAllFeeds } from "../feed-config";
 import { getFeedsDiagnostics, setFeedEnabled } from "../db/feeds";
 import { getCronHealth, getFeedFailures, getRun, listRuns, startRun } from "../db/runs";
+import type {
+  AdminCollectResponse,
+  AdminCollectorRunResponse,
+  AdminCronHealthResponse,
+  AdminFeedEnabledResponse,
+  AdminFeedsDiagnosticsResponse,
+  AdminRunDetailResponse,
+  AdminRunListResponse,
+} from "./types";
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -149,7 +158,7 @@ app.post("/collect", async (c) => {
     }),
   );
 
-  return c.json({ ok: true, run_id: runId, async: true });
+  return c.json<AdminCollectResponse>({ ok: true, run_id: runId, async: true });
 });
 
 app.post("/collector/run", async (c) => {
@@ -226,7 +235,7 @@ app.post("/collector/run", async (c) => {
     ...(r.error !== undefined ? { error: r.error } : {}),
   }));
 
-  return c.json({ started_at: startedAt, finished_at: finishedAt, results });
+  return c.json<AdminCollectorRunResponse>({ started_at: startedAt, finished_at: finishedAt, results });
 });
 
 app.post("/feeds/:id/enabled", async (c) => {
@@ -255,7 +264,7 @@ app.post("/feeds/:id/enabled", async (c) => {
   if (!found) {
     return c.json({ error: "feed not found" }, 404);
   }
-  return c.json({ id, enabled });
+  return c.json<AdminFeedEnabledResponse>({ id, enabled });
 });
 
 app.get("/runs", async (c) => {
@@ -273,7 +282,7 @@ app.get("/runs", async (c) => {
   const limitParam = Number(c.req.query("limit") ?? "20");
   const limit = Number.isFinite(limitParam) ? Math.min(Math.max(limitParam, 1), 100) : 20;
   const runs = await listRuns(c.env.DB, limit);
-  return c.json({ runs });
+  return c.json<AdminRunListResponse>({ runs });
 });
 
 app.get("/runs/:id", async (c) => {
@@ -305,7 +314,7 @@ app.get("/runs/:id", async (c) => {
       : null;
 
   c.header("Cache-Control", "private, max-age=30");
-  return c.json({ run: { ...run, duration_ms }, feeds });
+  return c.json<AdminRunDetailResponse>({ run: { ...run, duration_ms }, feeds });
 });
 
 app.get("/feeds/diagnostics", async (c) => {
@@ -322,7 +331,7 @@ app.get("/feeds/diagnostics", async (c) => {
 
   const feeds = await getFeedsDiagnostics(c.env.DB);
   c.header("Cache-Control", "private, max-age=30");
-  return c.json({ feeds, count: feeds.length });
+  return c.json<AdminFeedsDiagnosticsResponse>({ feeds, count: feeds.length });
 });
 
 app.get("/cron-health", async (c) => {
@@ -350,7 +359,7 @@ app.get("/cron-health", async (c) => {
   ]);
 
   c.header("Cache-Control", "private, max-age=60");
-  return c.json({ ...health, top_failing_feeds: topFailingFeeds });
+  return c.json<AdminCronHealthResponse>({ ...health, top_failing_feeds: topFailingFeeds });
 });
 
 export default app;

--- a/apps/web/worker/api/admin.ts
+++ b/apps/web/worker/api/admin.ts
@@ -188,10 +188,11 @@ app.post("/collector/run", async (c) => {
     }
     const body = parsed as Record<string, unknown>;
     if ("feed_ids" in body) {
-      if (!Array.isArray(body.feed_ids)) {
-        return c.json({ error: "feed_ids must be an array" }, 400);
+      const rawFeedIds = body.feed_ids;
+      if (!Array.isArray(rawFeedIds) || !rawFeedIds.every((v) => typeof v === "string")) {
+        return c.json({ error: "feed_ids must be an array of strings" }, 400);
       }
-      feedIds = body.feed_ids as string[];
+      feedIds = rawFeedIds;
       // 存在しない feed_id が含まれていれば 400
       const allIds = new Set(loadAllFeeds().map((f) => f.id));
       const unknown = feedIds.filter((id) => !allIds.has(id));
@@ -235,7 +236,11 @@ app.post("/collector/run", async (c) => {
     ...(r.error !== undefined ? { error: r.error } : {}),
   }));
 
-  return c.json<AdminCollectorRunResponse>({ started_at: startedAt, finished_at: finishedAt, results });
+  return c.json<AdminCollectorRunResponse>({
+    started_at: startedAt,
+    finished_at: finishedAt,
+    results,
+  });
 });
 
 app.post("/feeds/:id/enabled", async (c) => {

--- a/apps/web/worker/api/articles.ts
+++ b/apps/web/worker/api/articles.ts
@@ -35,14 +35,18 @@ import type {
   ArticleRelatedResponse,
   ArticleSearchResponse,
 } from "./types";
+import { makeOneOf } from "../utils/types";
 
 const FEEDS_VERSION = (feedsYaml as FeedsFile).version;
 
 const app = new Hono<{ Bindings: Env }>();
 
-const VALID_CATEGORIES: FeedCategory[] = ["bigtech", "ai", "jp", "zenn"];
-const VALID_LANGS: FeedLang[] = ["ja", "en"];
+const VALID_CATEGORIES = ["bigtech", "ai", "jp", "zenn"] as const satisfies readonly FeedCategory[];
+const VALID_LANGS = ["ja", "en"] as const satisfies readonly FeedLang[];
 const VALID_FEED_IDS = new Set(loadAllFeeds().map((f) => f.id));
+
+const isCategory = makeOneOf<FeedCategory>(VALID_CATEGORIES);
+const isLang = makeOneOf<FeedLang>(VALID_LANGS);
 
 const ISO_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
 // YYYY-MM-DD または YYYY-MM-DDTHH:MM:SS 形式を受け付ける
@@ -85,12 +89,8 @@ app.get("/", async (c) => {
   const limitRaw = req.query("limit");
   const cursorRaw = req.query("cursor");
 
-  const category =
-    categoryRaw && (VALID_CATEGORIES as string[]).includes(categoryRaw)
-      ? (categoryRaw as FeedCategory)
-      : undefined;
-  const lang =
-    langRaw && (VALID_LANGS as string[]).includes(langRaw) ? (langRaw as FeedLang) : undefined;
+  const category = isCategory(categoryRaw) ? categoryRaw : undefined;
+  const lang = isLang(langRaw) ? langRaw : undefined;
 
   const limit = Math.min(Math.max(Number(limitRaw ?? "20") || 20, 1), 100);
 
@@ -142,12 +142,8 @@ app.get("/random", async (c) => {
   const langRaw = c.req.query("lang");
   const feedIdRaw = c.req.query("feed_id") ?? undefined;
 
-  const category =
-    categoryRaw && (VALID_CATEGORIES as string[]).includes(categoryRaw)
-      ? (categoryRaw as FeedCategory)
-      : undefined;
-  const lang =
-    langRaw && (VALID_LANGS as string[]).includes(langRaw) ? (langRaw as FeedLang) : undefined;
+  const category = isCategory(categoryRaw) ? categoryRaw : undefined;
+  const lang = isLang(langRaw) ? langRaw : undefined;
   const feedId = feedIdRaw && VALID_FEED_IDS.has(feedIdRaw) ? feedIdRaw : undefined;
 
   const articles = await getRandomArticles(c.env.DB, { n, category, lang, feedId });
@@ -206,10 +202,10 @@ app.get("/by-feed/:feedId", async (c) => {
 
 app.get("/by-category/:cat", async (c) => {
   const catRaw = c.req.param("cat");
-  if (!(VALID_CATEGORIES as string[]).includes(catRaw)) {
+  if (!isCategory(catRaw)) {
     return c.json({ error: "invalid category: must be one of bigtech, ai, jp, zenn" }, 400);
   }
-  const category = catRaw as FeedCategory;
+  const category = catRaw;
 
   const limitRaw = c.req.query("limit") ?? "20";
   const limitNum = Number(limitRaw);
@@ -241,16 +237,16 @@ app.get("/calendar", async (c) => {
   }
 
   const categoryRaw = c.req.query("category");
-  if (categoryRaw !== undefined && !(VALID_CATEGORIES as string[]).includes(categoryRaw)) {
+  if (categoryRaw !== undefined && !isCategory(categoryRaw)) {
     return c.json({ error: "invalid category" }, 400);
   }
-  const category = categoryRaw as FeedCategory | undefined;
+  const category = isCategory(categoryRaw) ? categoryRaw : undefined;
 
   const langRaw = c.req.query("lang");
-  if (langRaw !== undefined && !(VALID_LANGS as string[]).includes(langRaw)) {
+  if (langRaw !== undefined && !isLang(langRaw)) {
     return c.json({ error: "invalid lang" }, 400);
   }
-  const lang = langRaw as FeedLang | undefined;
+  const lang = isLang(langRaw) ? langRaw : undefined;
 
   const items = await getArticlesCalendar(c.env.DB, days, lang, category);
 
@@ -337,7 +333,9 @@ app.get("/:guid/neighbors", async (c) => {
   const guid = c.req.param("guid");
   const neighbors = await getNeighbors(c.env.DB, guid);
   if (neighbors === null) return c.json({ error: "not found" }, 404);
-  return c.json<ArticleNeighborsResponse>(neighbors, 200, { "Cache-Control": "public, max-age=300" });
+  return c.json<ArticleNeighborsResponse>(neighbors, 200, {
+    "Cache-Control": "public, max-age=300",
+  });
 });
 
 app.get("/archive", async (c) => {
@@ -355,16 +353,16 @@ app.get("/archive", async (c) => {
   }
 
   const categoryRaw = c.req.query("category");
-  if (categoryRaw !== undefined && !(VALID_CATEGORIES as string[]).includes(categoryRaw)) {
+  if (categoryRaw !== undefined && !isCategory(categoryRaw)) {
     return c.json({ error: "invalid category" }, 400);
   }
-  const category = categoryRaw as FeedCategory | undefined;
+  const category = isCategory(categoryRaw) ? categoryRaw : undefined;
 
   const langRaw = c.req.query("lang");
-  if (langRaw !== undefined && !(VALID_LANGS as string[]).includes(langRaw)) {
+  if (langRaw !== undefined && !isLang(langRaw)) {
     return c.json({ error: "invalid lang" }, 400);
   }
-  const lang = langRaw as FeedLang | undefined;
+  const lang = isLang(langRaw) ? langRaw : undefined;
 
   const limitRaw = c.req.query("limit") ?? "200";
   const limit = parseInt(limitRaw, 10);

--- a/apps/web/worker/api/articles.ts
+++ b/apps/web/worker/api/articles.ts
@@ -21,6 +21,20 @@ import {
 import { computeArticlesEtag } from "../utils/etag";
 import feedsYaml from "../feeds.yaml";
 import type { FeedsFile } from "../types";
+import type {
+  ArticleArchiveResponse,
+  ArticleByAuthorResponse,
+  ArticleByCategoryResponse,
+  ArticleByDayResponse,
+  ArticleByFeedResponse,
+  ArticleCalendarResponse,
+  ArticleListResponse,
+  ArticleNeighborsResponse,
+  ArticlePopularResponse,
+  ArticleRandomResponse,
+  ArticleRelatedResponse,
+  ArticleSearchResponse,
+} from "./types";
 
 const FEEDS_VERSION = (feedsYaml as FeedsFile).version;
 
@@ -114,7 +128,7 @@ app.get("/", async (c) => {
 
   c.header("ETag", etag);
   c.header("Cache-Control", "public, max-age=60");
-  return c.json({
+  return c.json<ArticleListResponse>({
     articles: result.articles,
     nextCursor: encodeCursor(result.nextCursor),
   });
@@ -137,7 +151,7 @@ app.get("/random", async (c) => {
   const feedId = feedIdRaw && VALID_FEED_IDS.has(feedIdRaw) ? feedIdRaw : undefined;
 
   const articles = await getRandomArticles(c.env.DB, { n, category, lang, feedId });
-  return c.json({ articles }, 200, { "Cache-Control": "no-store" });
+  return c.json<ArticleRandomResponse>({ articles }, 200, { "Cache-Control": "no-store" });
 });
 
 app.get("/by-author/:author", async (c) => {
@@ -158,9 +172,11 @@ app.get("/by-author/:author", async (c) => {
 
   const result = await getArticlesByAuthor(c.env.DB, author, limitNum, cursor);
 
-  return c.json({ articles: result.articles, next_cursor: encodeCursor(result.nextCursor) }, 200, {
-    "Cache-Control": "public, max-age=300",
-  });
+  return c.json<ArticleByAuthorResponse>(
+    { articles: result.articles, next_cursor: encodeCursor(result.nextCursor) },
+    200,
+    { "Cache-Control": "public, max-age=300" },
+  );
 });
 
 app.get("/by-feed/:feedId", async (c) => {
@@ -181,9 +197,11 @@ app.get("/by-feed/:feedId", async (c) => {
 
   const result = await getArticlesByFeed(c.env.DB, feedId, limitNum, cursor);
 
-  return c.json({ articles: result.articles, next_cursor: encodeCursor(result.nextCursor) }, 200, {
-    "Cache-Control": "public, max-age=300",
-  });
+  return c.json<ArticleByFeedResponse>(
+    { articles: result.articles, next_cursor: encodeCursor(result.nextCursor) },
+    200,
+    { "Cache-Control": "public, max-age=300" },
+  );
 });
 
 app.get("/by-category/:cat", async (c) => {
@@ -206,9 +224,11 @@ app.get("/by-category/:cat", async (c) => {
 
   const result = await getArticlesByCategory(c.env.DB, category, limitNum, cursor);
 
-  return c.json({ articles: result.articles, next_cursor: encodeCursor(result.nextCursor) }, 200, {
-    "Cache-Control": "public, max-age=300",
-  });
+  return c.json<ArticleByCategoryResponse>(
+    { articles: result.articles, next_cursor: encodeCursor(result.nextCursor) },
+    200,
+    { "Cache-Control": "public, max-age=300" },
+  );
 });
 
 const VALID_CALENDAR_DAYS = [7, 30, 90, 365] as const;
@@ -234,7 +254,7 @@ app.get("/calendar", async (c) => {
 
   const items = await getArticlesCalendar(c.env.DB, days, lang, category);
 
-  return c.json({ days, items }, 200, {
+  return c.json<ArticleCalendarResponse>({ days, items }, 200, {
     "Cache-Control": "public, max-age=600",
   });
 });
@@ -254,7 +274,7 @@ app.get("/popular", async (c) => {
 
   const result = await getPopularArticles(c.env.DB, days, limit);
 
-  return c.json(result, 200, {
+  return c.json<ArticlePopularResponse>(result, 200, {
     "Cache-Control": "public, max-age=600",
   });
 });
@@ -290,7 +310,7 @@ app.get("/search", async (c) => {
 
   const result = await searchArticles(c.env.DB, tokens, limitNum, cursor);
 
-  return c.json(
+  return c.json<ArticleSearchResponse>(
     {
       query: tokens.join(" "),
       tokens,
@@ -310,14 +330,14 @@ app.get("/:guid/related", async (c) => {
 
   const items = await getRelatedArticles(c.env.DB, guid, n);
   if (items === null) return c.json({ error: "not found" }, 404);
-  return c.json({ items }, 200, { "Cache-Control": "public, max-age=300" });
+  return c.json<ArticleRelatedResponse>({ items }, 200, { "Cache-Control": "public, max-age=300" });
 });
 
 app.get("/:guid/neighbors", async (c) => {
   const guid = c.req.param("guid");
   const neighbors = await getNeighbors(c.env.DB, guid);
   if (neighbors === null) return c.json({ error: "not found" }, 404);
-  return c.json(neighbors, 200, { "Cache-Control": "public, max-age=300" });
+  return c.json<ArticleNeighborsResponse>(neighbors, 200, { "Cache-Control": "public, max-age=300" });
 });
 
 app.get("/archive", async (c) => {
@@ -357,7 +377,7 @@ app.get("/archive", async (c) => {
     countArticlesByMonth(c.env.DB, year, month, { category, lang }),
   ]);
 
-  return c.json({ year, month, items, total }, 200, {
+  return c.json<ArticleArchiveResponse>({ year, month, items, total }, 200, {
     "Cache-Control": "public, max-age=600",
   });
 });
@@ -401,7 +421,7 @@ app.get("/by-day/:date", async (c) => {
     countArticlesByDay(c.env.DB, startIso, endIso),
   ]);
 
-  return c.json(
+  return c.json<ArticleByDayResponse>(
     {
       date: dateRaw,
       articles: result.articles,

--- a/apps/web/worker/api/categories.ts
+++ b/apps/web/worker/api/categories.ts
@@ -1,13 +1,14 @@
 import { Hono } from "hono";
 import type { Env } from "../types";
 import { getCategoriesSummary } from "../db/feeds";
+import type { CategoriesResponse } from "./types";
 
 const app = new Hono<{ Bindings: Env }>();
 
 app.get("/", async (c) => {
   const categories = await getCategoriesSummary(c.env.DB);
   c.header("Cache-Control", "public, max-age=300");
-  return c.json({ categories });
+  return c.json<CategoriesResponse>({ categories });
 });
 
 export default app;

--- a/apps/web/worker/api/feeds.ts
+++ b/apps/web/worker/api/feeds.ts
@@ -3,6 +3,7 @@ import { loadAllFeeds } from "../feed-config";
 import type { Env, FeedCategory, FeedLang } from "../types";
 import { findFeedWithStats, getRecentArticlesByFeed, listFeedsWithStats } from "../db/feeds";
 import { getFeedHealth } from "../db/runs";
+import type { FeedsListResponse, FeedDetailResponse, FeedRunHealthResponse } from "./types";
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -32,7 +33,7 @@ app.get("/", async (c) => {
   if (enabledRaw !== undefined) opts.enabled = enabledRaw === "true";
 
   const feeds = await listFeedsWithStats(c.env.DB, opts);
-  return c.json({ feeds });
+  return c.json<FeedsListResponse>({ feeds });
 });
 
 const RECENT_DEFAULT = 10;
@@ -62,7 +63,7 @@ app.get("/:id", async (c) => {
   }
 
   c.header("Cache-Control", "public, max-age=300");
-  return c.json({ feed, recent_articles: recentArticles });
+  return c.json<FeedDetailResponse>({ feed, recent_articles: recentArticles });
 });
 
 const DAYS_DEFAULT = 7;
@@ -111,7 +112,7 @@ app.get("/:id/health", async (c) => {
           : null;
 
   c.header("Cache-Control", "public, max-age=300");
-  return c.json({
+  return c.json<FeedRunHealthResponse>({
     feed_id: id,
     window_days: days,
     total_runs: health.total_runs,

--- a/apps/web/worker/api/feeds.ts
+++ b/apps/web/worker/api/feeds.ts
@@ -3,12 +3,13 @@ import { loadAllFeeds } from "../feed-config";
 import type { Env, FeedCategory, FeedLang } from "../types";
 import { findFeedWithStats, getRecentArticlesByFeed, listFeedsWithStats } from "../db/feeds";
 import { getFeedHealth } from "../db/runs";
+import { makeOneOf } from "../utils/types";
 import type { FeedsListResponse, FeedDetailResponse, FeedRunHealthResponse } from "./types";
 
 const app = new Hono<{ Bindings: Env }>();
 
-const VALID_CATEGORIES = new Set<FeedCategory>(["bigtech", "ai", "jp", "zenn"]);
-const VALID_LANGS = new Set<FeedLang>(["ja", "en"]);
+const isCategory = makeOneOf<FeedCategory>(["bigtech", "ai", "jp", "zenn"]);
+const isLang = makeOneOf<FeedLang>(["ja", "en"]);
 
 app.get("/", async (c) => {
   const { req } = c;
@@ -17,10 +18,10 @@ app.get("/", async (c) => {
   const enabledRaw = req.query("enabled");
 
   // 不正なクエリパラメータは 400 を返す
-  if (categoryRaw !== undefined && !VALID_CATEGORIES.has(categoryRaw as FeedCategory)) {
+  if (categoryRaw !== undefined && !isCategory(categoryRaw)) {
     return c.json({ error: `invalid category: ${categoryRaw}` }, 400);
   }
-  if (langRaw !== undefined && !VALID_LANGS.has(langRaw as FeedLang)) {
+  if (langRaw !== undefined && !isLang(langRaw)) {
     return c.json({ error: `invalid lang: ${langRaw}` }, 400);
   }
   if (enabledRaw !== undefined && enabledRaw !== "true" && enabledRaw !== "false") {
@@ -28,8 +29,8 @@ app.get("/", async (c) => {
   }
 
   const opts: { category?: FeedCategory; lang?: FeedLang; enabled?: boolean } = {};
-  if (categoryRaw !== undefined) opts.category = categoryRaw as FeedCategory;
-  if (langRaw !== undefined) opts.lang = langRaw as FeedLang;
+  if (isCategory(categoryRaw)) opts.category = categoryRaw;
+  if (isLang(langRaw)) opts.lang = langRaw;
   if (enabledRaw !== undefined) opts.enabled = enabledRaw === "true";
 
   const feeds = await listFeedsWithStats(c.env.DB, opts);

--- a/apps/web/worker/api/health.ts
+++ b/apps/web/worker/api/health.ts
@@ -5,6 +5,7 @@ import { countAllArticles, countArticlesSince } from "../db/articles";
 import { getLatestCompletedRun } from "../db/runs";
 import { loadAllFeeds } from "../feed-config";
 import type { Env, FeedHealth, HealthResponse } from "../types";
+import type { HealthFeedsResponse } from "./types";
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -47,7 +48,7 @@ app.get("/", async (c) => {
     };
 
     c.header("Cache-Control", "no-cache");
-    return c.json(body);
+    return c.json<HealthResponse>(body);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return c.json({ ok: false, error: message }, 500);
@@ -60,7 +61,7 @@ app.get("/feeds", async (c) => {
     const configFeeds = loadAllFeeds();
     const health: FeedHealth[] = await getFeedHealth(c.env.DB, configFeeds);
     c.header("Cache-Control", "public, max-age=60");
-    return c.json(health);
+    return c.json<HealthFeedsResponse>(health);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return c.json({ status: "degraded", error: message }, 500);

--- a/apps/web/worker/api/stats.ts
+++ b/apps/web/worker/api/stats.ts
@@ -7,6 +7,7 @@ import {
   getTopPublishers30d,
 } from "../db/articles";
 import type { Env } from "../types";
+import type { StatsResponse } from "./types";
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -61,7 +62,7 @@ app.get("/", async (c) => {
       getByLang30d(c.env.DB),
     ]);
 
-  return c.json({
+  return c.json<StatsResponse>({
     total: totalRow?.n ?? 0,
     last_published_at: totalRow?.last_published ?? null,
     last_fetched_at: totalRow?.last_fetched ?? null,

--- a/apps/web/worker/api/syndication.ts
+++ b/apps/web/worker/api/syndication.ts
@@ -5,11 +5,14 @@ import { listArticles } from "../db/articles";
 import { computeSyndicationEtag } from "../utils/etag";
 import { loadAllFeeds } from "../feed-config";
 import feedsYaml from "../feeds.yaml";
+import { makeOneOf } from "../utils/types";
 
 const FEEDS_VERSION = (feedsYaml as FeedsFile).version;
 
-const VALID_CATEGORIES: FeedCategory[] = ["bigtech", "ai", "jp", "zenn"];
-const VALID_LANGS: FeedLang[] = ["ja", "en"];
+const VALID_CATEGORIES = ["bigtech", "ai", "jp", "zenn"] as const satisfies readonly FeedCategory[];
+const VALID_LANGS = ["ja", "en"] as const satisfies readonly FeedLang[];
+const isCategory = makeOneOf<FeedCategory>(VALID_CATEGORIES);
+const isLang = makeOneOf<FeedLang>(VALID_LANGS);
 const FEED_LIMIT = 50;
 const SITE_TITLE = "Tech News Bot";
 const SITE_DESCRIPTION = "Big tech / AI / 日本企業の technical blog を集約した RSS / JSON Feed";
@@ -33,12 +36,8 @@ const app = new Hono<{ Bindings: Env }>();
 function parseFilters(c: { req: { query: (k: string) => string | undefined } }) {
   const categoryRaw = c.req.query("category");
   const langRaw = c.req.query("lang");
-  const category =
-    categoryRaw && (VALID_CATEGORIES as string[]).includes(categoryRaw)
-      ? (categoryRaw as FeedCategory)
-      : undefined;
-  const lang =
-    langRaw && (VALID_LANGS as string[]).includes(langRaw) ? (langRaw as FeedLang) : undefined;
+  const category = isCategory(categoryRaw) ? categoryRaw : undefined;
+  const lang = isLang(langRaw) ? langRaw : undefined;
   return { category, lang };
 }
 
@@ -274,25 +273,25 @@ app.get("/feeds/category/*", async (c) => {
   const pathname = new URL(c.req.url).pathname;
   const basename = pathname.replace(/^.*\/feeds\/category\//, "");
 
-  let cat: FeedCategory;
+  let rawCat: string;
   let format: "json" | "xml" | "atom";
-
   if (basename.endsWith(".json")) {
-    cat = basename.slice(0, -5) as FeedCategory;
+    rawCat = basename.slice(0, -5);
     format = "json";
   } else if (basename.endsWith(".xml")) {
-    cat = basename.slice(0, -4) as FeedCategory;
+    rawCat = basename.slice(0, -4);
     format = "xml";
   } else if (basename.endsWith(".atom")) {
-    cat = basename.slice(0, -5) as FeedCategory;
+    rawCat = basename.slice(0, -5);
     format = "atom";
   } else {
     return c.json({ error: "Not Found" }, 404);
   }
 
-  if (!(VALID_CATEGORIES as string[]).includes(cat)) {
+  if (!isCategory(rawCat)) {
     return c.json({ error: "Not Found" }, 404);
   }
+  const cat = rawCat;
 
   const titleOverride = `${SITE_TITLE} — ${CATEGORY_DISPLAY_NAMES[cat]}`;
 
@@ -520,25 +519,25 @@ app.get("/feeds/lang/*", async (c) => {
   const pathname = new URL(c.req.url).pathname;
   const basename = pathname.replace(/^.*\/feeds\/lang\//, "");
 
-  let lang: FeedLang;
+  let rawLang: string;
   let format: "json" | "xml" | "atom";
-
   if (basename.endsWith(".json")) {
-    lang = basename.slice(0, -5) as FeedLang;
+    rawLang = basename.slice(0, -5);
     format = "json";
   } else if (basename.endsWith(".xml")) {
-    lang = basename.slice(0, -4) as FeedLang;
+    rawLang = basename.slice(0, -4);
     format = "xml";
   } else if (basename.endsWith(".atom")) {
-    lang = basename.slice(0, -5) as FeedLang;
+    rawLang = basename.slice(0, -5);
     format = "atom";
   } else {
     return c.json({ error: "Not Found" }, 404);
   }
 
-  if (!(VALID_LANGS as string[]).includes(lang)) {
+  if (!isLang(rawLang)) {
     return c.json({ error: "Not Found" }, 404);
   }
+  const lang = rawLang;
 
   const titleOverride = LANG_DISPLAY_NAMES[lang];
 

--- a/apps/web/worker/api/types.ts
+++ b/apps/web/worker/api/types.ts
@@ -1,0 +1,220 @@
+/**
+ * API エンドポイントのレスポンス型を集約する。
+ * ハンドラ実装側で `c.json<ResponseType>(payload)` に指定してコンパイル時に整合性を確認する。
+ *
+ * 注意: JSON の shape (フィールド名・型) はクライアントとの後方互換を保つため変更禁止。
+ * client/types/api.ts と shape を一致させること。
+ */
+
+import type {
+  Article,
+  FeedDiagnostic,
+  FeedFailure,
+  FeedHealth,
+  HealthCronRun,
+} from "../types";
+import type {
+  CalendarItem,
+  CategoryTrendPoint,
+  FeedActivityRow,
+  TopAuthorRow,
+  TopPublisherRow,
+  ByLang30d,
+} from "../db/articles";
+import type { FeedWithStats, CategorySummary } from "../db/feeds";
+import type { RunRow, RunFeedRow } from "../db/runs";
+
+// ---- /api/articles ----
+
+export interface ArticleListResponse {
+  articles: Article[];
+  nextCursor: string | null;
+}
+
+export interface ArticleRandomResponse {
+  articles: Article[];
+}
+
+export interface ArticleCalendarResponse {
+  days: number;
+  items: CalendarItem[];
+}
+
+export interface ArticlePopularResponse {
+  articles: Article[];
+  window_days: number;
+  total: number;
+}
+
+export interface ArticleSearchResponse {
+  query: string;
+  tokens: string[];
+  articles: Article[];
+  next_cursor: string | null;
+}
+
+export interface ArticleRelatedResponse {
+  items: Article[];
+}
+
+export interface ArticleNeighborsResponse {
+  prev: Article | null;
+  next: Article | null;
+}
+
+export interface ArticleArchiveResponse {
+  year: number;
+  month: number;
+  items: Article[];
+  total: number;
+}
+
+export interface ArticleByAuthorResponse {
+  articles: Article[];
+  next_cursor: string | null;
+}
+
+export interface ArticleByFeedResponse {
+  articles: Article[];
+  next_cursor: string | null;
+}
+
+export interface ArticleByCategoryResponse {
+  articles: Article[];
+  next_cursor: string | null;
+}
+
+export interface ArticleByDayResponse {
+  date: string;
+  articles: Article[];
+  next_cursor: string | null;
+  total: number;
+}
+
+// ---- /api/feeds ----
+
+export interface FeedsListResponse {
+  feeds: FeedWithStats[];
+}
+
+export interface FeedDetailResponse {
+  feed: FeedWithStats;
+  recent_articles: Article[];
+}
+
+/** フィード別ヘルス (run 単位集計) */
+export interface FeedRunHealthResponse {
+  feed_id: string;
+  window_days: number;
+  total_runs: number;
+  successful_runs: number;
+  failed_runs: number;
+  success_rate: number | null;
+  last_run_at: string | null;
+  last_run_status: "success" | "failed" | "skipped" | null;
+  last_error: { at: string; message: string | null } | null;
+  avg_duration_ms: number | null;
+  articles_inserted_total: number;
+}
+
+// ---- /api/categories ----
+
+export interface CategoriesResponse {
+  categories: CategorySummary[];
+}
+
+// ---- /api/health ----
+
+export interface HealthResponse {
+  ok: boolean;
+  version: string;
+  now: string;
+  feeds: {
+    total: number;
+    enabled: number;
+  };
+  articles: {
+    total: number;
+    last_24h: number;
+  };
+  last_cron_run: HealthCronRun | null;
+}
+
+export type HealthFeedsResponse = FeedHealth[];
+
+// ---- /api/stats ----
+
+export interface StatsResponse {
+  total: number;
+  last_published_at: string | null;
+  last_fetched_at: string | null;
+  last24h: number;
+  by_category: Record<string, number>;
+  by_lang: Record<string, number>;
+  stale_feeds: Array<{
+    id: string;
+    name: string;
+    last_status: string | null;
+    last_fetched_at: string | null;
+    last_error: string | null;
+  }>;
+  category_trend_30d: CategoryTrendPoint[];
+  feed_activity: FeedActivityRow[];
+  top_authors_30d: TopAuthorRow[];
+  top_publishers_30d: TopPublisherRow[];
+  by_lang_30d: ByLang30d;
+}
+
+// ---- /api/admin ----
+
+export interface AdminCollectResponse {
+  ok: boolean;
+  run_id: number;
+  async: boolean;
+}
+
+export interface AdminRunListResponse {
+  runs: RunRow[];
+}
+
+export interface AdminRunDetailResponse {
+  run: RunRow & { duration_ms: number | null };
+  feeds: RunFeedRow[];
+}
+
+export interface AdminFeedsDiagnosticsResponse {
+  feeds: FeedDiagnostic[];
+  count: number;
+}
+
+export interface AdminCronHealthResponse {
+  window_days: number;
+  runs_total: number;
+  runs_succeeded: number;
+  runs_failed: number;
+  avg_run_ms: number | null;
+  articles_collected: number;
+  top_failing_feeds: FeedFailure[];
+}
+
+export interface AdminFeedEnabledResponse {
+  id: string;
+  enabled: boolean;
+}
+
+export interface AdminCollectorRunResponse {
+  started_at: string;
+  finished_at: string;
+  results: Array<{
+    feed_id: string;
+    status: "ok" | "error" | "not_modified";
+    new_articles: number;
+    error?: string;
+  }>;
+}
+
+// ---- エラーレスポンス共通 ----
+
+export interface ErrorResponse {
+  error: string;
+}

--- a/apps/web/worker/api/types.ts
+++ b/apps/web/worker/api/types.ts
@@ -6,13 +6,7 @@
  * client/types/api.ts と shape を一致させること。
  */
 
-import type {
-  Article,
-  FeedDiagnostic,
-  FeedFailure,
-  FeedHealth,
-  HealthCronRun,
-} from "../types";
+import type { Article, FeedDiagnostic, FeedFailure, FeedHealth, HealthCronRun } from "../types";
 import type {
   CalendarItem,
   CategoryTrendPoint,

--- a/apps/web/worker/collector/index.ts
+++ b/apps/web/worker/collector/index.ts
@@ -23,13 +23,11 @@ const ALLOWED_URL_PREFIXES = ["http://", "https://"];
 // backoff: 500ms, 1000ms の 2 回まで。並列度 4 × max 1.5s = 6s < 30s cron 制限
 const BACKOFF_BASE_MS = 500;
 
-export interface CollectResult {
-  feedId: string;
-  status: "ok" | "error" | "not_modified";
-  inserted: number;
-  parsed: number;
-  error?: string;
-}
+/** discriminated union: status に応じて error フィールドの有無が変わる */
+export type CollectResult =
+  | { feedId: string; status: "ok"; inserted: number; parsed: number }
+  | { feedId: string; status: "not_modified"; inserted: number; parsed: number }
+  | { feedId: string; status: "error"; inserted: number; parsed: number; error: string };
 
 export interface CollectAllResult {
   total: number;
@@ -477,7 +475,7 @@ export async function collectAll(
           status,
           result.inserted,
           durationMs,
-          result.error,
+          result.status === "error" ? result.error : undefined,
         );
         d1Acc.add(meta);
       } catch (err) {

--- a/apps/web/worker/db/feeds.ts
+++ b/apps/web/worker/db/feeds.ts
@@ -6,6 +6,12 @@ import type {
   FeedHealth,
   FeedLang,
 } from "../types";
+import type {
+  CategorySummaryDbRow,
+  FeedDiagnosticDbRow,
+  FeedHealthFeedsDbRow,
+  FeedWithStatsDbRow,
+} from "./types";
 
 export interface FeedHeaders {
   last_etag: string | null;
@@ -228,16 +234,7 @@ export async function listFeedsWithStats(
   const rows = await db
     .prepare(sql)
     .bind(...binds)
-    .all<{
-      id: string;
-      name: string;
-      url: string;
-      category: string;
-      lang: string;
-      enabled: number;
-      articles_30d: number;
-      last_published_at: string | null;
-    }>();
+    .all<FeedWithStatsDbRow>();
 
   return (rows.results ?? []).map((r) => ({
     id: r.id,
@@ -269,16 +266,7 @@ export async function findFeedWithStats(db: D1Database, id: string): Promise<Fee
        GROUP BY f.id, f.name, f.url, f.category, f.lang, f.enabled`,
     )
     .bind(id, threshold)
-    .first<{
-      id: string;
-      name: string;
-      url: string;
-      category: string;
-      lang: string;
-      enabled: number;
-      articles_30d: number;
-      last_published_at: string | null;
-    }>();
+    .first<FeedWithStatsDbRow>();
 
   if (!row) return null;
 
@@ -332,12 +320,7 @@ export async function getCategoriesSummary(db: D1Database): Promise<CategorySumm
        GROUP BY f.category`,
     )
     .bind(threshold)
-    .all<{
-      category: string;
-      feeds_count: number;
-      articles_30d: number;
-      last_published_at: string | null;
-    }>();
+    .all<CategorySummaryDbRow>();
 
   const dbMap = new Map(
     (rows.results ?? []).map((r) => {
@@ -401,23 +384,7 @@ export async function getFeedsDiagnostics(db: D1Database): Promise<FeedDiagnosti
        ORDER BY f.id ASC`,
     )
     .bind(threshold)
-    .all<{
-      id: string;
-      name: string;
-      url: string;
-      category: string;
-      lang: string;
-      enabled: number;
-      last_fetched_at: string | null;
-      last_status: string | null;
-      last_error: string | null;
-      last_etag: string | null;
-      last_modified: string | null;
-      fetch_error_count: number;
-      articles_total: number;
-      articles_30d: number;
-      last_published_at: string | null;
-    }>();
+    .all<FeedDiagnosticDbRow>();
 
   return (rows.results ?? []).map((r) => ({
     id: r.id,
@@ -483,13 +450,7 @@ export async function getFeedHealth(db: D1Database, feeds: FeedConfig[]): Promis
         AND a.published_at >= datetime('now', '-7 days')
        GROUP BY f.id`,
     )
-    .all<{
-      id: string;
-      last_success_at: string | null;
-      last_failure_at: string | null;
-      consecutive_failures: number;
-      articles_last_7d: number;
-    }>();
+    .all<FeedHealthFeedsDbRow>();
 
   const dbMap = new Map(rows.results.map((r) => [r.id, r]));
 

--- a/apps/web/worker/db/runs.ts
+++ b/apps/web/worker/db/runs.ts
@@ -1,22 +1,19 @@
-export interface RunRow {
-  id: number;
-  started_at: string;
-  completed_at: string | null;
-  feeds_total: number | null;
-  feeds_ok: number | null;
-  feeds_failed: number | null;
-  articles_inserted: number | null;
-  error: string | null;
-}
+import type {
+  CollectorRunDbRow,
+  CollectorRunFeedDbRow,
+  CronHealthDbRow,
+  FeedFailureDbRow,
+  FeedHealthRunDbRow,
+} from "./types";
 
-export interface RunFeedRow {
-  run_id: number;
-  feed_id: string;
-  status: "ok" | "failed" | "skipped";
-  articles_inserted: number;
-  duration_ms: number;
-  error: string | null;
-}
+/** collector_runs の公開型エイリアス */
+export type RunRow = CollectorRunDbRow;
+
+/** collector_run_feeds の公開型エイリアス */
+export type RunFeedRow = CollectorRunFeedDbRow;
+
+/** getFeedHealth (runs) の公開型エイリアス */
+export type FeedHealthRow = FeedHealthRunDbRow;
 
 export async function startRun(
   db: D1Database,
@@ -109,22 +106,6 @@ export async function listRuns(db: D1Database, limit = 20): Promise<RunRow[]> {
   return result.results ?? [];
 }
 
-interface CronHealthRow {
-  runs_total: number;
-  runs_succeeded: number;
-  runs_failed: number;
-  avg_run_ms: number | null;
-  articles_collected: number;
-}
-
-interface FeedFailureRow {
-  feed_id: string;
-  failures: number;
-  successes: number;
-  last_error: string | null;
-  last_attempted_at: string | null;
-}
-
 // collector_runs を集計して運用メトリクスを返す。1 クエリで完結させ D1 CPU を節約する。
 export async function getCronHealth(
   db: D1Database,
@@ -155,7 +136,7 @@ export async function getCronHealth(
        WHERE started_at >= ?1`,
     )
     .bind(since)
-    .first<CronHealthRow>();
+    .first<CronHealthDbRow>();
 
   return {
     window_days: days,
@@ -172,7 +153,7 @@ export async function getFeedFailures(
   db: D1Database,
   days: 7 | 30,
   limit: number,
-): Promise<FeedFailureRow[]> {
+): Promise<FeedFailureDbRow[]> {
   const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
   const safeLimit = Math.min(Math.max(limit, 1), 100);
   const result = await db
@@ -192,20 +173,8 @@ export async function getFeedFailures(
        LIMIT ?2`,
     )
     .bind(since, safeLimit)
-    .all<FeedFailureRow>();
+    .all<FeedFailureDbRow>();
   return result.results ?? [];
-}
-
-export interface FeedHealthRow {
-  total_runs: number;
-  successful_runs: number;
-  failed_runs: number;
-  last_run_at: string | null;
-  last_run_status: string | null;
-  last_error_at: string | null;
-  last_error_message: string | null;
-  avg_duration_ms: number | null;
-  articles_inserted_total: number;
 }
 
 /**

--- a/apps/web/worker/db/types.ts
+++ b/apps/web/worker/db/types.ts
@@ -1,0 +1,145 @@
+/**
+ * D1 クエリ結果の Row 型を集約する。
+ * `.all<RowType>()` / `.first<RowType>()` のジェネリック引数として使用する。
+ * DB スキーマを変更した場合はこのファイルも合わせて更新すること。
+ */
+
+/** articles テーブルの全カラム (JOIN なし) */
+export interface ArticleDbRow {
+  id: number;
+  guid: string;
+  feed_id: string;
+  /** feeds テーブル LEFT JOIN 時のみ含まれる */
+  feed_name: string | null;
+  title: string;
+  url: string;
+  summary: string | null;
+  author: string | null;
+  published_at: string;
+  fetched_at: string;
+  /** DB 上は TEXT だが FeedCategory 列挙と一致する */
+  category: string;
+  /** DB 上は TEXT だが FeedLang 列挙と一致する */
+  lang: string;
+}
+
+/** feeds テーブルの基本カラム (articles JOIN なし) */
+export interface FeedDbRow {
+  id: string;
+  name: string;
+  url: string;
+  category: string;
+  lang: string;
+  /** DB 上は INTEGER (0/1) */
+  enabled: number;
+  last_fetched_at: string | null;
+  last_status: string | null;
+  last_error: string | null;
+  last_etag: string | null;
+  last_modified: string | null;
+  consecutive_failures: number;
+  last_success_at: string | null;
+  last_failure_at: string | null;
+}
+
+/** feeds + articles 集計 JOIN 結果 */
+export interface FeedWithStatsDbRow {
+  id: string;
+  name: string;
+  url: string;
+  category: string;
+  lang: string;
+  /** DB 上は INTEGER (0/1) */
+  enabled: number;
+  articles_30d: number;
+  last_published_at: string | null;
+}
+
+/** collector_runs テーブルの全カラム */
+export interface CollectorRunDbRow {
+  id: number;
+  started_at: string;
+  completed_at: string | null;
+  feeds_total: number | null;
+  feeds_ok: number | null;
+  feeds_failed: number | null;
+  articles_inserted: number | null;
+  error: string | null;
+}
+
+/** collector_run_feeds テーブルの全カラム */
+export interface CollectorRunFeedDbRow {
+  run_id: number;
+  feed_id: string;
+  status: "ok" | "failed" | "skipped";
+  articles_inserted: number;
+  duration_ms: number;
+  error: string | null;
+}
+
+/** getCronHealth クエリ結果 */
+export interface CronHealthDbRow {
+  runs_total: number;
+  runs_succeeded: number;
+  runs_failed: number;
+  avg_run_ms: number | null;
+  articles_collected: number;
+}
+
+/** getFeedFailures クエリ結果 */
+export interface FeedFailureDbRow {
+  feed_id: string;
+  failures: number;
+  successes: number;
+  last_error: string | null;
+  last_attempted_at: string | null;
+}
+
+/** getFeedHealth (runs) クエリ結果 */
+export interface FeedHealthRunDbRow {
+  total_runs: number;
+  successful_runs: number;
+  failed_runs: number;
+  last_run_at: string | null;
+  last_run_status: string | null;
+  last_error_at: string | null;
+  last_error_message: string | null;
+  avg_duration_ms: number | null;
+  articles_inserted_total: number;
+}
+
+/** getFeedsDiagnostics クエリ結果 */
+export interface FeedDiagnosticDbRow {
+  id: string;
+  name: string;
+  url: string;
+  category: string;
+  lang: string;
+  enabled: number;
+  last_fetched_at: string | null;
+  last_status: string | null;
+  last_error: string | null;
+  last_etag: string | null;
+  last_modified: string | null;
+  fetch_error_count: number;
+  articles_total: number;
+  articles_30d: number;
+  last_published_at: string | null;
+}
+
+/** getCategoriesSummary クエリ結果 */
+export interface CategorySummaryDbRow {
+  category: string;
+  feeds_count: number;
+  articles_30d: number;
+  last_published_at: string | null;
+}
+
+/** getFeedHealth (feeds.ts) クエリ結果 */
+export interface FeedHealthFeedsDbRow {
+  id: string;
+  last_success_at: string | null;
+  last_failure_at: string | null;
+  consecutive_failures: number;
+  articles_last_7d: number;
+}

--- a/apps/web/worker/types.ts
+++ b/apps/web/worker/types.ts
@@ -26,6 +26,23 @@ export interface Env {
 export type FeedCategory = "bigtech" | "ai" | "jp" | "zenn";
 export type FeedLang = "ja" | "en";
 
+/**
+ * Branded string types — DB / API 境界を越えても id と guid が混在しないことを型で保証する。
+ * 実体は string なので JSON シリアライズや D1 bind でそのまま使える。
+ */
+export type FeedId = string & { readonly __brand: "FeedId" };
+export type ArticleGuid = string & { readonly __brand: "ArticleGuid" };
+
+/** raw string を FeedId に昇格させる境界ファクトリ (feeds.yaml / D1 読み込み時に使う) */
+export function asFeedId(s: string): FeedId {
+  return s as FeedId;
+}
+
+/** raw string を ArticleGuid に昇格させる境界ファクトリ */
+export function asArticleGuid(s: string): ArticleGuid {
+  return s as ArticleGuid;
+}
+
 export interface FeedConfig {
   id: string;
   name: string;

--- a/apps/web/worker/utils/types.ts
+++ b/apps/web/worker/utils/types.ts
@@ -1,0 +1,34 @@
+/**
+ * worker 全体で再利用できる型ユーティリティを集約する。
+ * 汎用ロジックはここに置き、特定ドメイン専用の型は types.ts に置く。
+ */
+
+/**
+ * union 型の type guard factory。
+ * `includes` を `string[]` へ unsafe キャストせずに使えるよう、
+ * 正当な値の配列から型を絞り込む。
+ *
+ * @example
+ *   const isCategory = makeOneOf<FeedCategory>(["bigtech", "ai", "jp", "zenn"]);
+ *   if (isCategory(raw)) { ... } // raw は FeedCategory として利用可能
+ */
+export function makeOneOf<T extends string>(
+  values: readonly T[],
+): (value: string | undefined | null) => value is T {
+  const set = new Set<string>(values);
+  return (value): value is T => typeof value === "string" && set.has(value);
+}
+
+/**
+ * 要素がすべて string の配列かどうかを確認する type guard。
+ * JSON.parse した unknown な配列の型チェックに使う。
+ */
+export function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((v) => typeof v === "string");
+}
+
+/**
+ * 非空配列を表す型。
+ * 「1 件以上の要素が存在することが保証されている配列」が必要な関数のシグネチャに使う。
+ */
+export type NonEmptyArray<T> = [T, ...T[]];


### PR DESCRIPTION
## Summary

- `worker/db/types.ts` を新設し D1 クエリ結果の Row 型を集約。DB 層で inline だった `.all<{...}>()` の匿名型をすべて置換
- `worker/api/types.ts` を新設し全エンドポイントの Response 型を集約。ハンドラで `c.json<T>()` を使ってコンパイル時に shape を検証
- `worker/utils/types.ts` を新設し `makeOneOf<T>` type guard factory、`isStringArray`、`NonEmptyArray<T>` を提供
- `any` / `as string[]` 等の unsafe cast を `isCategory` / `isLang` type guard に置換 (articles, feeds, syndication, admin)
- `CollectResult` を discriminated union に変換し、`error` フィールドは `status === "error"` 時のみ存在することを型で保証
- `FeedId` / `ArticleGuid` branded string type を `types.ts` に追加
- `client/types/api.ts` の `FeedSummary` / `FeedsResponse` / `CalendarResponse` を実際の API shape に整合
- `useArticlesCalendar` フックの `data.days`（数値）→ `data.items`（配列）参照バグを修正
- テスト: `Array#sort()` → `Array#toSorted()`、`vi.fn<() => Promise<T>>()` 型パラメータ追加

## Test plan

- [x] `pnpm typecheck` — エラーなし
- [x] `pnpm lint` — エラーなし (警告 3 件は pre-existing lint rule false positive)
- [x] `pnpm build` — ビルド成功
- [x] `pnpm test` — 499 tests passed

Closes #216

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced validation for admin endpoints to return more specific error messages when invalid inputs are provided.

* **Chores**
  * Improved internal type safety and response structure consistency across API endpoints.
  * Updated data response formats to better align with backend payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->