### PR TITLE
docs: .claude rules / skills を整理

### DIFF
--- a/.claude/skills/tech-news-weekly/SKILL.md
+++ b/.claude/skills/tech-news-weekly/SKILL.md
@@ -218,5 +218,5 @@ Stage 1 の全記事 (de-dup 後) と Stage 3 の本文要約を総合して、�
 - 実装: `tools/d1-client/recent.mjs`
 - スキーマ: `migrations/0001_initial.sql` (`articles`, `feeds` テーブル)
 - 型: `apps/web/worker/types.ts` (`Article`, `FeedConfig` interface)
-- 関連 skill: `.claude/skills/tech-news-digest/SKILL.md` (デイリーダイジェスト skill)
+- 関連 skill: `.claude/skills/tech-news-digest/SKILL.md` (期間ベースダイジェスト skill)
 - 関連 skill: `.claude/skills/tech-news-search/SKILL.md` (キーワード深掘り検索)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,12 @@ PoC 規模 (Worker 1 個) なので `packages/` は廃止し、すべての work
 
 YAML は `@modyfi/vite-plugin-yaml` により build 時に JSON へ変換され Worker bundle に inline される。runtime 依存は無し。
 
-## Skill: `tech-news-digest`
+## Skills
 
-D1 から今日 / 今週の記事を抽出して日本語で要約 + トレンド検出する Claude Skill。詳細は `.claude/skills/tech-news-digest/SKILL.md` 参照。
+D1 の記事を活用する Claude Skills が 3 種類ある。詳細は各 SKILL.md 参照。
+
+| Skill | 用途 | SKILL.md |
+| ----- | ---- | -------- |
+| `tech-news-digest` | 今日・今週・任意期間の記事をリスト形式でダイジェスト | `.claude/skills/tech-news-digest/SKILL.md` |
+| `tech-news-weekly` | 週次・月次をストーリー形式のレポートとして生成 | `.claude/skills/tech-news-weekly/SKILL.md` |
+| `tech-news-search` | 特定キーワードで FTS5 全文検索し深掘り解説を生成 | `.claude/skills/tech-news-search/SKILL.md` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,8 +96,8 @@ YAML は `@modyfi/vite-plugin-yaml` により build 時に JSON へ変換され 
 
 D1 の記事を活用する Claude Skills が 3 種類ある。詳細は各 SKILL.md 参照。
 
-| Skill | 用途 | SKILL.md |
-| ----- | ---- | -------- |
+| Skill              | 用途                                                 | SKILL.md                                   |
+| ------------------ | ---------------------------------------------------- | ------------------------------------------ |
 | `tech-news-digest` | 今日・今週・任意期間の記事をリスト形式でダイジェスト | `.claude/skills/tech-news-digest/SKILL.md` |
-| `tech-news-weekly` | 週次・月次をストーリー形式のレポートとして生成 | `.claude/skills/tech-news-weekly/SKILL.md` |
-| `tech-news-search` | 特定キーワードで FTS5 全文検索し深掘り解説を生成 | `.claude/skills/tech-news-search/SKILL.md` |
+| `tech-news-weekly` | 週次・月次をストーリー形式のレポートとして生成       | `.claude/skills/tech-news-weekly/SKILL.md` |
+| `tech-news-search` | 特定キーワードで FTS5 全文検索し深掘り解説を生成     | `.claude/skills/tech-news-search/SKILL.md` |


### PR DESCRIPTION
Closes #221

## Summary
- CLAUDE.md の Skill セクションを 3 skill 全て一覧化 (digest / weekly / search)
- tech-news-weekly/SKILL.md の関連 skill 説明を「デイリーダイジェスト」から「期間ベースダイジェスト」に修正
- .claude/agents/ は global skill で十分と判断し作成しない

## Test plan
- md 編集のみのため Worker / SPA への影響なし
- pnpm build pass (確認済み)
- pnpm test 499 tests pass (確認済み)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated skill documentation with a consolidated overview of available tech news skills and features.
  * Refined description of period-based digest functionality for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->