### PR TITLE
refactor(web): migrate article/detail pages to tailwind (batch C)

### DIFF
--- a/apps/web/client/components/ArticleCard.tsx
+++ b/apps/web/client/components/ArticleCard.tsx
@@ -29,6 +29,14 @@ const CATEGORY_ICON: Record<string, string> = {
   zenn: "📝",
 };
 
+// カテゴリバッジの色: CSS custom properties を任意プロパティ記法で参照
+const CATEGORY_BADGE_CLASS: Record<string, string> = {
+  bigtech: "bg-[var(--cat-bigtech-bg)] text-[var(--cat-bigtech)]",
+  ai: "bg-[var(--cat-ai-bg)] text-[var(--cat-ai)]",
+  jp: "bg-[var(--cat-jp-bg)] text-[var(--cat-jp)]",
+  zenn: "bg-[var(--cat-zenn-bg)] text-[var(--cat-zenn)]",
+};
+
 function formatDate(iso: string): string {
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return iso;
@@ -72,28 +80,32 @@ export function ArticleCard({
     }
   }, [isSelected]);
 
+  const catBadgeClass =
+    CATEGORY_BADGE_CLASS[article.category] ?? "bg-[var(--accent-soft)] text-[var(--accent)]";
+
   return (
     <article
       ref={ref}
-      className={`article-card${read ? " read" : ""}${isSelected ? " is-selected" : ""}`}
+      className={`grid gap-[var(--space-2)] p-[var(--space-4)] bg-[var(--bg-elevated)] border border-[var(--border-subtle)] rounded-[var(--radius-lg)] transition-[border-color,box-shadow,transform] duration-200 hover:border-[var(--accent)] hover:shadow-[var(--shadow-md)] hover:-translate-y-0.5 focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2${read ? " opacity-55 hover:opacity-80" : ""}${isSelected ? " border-[var(--accent)] bg-[var(--accent-soft)] outline-2 outline-[var(--accent)] outline-offset-2" : ""}`}
       data-article-id={article.id}
       tabIndex={-1}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >
-      <div className="article-card-title-row">
+      {/* カードヘッダ行 (タイトル + アクションボタン) */}
+      <div className="flex items-start gap-[var(--space-2)]">
         <a
           href={safeHref(article.url)}
           target="_blank"
           rel="noopener noreferrer"
-          className="title"
+          className="flex-1 text-[var(--font-size-md)] font-semibold leading-[var(--line-height-tight)] text-[var(--fg-primary)] transition-colors duration-100 hover:text-[var(--accent)] hover:underline"
           onClick={() => markRead(article.id)}
         >
           {highlight(article.title, q)}
         </a>
         <button
           type="button"
-          className="star-button"
+          className="shrink-0 px-[var(--space-1)] py-0.5 bg-transparent text-[var(--fg-muted)] border-none text-[1rem] font-[inherit] cursor-pointer leading-none opacity-45 transition-[opacity,color] duration-100 hover:opacity-100 hover:text-[#d29922] aria-pressed:opacity-100 aria-pressed:text-[#d29922] focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2 focus-visible:rounded-[var(--radius-sm)]"
           onClick={() => toggleStar(article.id)}
           aria-label={starred ? "スターを外す" : "スターを付ける"}
           aria-pressed={starred}
@@ -105,17 +117,18 @@ export function ArticleCard({
         {hovered && (
           <button
             type="button"
-            className="read-toggle"
+            className="shrink-0 px-[var(--space-2)] py-0.5 bg-[var(--bg-overlay)] text-[var(--fg-muted)] border border-[var(--border-subtle)] rounded-[var(--radius-sm)] text-[var(--font-size-xs)] font-[inherit] cursor-pointer whitespace-nowrap opacity-75 transition-[opacity,border-color,color] duration-100 hover:opacity-100 hover:text-[var(--fg-primary)] hover:border-[var(--accent)] focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2"
             onClick={() => (read ? markUnread(article.id) : markRead(article.id))}
           >
             {read ? "未読に戻す" : "既読にする"}
           </button>
         )}
       </div>
-      <div className="meta">
+      {/* メタ行 */}
+      <div className="flex flex-wrap items-center gap-[var(--space-2)] text-[var(--fg-muted)] text-[var(--font-size-sm)]">
         <button
           type="button"
-          className={`badge cat-${article.category} badge-clickable`}
+          className={`inline-flex items-center px-[var(--space-2)] py-0.5 rounded-full text-[var(--font-size-xs)] font-semibold uppercase tracking-[0.04em] border-none font-[inherit] leading-[var(--line-height-tight)] whitespace-nowrap align-middle cursor-pointer transition-[opacity,filter] duration-100 hover:brightness-110 hover:opacity-90 focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2 ${catBadgeClass}`}
           onClick={() => onFilterByCategory(article.category)}
           title={`${CATEGORY_LABEL[article.category] ?? article.category} で絞り込む`}
         >
@@ -126,7 +139,7 @@ export function ArticleCard({
         </button>
         <button
           type="button"
-          className="feed-name feed-name-clickable"
+          className="text-[var(--fg-primary)] font-medium border-none bg-transparent font-[inherit] text-inherit p-0 cursor-pointer transition-colors duration-100 hover:text-[var(--accent)] hover:underline focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2 focus-visible:rounded-[var(--radius-sm)]"
           onClick={() => onFilterByFeedId(article.feed_id)}
           title={`${article.feed_name ?? article.feed_id} で絞り込む`}
         >
@@ -140,7 +153,7 @@ export function ArticleCard({
             {onNavigateToAuthor ? (
               <button
                 type="button"
-                className="author-name author-name-clickable"
+                className="text-[var(--fg-muted)] border-none bg-transparent font-[inherit] text-inherit p-0 cursor-pointer transition-colors duration-100 hover:text-[var(--accent)] hover:underline focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2"
                 onClick={() => {
                   if (article.author) onNavigateToAuthor(article.author);
                 }}
@@ -149,12 +162,16 @@ export function ArticleCard({
                 {article.author}
               </button>
             ) : (
-              <span className="author-name">{article.author}</span>
+              <span className="text-[var(--fg-muted)]">{article.author}</span>
             )}
           </>
         )}
       </div>
-      {article.summary && <p className="summary">{highlight(article.summary, q)}</p>}
+      {article.summary && (
+        <p className="text-[var(--fg-secondary)] text-[var(--font-size-sm)] leading-[var(--line-height-relaxed)] mt-0.5 mb-0 [-webkit-line-clamp:3] [display:-webkit-box] [-webkit-box-orient:vertical] overflow-hidden">
+          {highlight(article.summary, q)}
+        </p>
+      )}
       <ShareButtons url={article.url} title={article.title} />
     </article>
   );

--- a/apps/web/client/components/ArticleList.tsx
+++ b/apps/web/client/components/ArticleList.tsx
@@ -19,7 +19,7 @@ export function ArticleList({
   q,
 }: Props) {
   return (
-    <div className="article-list">
+    <div className="grid gap-[var(--space-3)]">
       {articles.map((a, i) => (
         <ArticleCard
           key={a.id}

--- a/apps/web/client/components/AuthorDetail.tsx
+++ b/apps/web/client/components/AuthorDetail.tsx
@@ -22,37 +22,61 @@ export function AuthorDetail({ author, onBack, onFilterByCategory, onFilterByFee
   const { articles, isLoading, error, hasMore, loadMore, loadingMore } = useAuthorArticles(author);
 
   return (
-    <div className="author-detail">
-      <div className="author-detail-header">
-        <button type="button" className="back-button" onClick={onBack}>
+    <div className="py-[var(--space-2)]">
+      <div className="flex flex-col gap-[var(--space-3)] mb-[var(--space-6)]">
+        {/* 戻るボタン */}
+        <button
+          type="button"
+          className="inline-flex items-center gap-[var(--space-1)] bg-transparent border-none text-[var(--accent)] cursor-pointer text-[var(--font-size-sm)] font-[inherit] py-[var(--space-1)] px-0 w-fit transition-opacity duration-100 hover:underline hover:opacity-85 focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2 focus-visible:rounded-[var(--radius-sm)]"
+          onClick={onBack}
+        >
           ← 一覧に戻る
         </button>
 
         {/* 著者プロファイルカード */}
-        <div className="author-detail-profile">
-          <div className="author-detail-avatar" aria-hidden="true">
+        <div className="flex items-center gap-[var(--space-4)] p-[var(--space-5)] bg-[var(--bg-elevated)] border border-[var(--border-subtle)] rounded-[var(--radius-xl)]">
+          <div
+            className="w-[52px] h-[52px] rounded-full bg-[var(--accent-soft)] border-2 border-[var(--accent)] flex items-center justify-center text-[1.4rem] font-bold text-[var(--accent)] shrink-0"
+            aria-hidden="true"
+          >
             {getInitial(author)}
           </div>
-          <div className="author-detail-info">
-            <h1 className="author-detail-name">{author}</h1>
+          <div className="flex flex-col gap-1">
+            <h1 className="m-0 text-[var(--font-size-xl)] font-bold leading-[var(--line-height-tight)]">
+              {author}
+            </h1>
             {!isLoading && !error && (
-              <span className="author-detail-count">{articles.length} 件の記事</span>
+              <span className="text-[var(--font-size-sm)] text-[var(--fg-muted)] font-medium">
+                {articles.length} 件の記事
+              </span>
             )}
           </div>
         </div>
       </div>
 
-      {isLoading && <div className="loader">読み込み中…</div>}
-      {error && !isLoading && <div className="error">取得エラー: {error}</div>}
+      {isLoading && (
+        <div className="text-center text-[var(--fg-muted)] py-[var(--space-8)] px-[var(--space-3)] border border-dashed border-[var(--border-subtle)] rounded-[var(--radius-lg)] mt-[var(--space-4)] text-[var(--font-size-base)] leading-[var(--line-height-relaxed)]">
+          読み込み中…
+        </div>
+      )}
+      {error && !isLoading && (
+        <div className="text-center text-[var(--danger)] py-[var(--space-8)] px-[var(--space-3)] border border-[rgba(207,34,46,0.3)] rounded-[var(--radius-lg)] mt-[var(--space-4)] text-[var(--font-size-base)] leading-[var(--line-height-relaxed)] bg-[var(--danger-soft)]">
+          取得エラー: {error}
+        </div>
+      )}
       {!isLoading && !error && articles.length === 0 && (
-        <div className="empty">
-          <span className="empty-icon">📭</span>
-          <div className="empty-title">記事がありません</div>
+        <div className="text-center text-[var(--fg-muted)] py-[var(--space-8)] px-[var(--space-3)] border border-dashed border-[var(--border-subtle)] rounded-[var(--radius-lg)] mt-[var(--space-4)] text-[var(--font-size-base)] leading-[var(--line-height-relaxed)]">
+          <span className="text-[2.5rem] block mb-[var(--space-3)] leading-none" aria-hidden="true">
+            📭
+          </span>
+          <div className="text-[var(--font-size-md)] font-semibold text-[var(--fg-secondary)] mb-[var(--space-1)]">
+            記事がありません
+          </div>
         </div>
       )}
 
       {articles.length > 0 && (
-        <div className="article-list">
+        <div className="grid gap-[var(--space-3)]">
           {articles.map((a) => (
             <ArticleCard
               key={a.id}
@@ -65,7 +89,12 @@ export function AuthorDetail({ author, onBack, onFilterByCategory, onFilterByFee
       )}
 
       {hasMore && (
-        <button type="button" className="load-more" onClick={loadMore} disabled={loadingMore}>
+        <button
+          type="button"
+          className="block mx-auto mt-[var(--space-5)] px-[var(--space-6)] py-[var(--space-2)] bg-[var(--bg-overlay)] text-[var(--fg-primary)] border border-[var(--border-subtle)] rounded-[var(--radius-lg)] cursor-pointer text-[var(--font-size-sm)] font-[inherit] font-medium transition-[border-color,background] duration-100 hover:border-[var(--accent)] hover:bg-[var(--bg-elevated)] disabled:opacity-50 disabled:cursor-progress focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2"
+          onClick={loadMore}
+          disabled={loadingMore}
+        >
           {loadingMore ? "読み込み中…" : "もっと見る"}
         </button>
       )}

--- a/apps/web/client/components/CategoriesOverview.tsx
+++ b/apps/web/client/components/CategoriesOverview.tsx
@@ -21,6 +21,22 @@ const CATEGORY_META: Record<string, { icon: string; description: string }> = {
   zenn: { icon: "📝", description: "Zenn のトレンド記事" },
 };
 
+// カテゴリカードの左ボーダー色: CSS custom properties を任意プロパティ記法で参照
+const CATEGORY_BORDER_CLASS: Record<string, string> = {
+  bigtech: "border-l-[4px] border-l-[var(--cat-bigtech)]",
+  ai: "border-l-[4px] border-l-[var(--cat-ai)]",
+  jp: "border-l-[4px] border-l-[var(--cat-jp)]",
+  zenn: "border-l-[4px] border-l-[var(--cat-zenn)]",
+};
+
+// カテゴリバッジの色
+const CATEGORY_BADGE_CLASS: Record<string, string> = {
+  bigtech: "bg-[var(--cat-bigtech-bg)] text-[var(--cat-bigtech)]",
+  ai: "bg-[var(--cat-ai-bg)] text-[var(--cat-ai)]",
+  jp: "bg-[var(--cat-jp-bg)] text-[var(--cat-jp)]",
+  zenn: "bg-[var(--cat-zenn-bg)] text-[var(--cat-zenn)]",
+};
+
 interface Props {
   onSelectCategory: (id: FeedCategory) => void;
 }
@@ -29,61 +45,85 @@ export function CategoriesOverview({ onSelectCategory }: Props) {
   const { categories, isLoading, error } = useCategories();
 
   if (isLoading) {
-    return <div className="loader">読み込み中…</div>;
+    return (
+      <div className="text-center text-[var(--fg-muted)] py-[var(--space-8)] px-[var(--space-3)] border border-dashed border-[var(--border-subtle)] rounded-[var(--radius-lg)] mt-[var(--space-4)] text-[var(--font-size-base)] leading-[var(--line-height-relaxed)]">
+        読み込み中…
+      </div>
+    );
   }
 
   if (error) {
-    return <div className="error">取得エラー: {error}</div>;
+    return (
+      <div className="text-center text-[var(--danger)] py-[var(--space-8)] px-[var(--space-3)] border border-[rgba(207,34,46,0.3)] rounded-[var(--radius-lg)] mt-[var(--space-4)] text-[var(--font-size-base)] leading-[var(--line-height-relaxed)] bg-[var(--danger-soft)]">
+        取得エラー: {error}
+      </div>
+    );
   }
 
   if (!categories) return null;
 
   return (
-    <div className="categories-overview">
-      <h2 className="categories-overview-title">カテゴリ一覧</h2>
-      <div className="categories-grid">
+    <div className="py-[var(--space-2)]">
+      <h2 className="text-[var(--font-size-xl)] font-bold m-0 mb-[var(--space-5)] tracking-[-0.01em]">
+        カテゴリ一覧
+      </h2>
+      <div className="grid grid-cols-1 gap-[var(--space-4)] sm:grid-cols-2">
         {categories.map((cat) => {
           const meta = CATEGORY_META[cat.id];
+          const borderClass = CATEGORY_BORDER_CLASS[cat.id] ?? "";
+          const badgeClass =
+            CATEGORY_BADGE_CLASS[cat.id] ?? "bg-[var(--accent-soft)] text-[var(--accent)]";
           return (
             <button
               key={cat.id}
               type="button"
-              className={`category-card cat-${cat.id}`}
+              className={`relative flex flex-col gap-[var(--space-3)] p-[var(--space-5)] bg-[var(--bg-elevated)] border border-[var(--border-subtle)] rounded-[var(--radius-xl)] overflow-hidden cursor-pointer text-left text-[var(--fg-primary)] text-[var(--font-size-base)] font-[inherit] transition-[box-shadow,transform,border-color] duration-200 hover:shadow-[var(--shadow-lg)] hover:-translate-y-[3px] focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2 ${borderClass}`}
               onClick={() => onSelectCategory(cat.id)}
             >
-              <div className="category-card-header">
-                <span className="category-card-icon" aria-hidden="true">
+              {/* カードヘッダ (アイコン + タイトル) */}
+              <div className="flex items-center gap-[var(--space-3)]">
+                <span className="text-[2rem] leading-none shrink-0" aria-hidden="true">
                   {meta?.icon ?? "📁"}
                 </span>
-                <div className="category-card-title">
-                  <span className="category-card-name">{cat.label}</span>
-                  <span className={`category-card-badge badge cat-${cat.id}`}>{cat.id}</span>
+                <div className="flex flex-col gap-[3px]">
+                  <span className="text-[var(--font-size-lg)] font-bold leading-[var(--line-height-tight)]">
+                    {cat.label}
+                  </span>
+                  <span
+                    className={`inline-flex items-center px-[var(--space-2)] py-0.5 rounded-full text-[var(--font-size-xs)] font-semibold uppercase tracking-[0.04em] border-none leading-[var(--line-height-tight)] whitespace-nowrap self-start ${badgeClass}`}
+                  >
+                    {cat.id}
+                  </span>
                 </div>
               </div>
               {meta?.description && (
-                <p
-                  style={{
-                    margin: 0,
-                    fontSize: "var(--font-size-sm)",
-                    color: "var(--fg-muted)",
-                    lineHeight: "var(--line-height-relaxed)",
-                  }}
-                >
+                <p className="m-0 text-[var(--font-size-sm)] text-[var(--fg-muted)] leading-[var(--line-height-relaxed)]">
                   {meta.description}
                 </p>
               )}
-              <div className="category-card-stats">
-                <div className="category-card-stat">
-                  <span className="category-card-stat-label">フィード数</span>
-                  <span className="category-card-stat-value">{cat.feeds_count}</span>
+              {/* 統計情報 */}
+              <div className="flex flex-col gap-[var(--space-2)] pt-[var(--space-2)] border-t border-[var(--border-subtle)]">
+                <div className="flex justify-between items-baseline gap-[var(--space-2)]">
+                  <span className="text-[var(--fg-muted)] text-[var(--font-size-sm)]">
+                    フィード数
+                  </span>
+                  <span className="font-semibold text-[var(--font-size-base)]">
+                    {cat.feeds_count}
+                  </span>
                 </div>
-                <div className="category-card-stat">
-                  <span className="category-card-stat-label">30 日の記事数</span>
-                  <span className="category-card-stat-value">{cat.articles_30d}</span>
+                <div className="flex justify-between items-baseline gap-[var(--space-2)]">
+                  <span className="text-[var(--fg-muted)] text-[var(--font-size-sm)]">
+                    30 日の記事数
+                  </span>
+                  <span className="font-semibold text-[var(--font-size-base)]">
+                    {cat.articles_30d}
+                  </span>
                 </div>
-                <div className="category-card-stat">
-                  <span className="category-card-stat-label">最終公開</span>
-                  <span className="category-card-stat-value">
+                <div className="flex justify-between items-baseline gap-[var(--space-2)]">
+                  <span className="text-[var(--fg-muted)] text-[var(--font-size-sm)]">
+                    最終公開
+                  </span>
+                  <span className="font-semibold text-[var(--font-size-base)]">
                     {cat.last_published_at ? formatRelative(cat.last_published_at) : "—"}
                   </span>
                 </div>

--- a/apps/web/client/components/FeedDetail.tsx
+++ b/apps/web/client/components/FeedDetail.tsx
@@ -18,6 +18,14 @@ const CATEGORY_ICON: Record<string, string> = {
   zenn: "📝",
 };
 
+// カテゴリバッジの色: CSS custom properties を任意プロパティ記法で参照
+const CATEGORY_BADGE_CLASS: Record<string, string> = {
+  bigtech: "bg-[var(--cat-bigtech-bg)] text-[var(--cat-bigtech)]",
+  ai: "bg-[var(--cat-ai-bg)] text-[var(--cat-ai)]",
+  jp: "bg-[var(--cat-jp-bg)] text-[var(--cat-jp)]",
+  zenn: "bg-[var(--cat-zenn-bg)] text-[var(--cat-zenn)]",
+};
+
 interface Props {
   feedId: string;
   onBack: () => void;
@@ -34,6 +42,14 @@ function getFaviconUrl(feedUrl: string): string {
     return "";
   }
 }
+
+// ローダー・エラー・空状態の共通クラス
+const loaderClass =
+  "text-center text-[var(--fg-muted)] py-[var(--space-8)] px-[var(--space-3)] border border-dashed border-[var(--border-subtle)] rounded-[var(--radius-lg)] mt-[var(--space-4)] text-[var(--font-size-base)] leading-[var(--line-height-relaxed)]";
+const errorClass =
+  "text-center text-[var(--danger)] py-[var(--space-8)] px-[var(--space-3)] border border-[rgba(207,34,46,0.3)] rounded-[var(--radius-lg)] mt-[var(--space-4)] text-[var(--font-size-base)] leading-[var(--line-height-relaxed)] bg-[var(--danger-soft)]";
+const backBtnClass =
+  "inline-flex items-center gap-[var(--space-1)] bg-transparent border-none text-[var(--accent)] cursor-pointer text-[var(--font-size-sm)] font-[inherit] py-[var(--space-1)] px-0 mb-[var(--space-4)] transition-opacity duration-100 hover:underline hover:opacity-85 focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2 focus-visible:rounded-[var(--radius-sm)]";
 
 export function FeedDetail({ feedId, onBack, onFilterByFeedId, onFilterByCategory }: Props) {
   // feed メタ (name, url, category, lang, articles_30d) のみ useFeedDetail で取得
@@ -54,27 +70,27 @@ export function FeedDetail({ feedId, onBack, onFilterByFeedId, onFilterByCategor
   const error = metaError;
 
   if (isLoading) {
-    return <div className="loader">読み込み中…</div>;
+    return <div className={loaderClass}>読み込み中…</div>;
   }
 
   if (error === "feed_not_found") {
     return (
-      <div className="feed-detail">
-        <button type="button" className="feed-detail-back" onClick={onBack}>
+      <div className="py-[var(--space-2)]">
+        <button type="button" className={backBtnClass} onClick={onBack}>
           ← 一覧に戻る
         </button>
-        <div className="error">フィードが見つかりません</div>
+        <div className={errorClass}>フィードが見つかりません</div>
       </div>
     );
   }
 
   if (error) {
     return (
-      <div className="feed-detail">
-        <button type="button" className="feed-detail-back" onClick={onBack}>
+      <div className="py-[var(--space-2)]">
+        <button type="button" className={backBtnClass} onClick={onBack}>
           ← 一覧に戻る
         </button>
-        <div className="error">取得エラー: {error}</div>
+        <div className={errorClass}>取得エラー: {error}</div>
       </div>
     );
   }
@@ -82,59 +98,86 @@ export function FeedDetail({ feedId, onBack, onFilterByFeedId, onFilterByCategor
   if (!feed) return null;
 
   const faviconUrl = getFaviconUrl(feed.url);
+  const catBadgeClass =
+    CATEGORY_BADGE_CLASS[feed.category] ?? "bg-[var(--accent-soft)] text-[var(--accent)]";
 
   return (
-    <div className="feed-detail">
-      <button type="button" className="feed-detail-back" onClick={onBack}>
+    <div className="py-[var(--space-2)]">
+      <button type="button" className={backBtnClass} onClick={onBack}>
         ← 一覧に戻る
       </button>
 
-      <section className="feed-detail-info">
-        <div className="feed-detail-header">
+      {/* フィードメタ情報 */}
+      <section className="bg-[var(--bg-elevated)] border border-[var(--border-subtle)] rounded-[var(--radius-xl)] p-[var(--space-5)] mb-[var(--space-6)]">
+        <div className="flex items-center gap-[var(--space-3)] mb-[var(--space-3)]">
           {/* favicon または プレースホルダー */}
           {faviconUrl && !faviconError ? (
             <img
               src={faviconUrl}
               alt=""
-              className="feed-detail-favicon"
+              className="w-8 h-8 rounded-[var(--radius-sm)] shrink-0 object-contain bg-[var(--bg-overlay)]"
               onError={() => setFaviconError(true)}
               aria-hidden="true"
             />
           ) : (
-            <div className="feed-detail-favicon-placeholder" aria-hidden="true">
+            <div
+              className="w-8 h-8 rounded-[var(--radius-sm)] shrink-0 bg-[var(--bg-overlay)] border border-[var(--border-subtle)] flex items-center justify-center text-[1.1rem]"
+              aria-hidden="true"
+            >
               {CATEGORY_ICON[feed.category] ?? "📰"}
             </div>
           )}
-          <h2 className="feed-detail-name">{feed.name}</h2>
+          <h2 className="m-0 text-[var(--font-size-xl)] font-bold leading-[var(--line-height-tight)]">
+            {feed.name}
+          </h2>
         </div>
-        <div className="feed-detail-meta">
-          <a href={feed.url} target="_blank" rel="noopener noreferrer" className="feed-detail-url">
+        <div className="flex items-center gap-[var(--space-2)] flex-wrap mb-[var(--space-3)]">
+          <a
+            href={feed.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[var(--font-size-sm)] break-all text-[var(--fg-muted)]"
+          >
             {feed.url}
           </a>
-          <span className={`badge cat-${feed.category}`}>
+          <span
+            className={`inline-flex items-center px-[var(--space-2)] py-0.5 rounded-full text-[var(--font-size-xs)] font-semibold uppercase tracking-[0.04em] border-none font-[inherit] leading-[var(--line-height-tight)] whitespace-nowrap ${catBadgeClass}`}
+          >
             <span aria-hidden="true" style={{ marginRight: "3px" }}>
               {CATEGORY_ICON[feed.category] ?? ""}
             </span>
             {CATEGORY_LABEL[feed.category] ?? feed.category}
           </span>
-          <span className="feed-detail-lang">{feed.lang.toUpperCase()}</span>
+          <span className="text-[var(--font-size-xs)] bg-[var(--bg-overlay)] border border-[var(--border-subtle)] rounded-[var(--radius-sm)] px-[var(--space-2)] py-0.5 text-[var(--fg-muted)] font-medium">
+            {feed.lang.toUpperCase()}
+          </span>
         </div>
-        <div className="feed-detail-stats">
-          <span className="feed-detail-stat-label">30 日の記事数:</span>
-          <span className="feed-detail-stat-value">{feed.articles_30d}</span>
+        <div className="flex items-center gap-[var(--space-2)] text-[var(--font-size-base)]">
+          <span className="text-[var(--fg-muted)]">30 日の記事数:</span>
+          <span className="font-semibold">{feed.articles_30d}</span>
         </div>
       </section>
 
-      <section className="feed-detail-articles">
-        <h3 className="feed-detail-articles-title">直近の記事</h3>
-        {articlesError && <div className="error">取得エラー: {articlesError}</div>}
+      {/* 記事一覧 */}
+      <section>
+        <h3 className="text-[var(--font-size-md)] font-semibold m-0 mb-[var(--space-3)] text-[var(--fg-muted)]">
+          直近の記事
+        </h3>
+        {articlesError && <div className={errorClass}>取得エラー: {articlesError}</div>}
         {!articlesError && articles.length === 0 ? (
-          <div className="empty">
-            <span className="empty-icon">📭</span>
-            <div className="empty-title">記事がありません</div>
+          <div className={loaderClass}>
+            <span
+              className="text-[2.5rem] block mb-[var(--space-3)] leading-none"
+              aria-hidden="true"
+            >
+              📭
+            </span>
+            <div className="text-[var(--font-size-md)] font-semibold text-[var(--fg-secondary)] mb-[var(--space-1)]">
+              記事がありません
+            </div>
           </div>
         ) : (
-          <div className="article-list">
+          <div className="grid gap-[var(--space-3)]">
             {articles.map((a) => (
               <ArticleCard
                 key={a.id}
@@ -146,7 +189,12 @@ export function FeedDetail({ feedId, onBack, onFilterByFeedId, onFilterByCategor
           </div>
         )}
         {hasMore && (
-          <button type="button" className="load-more" onClick={loadMore} disabled={loadingMore}>
+          <button
+            type="button"
+            className="block mx-auto mt-[var(--space-5)] px-[var(--space-6)] py-[var(--space-2)] bg-[var(--bg-overlay)] text-[var(--fg-primary)] border border-[var(--border-subtle)] rounded-[var(--radius-lg)] cursor-pointer text-[var(--font-size-sm)] font-[inherit] font-medium transition-[border-color,background] duration-100 hover:border-[var(--accent)] hover:bg-[var(--bg-elevated)] disabled:opacity-50 disabled:cursor-progress focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2"
+            onClick={loadMore}
+            disabled={loadingMore}
+          >
             {loadingMore ? "読み込み中…" : "もっと見る"}
           </button>
         )}

--- a/apps/web/tests/client/ArticleCard.test.tsx
+++ b/apps/web/tests/client/ArticleCard.test.tsx
@@ -33,23 +33,24 @@ describe("ArticleCard", () => {
     expect(screen.getByText("Sample Article Title")).toBeTruthy();
   });
 
-  it("applies read class when isRead returns true", () => {
+  it("applies dim style when isRead returns true", () => {
     // localStorage に id=1 を既読として設定してから描画する
     localStorage.setItem("tnb-read-articles", JSON.stringify([1]));
     const { container } = render(
       <ArticleCard article={baseArticle} onFilterByCategory={noop} onFilterByFeedId={noop} />,
     );
     const article = container.querySelector("article");
-    expect(article?.className).toContain("read");
+    // Tailwind 移行で .read クラス → opacity-55 utility に変更
+    expect(article?.className).toContain("opacity-55");
   });
 
-  it("does not apply read class for unread article", () => {
+  it("does not dim unread article", () => {
     const unreadArticle = { ...baseArticle, id: 99 };
     const { container } = render(
       <ArticleCard article={unreadArticle} onFilterByCategory={noop} onFilterByFeedId={noop} />,
     );
     const article = container.querySelector("article");
-    expect(article?.className).not.toContain("read");
+    expect(article?.className).not.toContain("opacity-55");
   });
 
   it("renders the category badge", () => {


### PR DESCRIPTION
## Summary
- `ArticleCard.tsx` — legacy CSS class から Tailwind utility class へ移行
- `ArticleList.tsx` — `article-list` グリッドを `grid gap-[var(--space-3)]` へ移行
- `AuthorDetail.tsx` — プロファイルカード・loader/error/empty 状態・load-more ボタンを移行
- `FeedDetail.tsx` — フィードメタ情報セクション・記事一覧・load-more ボタンを移行
- `CategoriesOverview.tsx` — カテゴリグリッド・カード・バッジを移行
- カテゴリ色は `bg-[var(--cat-bigtech-bg)]` 等の任意プロパティ記法で参照
- `index.css` の legacy CSS は最終 cleanup PR で削除予定

## Bundle size
| | CSS raw | CSS gzip | JS raw | JS gzip |
|---|---|---|---|---|
| Before (main) | 46.94 kB | 8.54 kB | 247.63 kB | 75.93 kB |
| After | 55.77 kB | 9.78 kB | 257.52 kB | 77.14 kB |

> CSS +8.83 kB raw / +1.24 kB gzip、JS +9.89 kB raw / +1.21 kB gzip。
> 増加分は Tailwind が追加生成したユーティリティクラス (legacy CSS は未削除のため一時的な二重保持)。

Closes #250
Refs #245

## Test plan
- [x] pnpm build (success)
- [x] pnpm test (507 passed)
- [x] pnpm format (no issues)