### PR TITLE
refactor(web): migrate UI parts to tailwind (batch A)

### DIFF
--- a/apps/web/client/components/BookmarkButton.tsx
+++ b/apps/web/client/components/BookmarkButton.tsx
@@ -11,7 +11,7 @@ export function BookmarkButton({ guid }: Props) {
   return (
     <button
       type="button"
-      className="bookmark-button"
+      className="shrink-0 px-[2px] py-[var(--space-1)] bg-transparent text-[var(--fg-muted)] border-none text-[1rem] font-[inherit] cursor-pointer leading-none opacity-45 transition-[opacity,color] duration-100 hover:opacity-100 hover:text-[var(--accent)] aria-pressed:opacity-100 aria-pressed:text-[var(--accent)] focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2 focus-visible:rounded-[var(--radius-sm)]"
       onClick={() => toggle(guid)}
       aria-label={bookmarked ? "ブックマークから削除" : "ブックマークに追加"}
       aria-pressed={bookmarked}

--- a/apps/web/client/components/HelpModal.tsx
+++ b/apps/web/client/components/HelpModal.tsx
@@ -19,27 +19,35 @@ export function HelpModal({ open, onClose }: Props) {
 
   return (
     <div
-      className="help-overlay"
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-[100] backdrop-blur-[4px] [-webkit-backdrop-filter:blur(4px)]"
       onClick={onClose}
       role="dialog"
       aria-modal
       aria-label="キーボードショートカット"
     >
-      <div className="help-modal" onClick={(e) => e.stopPropagation()}>
-        <div className="help-modal-header">
-          <h2>キーボードショートカット</h2>
-          <button type="button" className="help-close" onClick={onClose} aria-label="閉じる">
+      <div
+        className="bg-[var(--bg-elevated)] border border-[var(--border-subtle)] rounded-[var(--radius-xl)] px-[var(--space-6)] py-[var(--space-5)] min-w-[320px] max-w-[480px] w-[90%] shadow-[var(--shadow-xl)]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-[var(--space-4)]">
+          <h2 className="m-0 text-[var(--font-size-md)] font-semibold">キーボードショートカット</h2>
+          <button
+            type="button"
+            className="bg-transparent border-none text-[var(--fg-muted)] text-[1rem] cursor-pointer px-[var(--space-2)] py-[2px] rounded-[var(--radius-sm)] transition-[color,background] duration-100 hover:text-[var(--fg-primary)] hover:bg-[var(--bg-overlay)] focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2"
+            onClick={onClose}
+            aria-label="閉じる"
+          >
             ✕
           </button>
         </div>
-        <table className="help-table">
+        <table className="border-collapse w-full text-[var(--font-size-base)]">
           <tbody>
             {SHORTCUTS.map(({ key, label }) => (
               <tr key={key}>
-                <td>
+                <td className="py-[5px] px-[var(--space-2)] align-middle w-[40%] whitespace-nowrap">
                   <kbd>{key}</kbd>
                 </td>
-                <td>{label}</td>
+                <td className="py-[5px] px-[var(--space-2)] align-middle">{label}</td>
               </tr>
             ))}
           </tbody>

--- a/apps/web/client/components/ShareButtons.tsx
+++ b/apps/web/client/components/ShareButtons.tsx
@@ -6,6 +6,10 @@ interface Props {
   title: string;
 }
 
+// 共通ボタン/リンクの見た目
+const shareButtonBase =
+  "inline-flex items-center justify-center w-[26px] h-[26px] p-0 bg-[var(--bg-overlay)] text-[var(--fg-muted)] border border-[var(--border-subtle)] rounded-[var(--radius-sm)] cursor-pointer no-underline font-[inherit] transition-[color,border-color,background] duration-100 hover:text-[var(--fg-primary)] hover:border-[var(--accent)] hover:bg-[var(--bg-elevated)] focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2";
+
 export function ShareButtons({ url, title }: Props) {
   const [copied, setCopied] = useState(false);
   const { show } = useToast();
@@ -28,12 +32,12 @@ export function ShareButtons({ url, title }: Props) {
   }
 
   return (
-    <div className="share-buttons">
+    <div className="flex gap-[var(--space-2)] items-center">
       <a
         href={xHref}
         target="_blank"
         rel="noopener"
-        className="share-button"
+        className={shareButtonBase}
         aria-label="X (Twitter) でシェア"
       >
         {/* X (Twitter) logo */}
@@ -52,7 +56,7 @@ export function ShareButtons({ url, title }: Props) {
         href={hatenaHref}
         target="_blank"
         rel="noopener"
-        className="share-button"
+        className={shareButtonBase}
         aria-label="はてなブックマークに追加"
       >
         {/* Hatena Bookmark "B!" mark */}
@@ -80,8 +84,8 @@ export function ShareButtons({ url, title }: Props) {
       </a>
       <button
         type="button"
-        className={`share-button${copied ? " share-button-copied" : ""}`}
-        aria-label="URLをコピー"
+        className={`${shareButtonBase}${copied ? " text-[var(--success)] border-[var(--success)]" : ""}`}
+        aria-label={copied ? "コピー済み" : "URLをコピー"}
         onClick={handleCopy}
       >
         {copied ? (

--- a/apps/web/client/components/ShortcutsHelp.tsx
+++ b/apps/web/client/components/ShortcutsHelp.tsx
@@ -20,32 +20,35 @@ export function ShortcutsHelp({ open, onClose }: Props) {
 
   return (
     <div
-      className="shortcuts-help-overlay"
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-[100] backdrop-blur-[4px] [-webkit-backdrop-filter:blur(4px)]"
       onClick={onClose}
       role="dialog"
       aria-modal="true"
       aria-label="キーボードショートカット"
     >
-      <div className="shortcuts-help-modal" onClick={(e) => e.stopPropagation()}>
-        <div className="shortcuts-help-header">
-          <h2>キーボードショートカット</h2>
+      <div
+        className="bg-[var(--bg-elevated)] border border-[var(--border-subtle)] rounded-[var(--radius-xl)] px-[var(--space-6)] py-[var(--space-5)] min-w-[320px] max-w-[480px] w-[90%] shadow-[var(--shadow-xl)]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-[var(--space-4)]">
+          <h2 className="m-0 text-[var(--font-size-md)] font-semibold">キーボードショートカット</h2>
           <button
             type="button"
-            className="shortcuts-help-close"
+            className="bg-transparent border-none text-[var(--fg-muted)] text-[1rem] cursor-pointer px-[var(--space-2)] py-[2px] rounded-[var(--radius-sm)] transition-[color,background] duration-100 hover:text-[var(--fg-primary)] hover:bg-[var(--bg-overlay)] focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2"
             onClick={onClose}
             aria-label="閉じる"
           >
             ✕
           </button>
         </div>
-        <table className="shortcuts-help-table">
+        <table className="border-collapse w-full text-[var(--font-size-base)]">
           <tbody>
             {SHORTCUTS.map(({ key, label }) => (
               <tr key={key}>
-                <td>
+                <td className="py-[5px] px-[var(--space-2)] align-middle w-[40%] whitespace-nowrap">
                   <kbd>{key}</kbd>
                 </td>
-                <td>{label}</td>
+                <td className="py-[5px] px-[var(--space-2)] align-middle">{label}</td>
               </tr>
             ))}
           </tbody>

--- a/apps/web/client/components/Toast.tsx
+++ b/apps/web/client/components/Toast.tsx
@@ -5,18 +5,31 @@ interface Props {
   onDismiss: (id: string) => void;
 }
 
+// kind に応じたボーダー色。success / error のみ特殊色、それ以外は subtle
+function kindBorderClass(kind: ToastData["kind"]) {
+  if (kind === "success") return "border-[var(--success)]";
+  if (kind === "error") return "border-[var(--danger)]";
+  return "border-[var(--border-subtle)]";
+}
+
+function kindMsgClass(kind: ToastData["kind"]) {
+  if (kind === "success") return "text-[var(--success)]";
+  if (kind === "error") return "text-[var(--danger)]";
+  return "text-[var(--fg-primary)]";
+}
+
 export function Toast({ toast, onDismiss }: Props) {
   return (
     <div
-      className={`toast toast-${toast.kind}`}
+      className={`flex items-center gap-[var(--space-3)] px-[var(--space-4)] py-[var(--space-3)] bg-[var(--bg-elevated)] border rounded-[var(--radius-lg)] shadow-[var(--shadow-lg)] text-[var(--font-size-base)] min-w-[220px] max-w-[360px] pointer-events-auto [animation:toast-in_0.2s_ease] ${kindBorderClass(toast.kind)}`}
       role="status"
       aria-live="polite"
       aria-atomic="true"
     >
-      <span className="toast-msg">{toast.msg}</span>
+      <span className={`flex-1 ${kindMsgClass(toast.kind)}`}>{toast.msg}</span>
       <button
         type="button"
-        className="toast-close"
+        className="shrink-0 bg-transparent border-none text-[var(--fg-muted)] text-[var(--font-size-sm)] font-[inherit] cursor-pointer p-0 px-[2px] leading-none opacity-70 transition-opacity duration-100 hover:opacity-100 hover:text-[var(--fg-primary)]"
         aria-label="閉じる"
         onClick={() => onDismiss(toast.id)}
       >

--- a/apps/web/client/components/ToastContainer.tsx
+++ b/apps/web/client/components/ToastContainer.tsx
@@ -6,7 +6,10 @@ export function ToastContainer() {
   if (!ctx || ctx.toasts.length === 0) return null;
 
   return (
-    <div className="toast-container" aria-label="通知">
+    <div
+      className="fixed top-[calc(var(--header-height)+var(--space-3))] right-[var(--space-4)] z-[200] flex flex-col gap-[var(--space-2)] pointer-events-none"
+      aria-label="通知"
+    >
       {ctx.toasts.map((toast) => (
         <Toast key={toast.id} toast={toast} onDismiss={ctx.dismiss} />
       ))}

--- a/apps/web/tests/client/ShareButtons.test.tsx
+++ b/apps/web/tests/client/ShareButtons.test.tsx
@@ -41,18 +41,16 @@ describe("ShareButtons", () => {
     expect(screen.getByRole("button", { name: /URLをコピー/i })).toBeTruthy();
   });
 
-  it("copy button click succeeds and shows copied state", async () => {
+  it("copy button click succeeds and shows copied state via aria-label", async () => {
     // happy-dom は Clipboard API を実装しているため writeText は実際に呼ばれる。
-    // spy が happy-dom の内部 window コンテキストを越えられないため、
-    // クリック後に "Copied" 状態が表示されることで動作を確認する。
+    // コピー後は aria-label が "コピー済み" に変わることで copied 状態を確認する。
     const user = userEvent.setup();
     render(<ShareButtons url={TEST_URL} title={TEST_TITLE} />);
 
     const copyBtn = screen.getByRole("button", { name: /URLをコピー/i });
     await user.click(copyBtn);
 
-    // writeText 成功後に aria-label が変わることで "copied" 状態を検証
-    // (SVG のみ表示のため button の aria-label は変わらない; class 変化で確認)
-    expect(copyBtn.classList.contains("share-button-copied")).toBe(true);
+    // writeText 成功後に aria-label が "コピー済み" になることで copied 状態を確認
+    expect(screen.getByRole("button", { name: "コピー済み" })).toBeTruthy();
   });
 });

--- a/apps/web/tests/client/useToast.test.tsx
+++ b/apps/web/tests/client/useToast.test.tsx
@@ -96,16 +96,16 @@ describe("useToast / ToastContainer", () => {
       }
     });
 
-    // .toast-msg 要素のみで判定 (ボタンのテキストは除外)
-    const toastMsgs = document.querySelectorAll(".toast-msg");
-    const msgs = [...toastMsgs].map((el) => el.textContent);
+    // role="status" を持つ Toast 要素のみで判定 (トリガーボタンは除外)
+    const toasts = screen.getAllByRole("status");
+    const msgs = toasts.map((el) => el.textContent ?? "");
 
     // 最新 3 件のみ残り、最古の「通知1」は消える
-    expect(msgs).not.toContain("通知1");
-    expect(msgs).toContain("通知2");
-    expect(msgs).toContain("通知3");
-    expect(msgs).toContain("通知4");
-    expect(toastMsgs).toHaveLength(3);
+    expect(msgs.some((m) => m.includes("通知1"))).toBe(false);
+    expect(msgs.some((m) => m.includes("通知2"))).toBe(true);
+    expect(msgs.some((m) => m.includes("通知3"))).toBe(true);
+    expect(msgs.some((m) => m.includes("通知4"))).toBe(true);
+    expect(toasts).toHaveLength(3);
   });
 
   it("toast 要素に aria-live='polite' と role='status' が設定されている", () => {


### PR DESCRIPTION
## Summary
- `Toast.tsx`: `toast`/`toast-*` class から Tailwind utility class に移行
- `ToastContainer.tsx`: `toast-container` class を utility に移行
- `BookmarkButton.tsx`: `bookmark-button` class を utility に移行
- `ShareButtons.tsx`: `share-button`/`share-button-copied` class を utility に移行。copied 状態は aria-label で表現
- `HelpModal.tsx`: `help-overlay`/`help-modal` 等のレガシークラスを utility に移行
- `ShortcutsHelp.tsx`: `shortcuts-help-overlay`/`shortcuts-help-modal` 等のレガシークラスを utility に移行
- `index.css` のレガシー CSS は最終 cleanup PR で削除予定

## Bundle size
| | CSS raw | CSS gzip | JS raw | JS gzip |
|---|---|---|---|---|
| Before (main) | 46.94 kB | 8.54 kB | 247.63 kB | 75.93 kB |
| After | 51.67 kB | 9.14 kB | 250.25 kB | 76.49 kB |

CSS は +4.73 kB raw / +0.60 kB gzip。utility class の追加生成によるもので、legacy CSS 削除後は逆に縮小予定。

Closes #248
Refs #245

## Test plan
- [x] pnpm build (exit 0)
- [x] pnpm test (507 passed)
- [x] pnpm run check (lint 警告は main ブランチから継続する既存の問題のみ)