### PR TITLE
chore: Slack section 文言修正 + @types/node major bump を ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    ignore:
+      # Node.js LTS 24 を当面利用するため、@types/node の major bump は対象外にする
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
     groups:
       types:
         # @types/* をまとめて 1 PR に

--- a/apps/web/worker/notify/slack-daily.ts
+++ b/apps/web/worker/notify/slack-daily.ts
@@ -92,7 +92,7 @@ export function buildPayload(
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `*${label} (${catArticles.length} 件抜粋)*\n${lines.join("\n")}`,
+        text: `*${label} (${catArticles.length} 件)*\n${lines.join("\n")}`,
       },
     });
   }


### PR DESCRIPTION
## 概要

- **Slack 文言**: カテゴリ section 見出しの `(N 件抜粋)` → `(N 件)` に変更。実際は `MAX_PER_CATEGORY=5` 件しか表示しないため「抜粋」の表現が誤解を招くと指摘あり。
- **dependabot**: `@types/node` の major bump を ignore に追加。Node.js LTS 24 を当面利用するため、25 系の自動 PR は不要。

## 関連

- 進行中の PR #56 (`@types/node` 25 系 bump) はこの設定後に close + ブランチ削除する。

## テスト

`pnpm test` 全 517 件 pass。