### PR TITLE
feat(feeds): CyberAgent Research と Microsoft AI Blog を追加

### DIFF
--- a/apps/web/worker/feeds.yaml
+++ b/apps/web/worker/feeds.yaml
@@ -127,6 +127,13 @@ feeds:
     lang: en
     enabled: true
 
+  - id: microsoft-ai-blog
+    name: Microsoft AI Blog
+    url: https://blogs.microsoft.com/ai/feed/
+    category: ai
+    lang: en
+    enabled: true
+
   # ─────────── AI labs ───────────
   - id: openai-blog
     name: OpenAI News
@@ -175,6 +182,13 @@ feeds:
   - id: cyberagent-developers
     name: CyberAgent Developers Blog
     url: https://developers.cyberagent.co.jp/blog/feed/
+    category: jp
+    lang: ja
+    enabled: true
+
+  - id: cyberagent-research
+    name: CyberAgent AI Lab Research Blog
+    url: https://research.cyberagent.ai/feed/
     category: jp
     lang: ja
     enabled: true


### PR DESCRIPTION
## 概要

#239 で取りこぼした AI / jp カテゴリのフィード 2 件を追加。

| id | name | URL | category | lang |
|---|---|---|---|---|
| `cyberagent-research` | CyberAgent AI Lab Research Blog | `https://research.cyberagent.ai/feed/` | `jp` | ja |
| `microsoft-ai-blog` | Microsoft AI Blog | `https://blogs.microsoft.com/ai/feed/` | `ai` | en |

## 経緯

- 前回 PR で `ai-lab.cyberagent.ai` (NXDOMAIN) として除外していたが、正しいドメインは `research.cyberagent.ai`
- Microsoft AI Blog は過去 403 と認識されていたが、現状は素朴な UA でも 200 OK

## 検証

- `node tools/validate-feeds.mjs` で 2 件とも `200 application/rss+xml` を確認
- 既存の `cyberagent-developers`, `openai-blog`, `azure-blog`, `microsoft-engineering` とは別 URL で重複なし

Closes #240