### PR TITLE
fix: Slack 用 cron を 3 時間 cron 内に統合 (Free plan 上限回避)

### DIFF
--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -55,20 +55,10 @@ app.all("*", async (c) => {
 
 const handler: ExportedHandler<Env> = {
   fetch: app.fetch,
-  async scheduled(controller, env, ctx) {
+  async scheduled(_controller, env, ctx) {
     // READONLY=1 の preview 環境ではコレクターを起動しない
     if (env.READONLY === "1") {
       console.log("[scheduled] READONLY mode – skipping");
-      return;
-    }
-
-    // 日次 cron (0 0 * * *): Slack ダイジェスト投稿
-    if (controller.cron === "0 0 * * *") {
-      ctx.waitUntil(
-        sendDailyDigest(env.DB, env.SLACK_WEBHOOK_URL).catch((err) => {
-          console.error("[scheduled] sendDailyDigest failed", err);
-        }),
-      );
       return;
     }
 
@@ -78,8 +68,18 @@ const handler: ExportedHandler<Env> = {
         console.error("[scheduled] collectAll failed", err);
       }),
     );
+
+    const utcHour = new Date().getUTCHours();
+    // UTC 00:00 (JST 09:00): Slack 日次ダイジェスト投稿
+    if (utcHour === 0) {
+      ctx.waitUntil(
+        sendDailyDigest(env.DB, env.SLACK_WEBHOOK_URL).catch((err) => {
+          console.error("[scheduled] sendDailyDigest failed", err);
+        }),
+      );
+    }
     // Run retention once per day at UTC 17:00 to avoid peak write hours
-    if (new Date().getUTCHours() === 17) {
+    if (utcHour === 17) {
       ctx.waitUntil(
         pruneOldArticles(env.DB, Number(env.RETENTION_DAYS ?? "0")).then((r) => {
           console.log(`[retention] deleted=${r.deleted}`);

--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -18,10 +18,9 @@ database_id = "a6cd7dbc-9f26-46d9-83c8-4a7b89405b7b"
 migrations_dir = "../../migrations"
 
 [triggers]
-# 0 */3 * * * : 3 時間ごとの RSS 収集
-# 0 0 * * *   : 毎日 UTC 00:00 (JST 09:00) に Slack 日次ダイジェスト投稿
-# SLACK_WEBHOOK_URL は wrangler secret put SLACK_WEBHOOK_URL で登録する
-crons = ["0 */3 * * *", "0 0 * * *"]
+# 0 */3 * * * : 3 時間ごと (UTC 00,03,...,21) — RSS 収集 + Slack 日次 (00:00 のみ) + retention (17:00 のみ)
+# Slack 投稿には SLACK_WEBHOOK_URL を `wrangler secret put SLACK_WEBHOOK_URL` で登録する
+crons = ["0 */3 * * *"]
 
 [vars]
 COLLECTOR_CONCURRENCY = "4"


### PR DESCRIPTION
## 背景

#229 で追加した \`crons = [\"0 */3 * * *\", \"0 0 * * *\"]\` でデプロイすると Cloudflare Workers Free plan の cron triggers 上限 (5) を超えるエラーが発生。

\`\`\`
✘ ERROR: A request to the Cloudflare API (/accounts/***/workers/scripts/tech-news-bot/schedules) failed.
You have exceeded the limit of 5 cron triggers.
\`\`\`

## 修正

- \`wrangler.toml\` の \`crons\` を \`[\"0 */3 * * *\"]\` のみに戻す
- \`scheduled()\` 内で \`new Date().getUTCHours() === 0\` のときに \`sendDailyDigest\` を呼ぶ
- retention (UTC 17:00) と同じパターン

## テスト

\`pnpm test\` 全 517 件 pass。