### PR TITLE
feat: Slack 日次記事ダイジェスト投稿機能

### DIFF
--- a/apps/web/tests/worker/notify/slack-daily.test.ts
+++ b/apps/web/tests/worker/notify/slack-daily.test.ts
@@ -1,0 +1,316 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { env } from "cloudflare:test";
+import { insertArticles } from "../../../worker/db/articles";
+import { syncFeeds } from "../../../worker/db/feeds";
+import {
+  buildPayload,
+  countByCategory,
+  fetchLast24hArticles,
+  postDailyDigest,
+  sendDailyDigest,
+  type DailyDigestArticle,
+} from "../../../worker/notify/slack-daily";
+import type { FeedConfig } from "../../../worker/types";
+
+const WEBHOOK_URL = "https://hooks.slack.com/services/test/webhook";
+
+const FEEDS: FeedConfig[] = [
+  {
+    id: "feed-bigtech",
+    name: "BigTech Blog",
+    url: "https://bigtech.test/rss",
+    category: "bigtech",
+    lang: "en",
+    enabled: true,
+  },
+  {
+    id: "feed-ai",
+    name: "AI News",
+    url: "https://ai.test/rss",
+    category: "ai",
+    lang: "en",
+    enabled: true,
+  },
+  {
+    id: "feed-jp",
+    name: "JP Blog",
+    url: "https://jp.test/rss",
+    category: "jp",
+    lang: "ja",
+    enabled: true,
+  },
+  {
+    id: "feed-zenn",
+    name: "Zenn",
+    url: "https://zenn.dev/feed",
+    category: "zenn",
+    lang: "ja",
+    enabled: true,
+  },
+];
+
+beforeEach(async () => {
+  await syncFeeds(env.DB, FEEDS);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// 現在時刻から指定分だけ前の ISO 文字列を返す
+function minutesAgo(minutes: number): string {
+  return new Date(Date.now() - minutes * 60 * 1000).toISOString();
+}
+
+// 現在時刻から指定時間だけ前の ISO 文字列を返す
+function hoursAgo(hours: number): string {
+  return minutesAgo(hours * 60);
+}
+
+describe("fetchLast24hArticles", () => {
+  it("returns empty array when no articles exist", async () => {
+    const articles = await fetchLast24hArticles(env.DB);
+    expect(articles).toHaveLength(0);
+  });
+
+  it("returns articles published within 24 hours", async () => {
+    await insertArticles(env.DB, [
+      {
+        guid: "g1",
+        feed_id: "feed-bigtech",
+        title: "Recent Article",
+        url: "https://bigtech.test/1",
+        summary: null,
+        author: null,
+        published_at: hoursAgo(1),
+        category: "bigtech",
+        lang: "en",
+      },
+    ]);
+
+    const articles = await fetchLast24hArticles(env.DB);
+    expect(articles).toHaveLength(1);
+    expect(articles[0].title).toBe("Recent Article");
+  });
+
+  it("excludes articles older than 24 hours", async () => {
+    await insertArticles(env.DB, [
+      {
+        guid: "g-old",
+        feed_id: "feed-bigtech",
+        title: "Old Article",
+        url: "https://bigtech.test/old",
+        summary: null,
+        author: null,
+        published_at: hoursAgo(25),
+        category: "bigtech",
+        lang: "en",
+      },
+      {
+        guid: "g-new",
+        feed_id: "feed-ai",
+        title: "New Article",
+        url: "https://ai.test/new",
+        summary: null,
+        author: null,
+        published_at: hoursAgo(1),
+        category: "ai",
+        lang: "en",
+      },
+    ]);
+
+    const articles = await fetchLast24hArticles(env.DB);
+    expect(articles).toHaveLength(1);
+    expect(articles[0].title).toBe("New Article");
+  });
+});
+
+describe("countByCategory", () => {
+  it("returns zero counts when articles is empty", () => {
+    const counts = countByCategory([]);
+    expect(counts.bigtech).toBe(0);
+    expect(counts.ai).toBe(0);
+    expect(counts.jp).toBe(0);
+    expect(counts.zenn).toBe(0);
+  });
+
+  it("counts articles by category correctly", () => {
+    const articles: DailyDigestArticle[] = [
+      { title: "a1", url: "u1", feed_name: "F", category: "bigtech" },
+      { title: "a2", url: "u2", feed_name: "F", category: "bigtech" },
+      { title: "a3", url: "u3", feed_name: "F", category: "ai" },
+      { title: "a4", url: "u4", feed_name: "F", category: "zenn" },
+    ];
+    const counts = countByCategory(articles);
+    expect(counts.bigtech).toBe(2);
+    expect(counts.ai).toBe(1);
+    expect(counts.jp).toBe(0);
+    expect(counts.zenn).toBe(1);
+  });
+});
+
+describe("buildPayload", () => {
+  it("returns text with total count when articles exist", () => {
+    const articles: DailyDigestArticle[] = Array.from({ length: 3 }, (_, i) => ({
+      title: `Article ${i}`,
+      url: `https://example.test/${i}`,
+      feed_name: "Feed",
+      category: "bigtech" as const,
+    }));
+    const { text } = buildPayload(articles, "2026-04-28");
+    expect(text).toContain("2026-04-28");
+    expect(text).toContain("3 件");
+  });
+
+  it("returns empty-looking text when articles is empty", () => {
+    const { text, blocks } = buildPayload([], "2026-04-28");
+    expect(text).toContain("0 件");
+    // header + summary + divider (カテゴリ section なし)
+    expect((blocks as unknown[]).length).toBe(3);
+  });
+
+  it("limits each category to MAX_PER_CATEGORY (5) articles", () => {
+    // 10 件の bigtech 記事を用意
+    const articles: DailyDigestArticle[] = Array.from({ length: 10 }, (_, i) => ({
+      title: `Article ${i}`,
+      url: `https://bigtech.test/${i}`,
+      feed_name: "BigTech",
+      category: "bigtech" as const,
+    }));
+    const { blocks } = buildPayload(articles, "2026-04-28");
+
+    // カテゴリ section は 1 つ (bigtech のみ)
+    const sections = (blocks as { type: string; text?: { text: string } }[]).filter(
+      (b) => b.type === "section",
+    );
+    const bigtechSection = sections.find((s) => s.text?.text.includes("ビッグテック"));
+    expect(bigtechSection).toBeDefined();
+    // 5 件の bullet + 1 行の「他 N 件」= 6 行
+    const lineCount = (bigtechSection!.text!.text.match(/\n/g) ?? []).length;
+    // タイトル行 (1) + 5 件 bullet + 他 N 件 = 7 行 → 改行は 6 個
+    expect(lineCount).toBe(6);
+    // 「他 5 件」の表示を確認
+    expect(bigtechSection!.text!.text).toContain("他 5 件");
+  });
+
+  it("does not show 'other N' when articles <= 5 per category", () => {
+    const articles: DailyDigestArticle[] = Array.from({ length: 3 }, (_, i) => ({
+      title: `Article ${i}`,
+      url: `https://bigtech.test/${i}`,
+      feed_name: "BigTech",
+      category: "bigtech" as const,
+    }));
+    const { blocks } = buildPayload(articles, "2026-04-28");
+    const sections = (blocks as { type: string; text?: { text: string } }[]).filter(
+      (b) => b.type === "section",
+    );
+    const bigtechSection = sections.find((s) => s.text?.text.includes("ビッグテック"));
+    expect(bigtechSection?.text?.text).not.toContain("他");
+  });
+});
+
+describe("postDailyDigest", () => {
+  it("returns posted=false when webhookUrl is undefined", async () => {
+    const spy = vi.spyOn(globalThis, "fetch");
+    const result = await postDailyDigest(undefined, [], "2026-04-28");
+    expect(result.posted).toBe(false);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("returns posted=false when webhookUrl is empty string", async () => {
+    const spy = vi.spyOn(globalThis, "fetch");
+    const result = await postDailyDigest("", [], "2026-04-28");
+    expect(result.posted).toBe(false);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("calls fetch with POST when webhookUrl is set", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    const result = await postDailyDigest(WEBHOOK_URL, [], "2026-04-28");
+    expect(result.posted).toBe(true);
+    expect(spy).toHaveBeenCalledTimes(1);
+    const [url, init] = spy.mock.calls[0];
+    expect(url).toBe(WEBHOOK_URL);
+    expect(init?.method).toBe("POST");
+  });
+
+  it("payload contains date label and article count", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    const articles: DailyDigestArticle[] = [
+      { title: "Test", url: "https://example.test/1", feed_name: "F", category: "ai" },
+    ];
+    await postDailyDigest(WEBHOOK_URL, articles, "2026-04-28");
+
+    const body = JSON.parse(spy.mock.calls[0][1]?.body as string) as {
+      text: string;
+      blocks: unknown[];
+    };
+    expect(body.text).toContain("2026-04-28");
+    expect(body.text).toContain("1 件");
+    expect(Array.isArray(body.blocks)).toBe(true);
+  });
+
+  it("does not throw on non-2xx response", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(null, { status: 500 }));
+    await expect(postDailyDigest(WEBHOOK_URL, [], "2026-04-28")).resolves.toBeDefined();
+  });
+
+  it("does not throw on network error", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(new TypeError("Failed to fetch"));
+    await expect(postDailyDigest(WEBHOOK_URL, [], "2026-04-28")).resolves.toBeDefined();
+  });
+});
+
+describe("sendDailyDigest", () => {
+  it("returns posted=false when SLACK_WEBHOOK_URL is not set", async () => {
+    const spy = vi.spyOn(globalThis, "fetch");
+    const result = await sendDailyDigest(env.DB, undefined);
+    expect(result.posted).toBe(false);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("posts to Slack with articles from D1 when webhook URL is set", async () => {
+    await insertArticles(env.DB, [
+      {
+        guid: "g-slack-1",
+        feed_id: "feed-bigtech",
+        title: "Slack Test Article",
+        url: "https://bigtech.test/slack",
+        summary: null,
+        author: null,
+        published_at: hoursAgo(2),
+        category: "bigtech",
+        lang: "en",
+      },
+    ]);
+
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    const result = await sendDailyDigest(env.DB, WEBHOOK_URL);
+    expect(result.posted).toBe(true);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    const body = JSON.parse(spy.mock.calls[0][1]?.body as string) as { text: string };
+    expect(body.text).toContain("1 件");
+  });
+
+  it("posts empty digest (0 件) when no articles in last 24h", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    const result = await sendDailyDigest(env.DB, WEBHOOK_URL);
+    expect(result.posted).toBe(true);
+
+    const body = JSON.parse(spy.mock.calls[0][1]?.body as string) as { text: string };
+    expect(body.text).toContain("0 件");
+  });
+});

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -7,6 +7,7 @@ import syndication from "./api/syndication";
 import opml from "./api/opml";
 import { collectAll } from "./collector";
 import { pruneOldArticles } from "./db/retention";
+import { sendDailyDigest } from "./notify/slack-daily";
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -54,12 +55,24 @@ app.all("*", async (c) => {
 
 const handler: ExportedHandler<Env> = {
   fetch: app.fetch,
-  async scheduled(_controller, env, ctx) {
+  async scheduled(controller, env, ctx) {
     // READONLY=1 の preview 環境ではコレクターを起動しない
     if (env.READONLY === "1") {
-      console.log("[scheduled] READONLY mode – skipping collectAll");
+      console.log("[scheduled] READONLY mode – skipping");
       return;
     }
+
+    // 日次 cron (0 0 * * *): Slack ダイジェスト投稿
+    if (controller.cron === "0 0 * * *") {
+      ctx.waitUntil(
+        sendDailyDigest(env.DB, env.SLACK_WEBHOOK_URL).catch((err) => {
+          console.error("[scheduled] sendDailyDigest failed", err);
+        }),
+      );
+      return;
+    }
+
+    // 3 時間ごとの cron (0 */3 * * *): RSS 収集
     ctx.waitUntil(
       collectAll(env).catch((err) => {
         console.error("[scheduled] collectAll failed", err);

--- a/apps/web/worker/notify/slack-daily.ts
+++ b/apps/web/worker/notify/slack-daily.ts
@@ -1,0 +1,162 @@
+import type { FeedCategory } from "../types";
+
+/** カテゴリの表示名マップ */
+const CATEGORY_LABELS: Record<FeedCategory, string> = {
+  bigtech: "🏢 ビッグテック",
+  ai: "🤖 AI",
+  jp: "🇯🇵 日本語",
+  zenn: "📝 Zenn",
+};
+
+const CATEGORIES: FeedCategory[] = ["bigtech", "ai", "jp", "zenn"];
+const MAX_PER_CATEGORY = 5;
+
+export interface DailyDigestArticle {
+  title: string;
+  url: string;
+  feed_name?: string | null;
+  category: FeedCategory;
+}
+
+export interface DailyDigestResult {
+  /** 投稿が行われた (webhookUrl が設定されていた) 場合 true */
+  posted: boolean;
+}
+
+/** 過去 24 時間の記事を D1 から取得する */
+export async function fetchLast24hArticles(db: D1Database): Promise<DailyDigestArticle[]> {
+  const result = await db
+    .prepare(
+      // datetime() で正規化しないと ISO 8601 ('T' 含む) と SQLite datetime() 出力 (スペース区切り) のテキスト比較が壊れる
+      `SELECT a.title, a.url, f.name AS feed_name, a.category
+       FROM articles a
+       LEFT JOIN feeds f ON f.id = a.feed_id
+       WHERE datetime(a.published_at) > datetime('now', '-1 day')
+       ORDER BY a.published_at DESC`,
+    )
+    .all<DailyDigestArticle>();
+  return result.results ?? [];
+}
+
+/** カテゴリ別の件数を集計する */
+export function countByCategory(articles: DailyDigestArticle[]): Record<FeedCategory, number> {
+  const counts: Record<FeedCategory, number> = { bigtech: 0, ai: 0, jp: 0, zenn: 0 };
+  for (const a of articles) {
+    if (a.category in counts) counts[a.category]++;
+  }
+  return counts;
+}
+
+/** Slack blocks payload を組み立てる */
+export function buildPayload(
+  articles: DailyDigestArticle[],
+  dateLabel: string,
+): { text: string; blocks: unknown[] } {
+  const total = articles.length;
+  const counts = countByCategory(articles);
+
+  const summaryParts = CATEGORIES.map((cat) => `${cat} ${counts[cat]}`).join(" / ");
+  const headerText = `📰 Tech News Daily — ${dateLabel}`;
+  const summaryText = `*過去 24h: ${total} 件* (${summaryParts})`;
+
+  const blocks: unknown[] = [
+    {
+      type: "header",
+      text: { type: "plain_text", text: headerText },
+    },
+    {
+      type: "section",
+      text: { type: "mrkdwn", text: summaryText },
+    },
+    { type: "divider" },
+  ];
+
+  // カテゴリ別に section を追加
+  for (const cat of CATEGORIES) {
+    const catArticles = articles.filter((a) => a.category === cat);
+    if (catArticles.length === 0) continue;
+
+    const excerpt = catArticles.slice(0, MAX_PER_CATEGORY);
+    const remaining = catArticles.length - excerpt.length;
+
+    const lines = excerpt.map((a) => {
+      const feedLabel = a.feed_name ? ` _(${a.feed_name})_` : "";
+      return `• <${a.url}|${a.title}>${feedLabel}`;
+    });
+    if (remaining > 0) {
+      lines.push(`_... 他 ${remaining} 件_`);
+    }
+
+    const label = CATEGORY_LABELS[cat];
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `*${label} (${catArticles.length} 件抜粋)*\n${lines.join("\n")}`,
+      },
+    });
+  }
+
+  return {
+    text: `📰 Tech News Daily — ${dateLabel} (${total} 件)`,
+    blocks,
+  };
+}
+
+/**
+ * Slack incoming webhook に日次ダイジェストを投稿する。
+ * SLACK_WEBHOOK_URL が未設定なら no-op (ログのみ)。fetch 失敗は console.error のみ。
+ * Discord は blocks を無視して text フィールドをメッセージとして表示する。
+ */
+export async function postDailyDigest(
+  webhookUrl: string | undefined,
+  articles: DailyDigestArticle[],
+  dateLabel: string,
+): Promise<DailyDigestResult> {
+  if (!webhookUrl) {
+    console.log("[slack-daily] SLACK_WEBHOOK_URL not set – skipping daily digest");
+    return { posted: false };
+  }
+
+  const payload = buildPayload(articles, dateLabel);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 5000);
+
+  try {
+    const res = await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      console.error(`[slack-daily] webhook returned non-2xx: ${res.status} ${res.statusText}`);
+    }
+  } catch (err) {
+    console.error(
+      `[slack-daily] failed to post: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+
+  return { posted: true };
+}
+
+/**
+ * D1 から過去 24h の記事を取得して Slack に投稿するエントリポイント。
+ * SLACK_WEBHOOK_URL が未設定なら no-op で正常終了。
+ */
+export async function sendDailyDigest(
+  db: D1Database,
+  webhookUrl: string | undefined,
+): Promise<DailyDigestResult> {
+  if (!webhookUrl) {
+    console.log("[slack-daily] SLACK_WEBHOOK_URL not set – skipping daily digest");
+    return { posted: false };
+  }
+
+  const articles = await fetchLast24hArticles(db);
+  const dateLabel = new Date().toISOString().slice(0, 10);
+  return postDailyDigest(webhookUrl, articles, dateLabel);
+}

--- a/apps/web/worker/types.ts
+++ b/apps/web/worker/types.ts
@@ -21,6 +21,8 @@ export interface Env {
   COLLECTOR_ALERT_WEBHOOK?: string;
   // 閾値: feeds_failed がこの値以上になったら通知する (default: "5")
   COLLECTOR_ALERT_THRESHOLD?: string;
+  // 日次ダイジェスト投稿先 (wrangler secret put SLACK_WEBHOOK_URL)
+  SLACK_WEBHOOK_URL?: string;
 }
 
 export type FeedCategory = "bigtech" | "ai" | "jp" | "zenn";

--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -18,7 +18,10 @@ database_id = "a6cd7dbc-9f26-46d9-83c8-4a7b89405b7b"
 migrations_dir = "../../migrations"
 
 [triggers]
-crons = ["0 */3 * * *"]
+# 0 */3 * * * : 3 時間ごとの RSS 収集
+# 0 0 * * *   : 毎日 UTC 00:00 (JST 09:00) に Slack 日次ダイジェスト投稿
+# SLACK_WEBHOOK_URL は wrangler secret put SLACK_WEBHOOK_URL で登録する
+crons = ["0 */3 * * *", "0 0 * * *"]
 
 [vars]
 COLLECTOR_CONCURRENCY = "4"


### PR DESCRIPTION
## 概要

毎日 UTC 00:00 (JST 09:00) の cron で、過去 24h の記事をカテゴリ別にまとめて Slack incoming webhook へ投稿する機能を追加。

## 動作

- 投稿先: `SLACK_WEBHOOK_URL` (wrangler secret) — 未設定なら no-op で正常終了
- 内容: ヘッダ + サマリ (`bigtech N / ai N / jp N / zenn N`) + カテゴリ別 section
- 各カテゴリ最大 5 件抜粋、超過分は「他 N 件」表示
- 5s timeout / fetch 失敗は console.error のみ (cron を落とさない設計)

## 実装

- `apps/web/worker/notify/slack-daily.ts` — payload 組み立て + 投稿ロジック
  - `datetime(a.published_at) > datetime('now', '-1 day')` で正規化 (ISO 8601 'T' と SQLite ' ' のテキスト比較ずれを回避)
- `apps/web/worker/index.ts` — `scheduled()` で `controller.cron === "0 0 * * *"` を判定して dispatch
- `apps/web/worker/types.ts` — `Env.SLACK_WEBHOOK_URL?: string`
- `apps/web/wrangler.toml` — `crons = ["0 */3 * * *", "0 0 * * *"]`

## 設定方法

```bash
wrangler secret put SLACK_WEBHOOK_URL
# (Slack incoming webhook URL を貼り付け)
```

## テスト

`apps/web/tests/worker/notify/slack-daily.test.ts` (18 ケース):
- `fetchLast24hArticles`: 24h 境界の包含/除外
- `countByCategory`: 集計の正しさ
- `buildPayload`: テキスト・blocks の構成、カテゴリごと 5 件制限
- `postDailyDigest`: webhookUrl 未設定時の no-op、POST 呼び出し、500 / network error の握り潰し
- `sendDailyDigest`: D1 統合 + webhook 投稿の end-to-end

`pnpm test` 全 517 件 pass。

Closes #224