### PR TITLE
refactor(web): migrate filter/search/stats to tailwind (batch B)

### DIFF
--- a/apps/web/client/components/CalendarHeatmap.tsx
+++ b/apps/web/client/components/CalendarHeatmap.tsx
@@ -193,6 +193,7 @@ export function CalendarHeatmap({ days: initialDays = 90 }: Props) {
                     className={`w-[12px] h-[12px] rounded-[2px] transition-opacity duration-100 hover:opacity-80${
                       level >= 0 ? ` ${bgClass}` : " invisible"
                     }`}
+                    data-level={level}
                     aria-label={label || undefined}
                     title={label || undefined}
                     aria-hidden={!cell.inRange}

--- a/apps/web/client/components/CalendarHeatmap.tsx
+++ b/apps/web/client/components/CalendarHeatmap.tsx
@@ -28,6 +28,15 @@ function formatDateLabel(dateStr: string): string {
 
 const DAY_LABELS = ["日", "月", "火", "水", "木", "金", "土"];
 
+// ヒートマップレベル → CSS 変数を任意プロパティ式で参照するマップ
+const LEVEL_BG_CLASSES: Record<number, string> = {
+  0: "bg-[var(--heatmap-l0)]",
+  1: "bg-[var(--heatmap-l1)]",
+  2: "bg-[var(--heatmap-l2)]",
+  3: "bg-[var(--heatmap-l3)]",
+  4: "bg-[var(--heatmap-l4)]",
+};
+
 interface Props {
   days?: Period;
 }
@@ -38,9 +47,13 @@ export function CalendarHeatmap({ days: initialDays = 90 }: Props) {
 
   if (error) {
     return (
-      <section className="stats-section">
-        <h2 className="stats-section-title">活動カレンダー</h2>
-        <p className="error calendar-heatmap-error">ヒートマップを取得できませんでした</p>
+      <section className="p-[var(--space-4)] bg-[var(--bg-elevated)] border border-[var(--border-subtle)] rounded-[var(--radius-lg)]">
+        <h2 className="text-[var(--font-size-sm)] font-semibold text-[var(--fg-muted)] m-0 mb-[var(--space-4)] uppercase tracking-[0.05em]">
+          活動カレンダー
+        </h2>
+        <p className="text-center text-[var(--danger)] p-[var(--space-8)_var(--space-3)] border border-[rgba(207,34,46,0.3)] rounded-[var(--radius-lg)] bg-[var(--danger-soft)] text-[var(--font-size-base)] leading-[var(--line-height-relaxed)] mt-0">
+          ヒートマップを取得できませんでした
+        </p>
       </section>
     );
   }
@@ -99,15 +112,25 @@ export function CalendarHeatmap({ days: initialDays = 90 }: Props) {
   }
 
   return (
-    <section className="stats-section">
-      <div className="calendar-heatmap-header">
-        <h2 className="stats-section-title">活動カレンダー</h2>
-        <div className="calendar-heatmap-period-toggle" role="group" aria-label="表示期間">
+    <section className="p-[var(--space-4)] bg-[var(--bg-elevated)] border border-[var(--border-subtle)] rounded-[var(--radius-lg)]">
+      <div className="flex items-center justify-between flex-wrap gap-[var(--space-2)] mb-[var(--space-3)]">
+        <h2 className="text-[var(--font-size-sm)] font-semibold text-[var(--fg-muted)] m-0 uppercase tracking-[0.05em]">
+          活動カレンダー
+        </h2>
+        <div
+          className="flex gap-[var(--space-1)] border border-[var(--border-subtle)] rounded-[var(--radius-full)] p-[3px] bg-[var(--bg-overlay)]"
+          role="group"
+          aria-label="表示期間"
+        >
           {PERIODS.map((p) => (
             <button
               key={p}
               type="button"
-              className={`calendar-heatmap-period-btn${period === p ? " active" : ""}`}
+              className={`px-[var(--space-3)] py-[3px] border-none rounded-[var(--radius-full)] text-[var(--font-size-sm)] font-[inherit] cursor-pointer transition-[background,color] duration-100 focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2${
+                period === p
+                  ? " bg-[var(--bg-elevated)] text-[var(--accent)] font-semibold shadow-[var(--shadow-sm)]"
+                  : " bg-transparent text-[var(--fg-muted)] hover:text-[var(--fg-primary)]"
+              }`}
               onClick={() => setPeriod(p)}
               aria-pressed={period === p}
             >
@@ -118,29 +141,34 @@ export function CalendarHeatmap({ days: initialDays = 90 }: Props) {
       </div>
 
       {isLoading ? (
-        <div className="loader calendar-heatmap-loader">読み込み中…</div>
+        <div className="text-center text-[var(--fg-muted)] p-[var(--space-4)] border border-dashed border-[var(--border-subtle)] rounded-[var(--radius-lg)] text-[var(--font-size-base)]">
+          読み込み中…
+        </div>
       ) : (
-        <div className="calendar-heatmap-wrapper">
+        <div className="overflow-x-auto pb-[var(--space-1)]">
           {/* 月ラベル行 */}
           <div
-            className="calendar-heatmap-months"
+            className="grid gap-[3px] ml-[24px] mb-[2px]"
             style={{ gridTemplateColumns: `repeat(${totalWeeks}, 1fr)` }}
           >
             {Array.from({ length: totalWeeks }, (_, w) => {
               const label = monthLabels.find((m) => m.weekIndex === w);
               return (
-                <div key={w} className="calendar-heatmap-month-label">
+                <div key={w} className="text-[0.65rem] text-[var(--fg-muted)] whitespace-nowrap">
                   {label?.label ?? ""}
                 </div>
               );
             })}
           </div>
 
-          <div className="calendar-heatmap-body">
+          <div className="flex gap-[var(--space-1)] items-start">
             {/* 曜日ラベル列 */}
-            <div className="calendar-heatmap-days">
+            <div className="grid [grid-template-rows:repeat(7,12px)] gap-[3px] shrink-0 w-[20px]">
               {DAY_LABELS.map((label, i) => (
-                <div key={i} className="calendar-heatmap-day-label">
+                <div
+                  key={i}
+                  className="text-[0.6rem] text-[var(--fg-muted)] leading-[12px] text-right"
+                >
                   {/* 月・水・金のみ表示してスペースを節約する */}
                   {i % 2 === 1 ? label : ""}
                 </div>
@@ -149,7 +177,7 @@ export function CalendarHeatmap({ days: initialDays = 90 }: Props) {
 
             {/* ヒートマップグリッド: 縦 7 行 (曜日) × 横 N 週 */}
             <div
-              className="calendar-heatmap"
+              className="grid [grid-template-rows:repeat(7,12px)] [grid-auto-flow:column] gap-[3px] shrink-0"
               style={{ gridTemplateColumns: `repeat(${totalWeeks}, 1fr)` }}
             >
               {cells.map((cell, idx) => {
@@ -157,11 +185,14 @@ export function CalendarHeatmap({ days: initialDays = 90 }: Props) {
                 const label = cell.dateStr
                   ? `${formatDateLabel(cell.dateStr)}: ${cell.count}件`
                   : "";
+                // inRange でないセルは invisible にする
+                const bgClass = level >= 0 ? (LEVEL_BG_CLASSES[level] ?? "") : "";
                 return (
                   <div
                     key={idx}
-                    className="calendar-heatmap-cell"
-                    data-level={level >= 0 ? level : undefined}
+                    className={`w-[12px] h-[12px] rounded-[2px] transition-opacity duration-100 hover:opacity-80${
+                      level >= 0 ? ` ${bgClass}` : " invisible"
+                    }`}
                     aria-label={label || undefined}
                     title={label || undefined}
                     aria-hidden={!cell.inRange}
@@ -172,12 +203,16 @@ export function CalendarHeatmap({ days: initialDays = 90 }: Props) {
           </div>
 
           {/* 凡例 */}
-          <div className="calendar-heatmap-legend">
-            <span className="calendar-heatmap-legend-label">少</span>
+          <div className="flex items-center gap-[3px] mt-[var(--space-2)] justify-end">
+            <span className="text-[0.65rem] text-[var(--fg-muted)] mx-[2px]">少</span>
             {[0, 1, 2, 3, 4].map((level) => (
-              <div key={level} className="calendar-heatmap-cell" data-level={level} aria-hidden />
+              <div
+                key={level}
+                className={`w-[12px] h-[12px] rounded-[2px] ${LEVEL_BG_CLASSES[level] ?? ""}`}
+                aria-hidden
+              />
             ))}
-            <span className="calendar-heatmap-legend-label">多</span>
+            <span className="text-[0.65rem] text-[var(--fg-muted)] mx-[2px]">多</span>
           </div>
         </div>
       )}

--- a/apps/web/client/components/FilterBar.tsx
+++ b/apps/web/client/components/FilterBar.tsx
@@ -19,6 +19,10 @@ interface Props {
   onClear: () => void;
 }
 
+// select / date-input の共通スタイル
+const inputClass =
+  "px-[var(--space-3)] py-[var(--space-2)] bg-[var(--bg-overlay)] text-[var(--fg-primary)] border border-[var(--border-subtle)] rounded-[var(--radius-md)] text-[var(--font-size-sm)] font-[inherit] cursor-pointer transition-[border-color] duration-100 focus:outline-2 focus:outline-[var(--accent)] focus:outline-offset-2";
+
 export function FilterBar({
   category,
   lang,
@@ -53,7 +57,7 @@ export function FilterBar({
   return (
     <>
       <select
-        className="select"
+        className={`${inputClass} min-w-[130px]`}
         value={category}
         onChange={(e) => onCategoryChange(e.target.value as FeedCategory | "")}
       >
@@ -65,7 +69,7 @@ export function FilterBar({
       </select>
 
       <select
-        className="select"
+        className={`${inputClass} min-w-[130px]`}
         value={lang}
         onChange={(e) => onLangChange(e.target.value as FeedLang | "")}
       >
@@ -74,7 +78,11 @@ export function FilterBar({
         <option value="ja">日本語</option>
       </select>
 
-      <select className="select" value={feedId} onChange={(e) => onFeedChange(e.target.value)}>
+      <select
+        className={`${inputClass} min-w-[130px]`}
+        value={feedId}
+        onChange={(e) => onFeedChange(e.target.value)}
+      >
         <option value="">All feeds</option>
         {visibleFeeds.map((f) => (
           <option key={f.id} value={f.id}>
@@ -85,32 +93,34 @@ export function FilterBar({
 
       <input
         type="date"
-        className="date-input"
+        className={inputClass}
         value={dateFrom}
         onChange={(e) => onDateFromChange(e.target.value)}
         aria-label="期間 開始日"
       />
-      <span className="date-sep">〜</span>
+      <span className="text-[var(--fg-muted)] px-[2px] text-[var(--font-size-sm)]">〜</span>
       <input
         type="date"
-        className="date-input"
+        className={inputClass}
         value={dateTo}
         onChange={(e) => onDateToChange(e.target.value)}
         aria-label="期間 終了日"
       />
 
-      <label className="unread-only-label">
+      <label className="flex items-center gap-[var(--space-2)] text-[var(--fg-muted)] text-[var(--font-size-sm)] cursor-pointer whitespace-nowrap select-none">
         <input
           type="checkbox"
+          className="cursor-pointer accent-[var(--accent)] w-[14px] h-[14px]"
           checked={unreadOnly}
           onChange={(e) => onUnreadOnlyChange(e.target.checked)}
         />
         未読のみ
       </label>
 
-      <label className="unread-only-label">
+      <label className="flex items-center gap-[var(--space-2)] text-[var(--fg-muted)] text-[var(--font-size-sm)] cursor-pointer whitespace-nowrap select-none">
         <input
           type="checkbox"
+          className="cursor-pointer accent-[var(--accent)] w-[14px] h-[14px]"
           checked={starredOnly}
           onChange={(e) => onStarredOnlyChange(e.target.checked)}
         />
@@ -118,7 +128,11 @@ export function FilterBar({
       </label>
 
       {hasFilter && (
-        <button type="button" className="clear-filter" onClick={onClear}>
+        <button
+          type="button"
+          className="px-[var(--space-3)] py-[var(--space-2)] bg-[var(--bg-overlay)] text-[var(--fg-muted)] border border-[var(--border-subtle)] rounded-[var(--radius-md)] text-[var(--font-size-sm)] font-[inherit] cursor-pointer whitespace-nowrap transition-[border-color,color] duration-100 hover:border-[var(--accent)] hover:text-[var(--fg-primary)] focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2"
+          onClick={onClear}
+        >
           ✕ 解除
         </button>
       )}

--- a/apps/web/client/components/PresetBar.tsx
+++ b/apps/web/client/components/PresetBar.tsx
@@ -17,22 +17,29 @@ export function PresetBar({ presets, currentFilters, onApply, onAdd, onRemove }:
   }
 
   return (
-    <div className="preset-bar">
-      <button type="button" className="preset-add" onClick={handleAdd}>
+    <div className="flex flex-wrap items-center gap-[var(--space-2)] mb-[var(--space-3)]">
+      <button
+        type="button"
+        className="px-[var(--space-3)] py-[4px] bg-[var(--bg-elevated)] text-[var(--fg-muted)] border border-dashed border-[var(--border-subtle)] rounded-[var(--radius-full)] text-[var(--font-size-sm)] font-[inherit] cursor-pointer whitespace-nowrap transition-[border-color,color] duration-100 hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2"
+        onClick={handleAdd}
+      >
         + 現在のフィルタを保存
       </button>
       {presets.map((preset) => (
-        <span key={preset.id} className="preset-pill">
+        <span
+          key={preset.id}
+          className="inline-flex items-center bg-[var(--accent-soft)] border border-[var(--accent)] rounded-[var(--radius-full)] overflow-hidden"
+        >
           <button
             type="button"
-            className="preset-pill-name"
+            className="px-[var(--space-3)] py-[4px] bg-transparent text-[var(--accent)] border-none text-[var(--font-size-sm)] font-[inherit] cursor-pointer whitespace-nowrap hover:underline"
             onClick={() => onApply(preset.filters)}
           >
             {preset.name}
           </button>
           <button
             type="button"
-            className="preset-pill-remove"
+            className="px-[var(--space-2)] py-[4px] pl-[2px] bg-transparent text-[var(--accent)] border-none text-[var(--font-size-sm)] font-[inherit] cursor-pointer opacity-60 leading-none transition-opacity duration-100 hover:opacity-100"
             aria-label={`${preset.name} を削除`}
             onClick={() => onRemove(preset.id)}
           >

--- a/apps/web/client/components/SearchInput.tsx
+++ b/apps/web/client/components/SearchInput.tsx
@@ -30,7 +30,7 @@ export const SearchInput = forwardRef<HTMLInputElement, Props>(function SearchIn
     <input
       ref={ref}
       type="search"
-      className="search-input"
+      className="w-full px-[var(--space-3)] py-[var(--space-2)] bg-[var(--bg-overlay)] border border-[var(--border-subtle)] rounded-[var(--radius-md)] text-[var(--fg-primary)] text-[var(--font-size-base)] font-[inherit] transition-[border-color] duration-100 placeholder:text-[var(--fg-muted)] focus:outline-none focus:border-[var(--accent)] focus:shadow-[0_0_0_3px_var(--accent-soft)]"
       placeholder="記事を検索 (タイトル / 概要)"
       value={local}
       onChange={(e) => setLocal(e.target.value)}

--- a/apps/web/client/components/SearchSuggestions.tsx
+++ b/apps/web/client/components/SearchSuggestions.tsx
@@ -10,12 +10,20 @@ export function SearchSuggestions({ items, onPick, onRemove, onClearAll, visible
   if (!visible || items.length === 0) return null;
 
   return (
-    <ul role="listbox" className="search-suggestions">
+    <ul
+      role="listbox"
+      className="absolute top-full left-0 right-0 bg-[var(--bg-elevated)] border border-[var(--border-subtle)] rounded-b-[var(--radius-md)] max-h-[300px] overflow-y-auto z-50 list-none m-0 py-[var(--space-1)] shadow-[var(--shadow-md)]"
+    >
       {items.map((item) => (
-        <li key={item} role="option" aria-selected={false} className="search-suggestion-item">
+        <li
+          key={item}
+          role="option"
+          aria-selected={false}
+          className="flex justify-between items-center p-0"
+        >
           <button
             type="button"
-            className="search-suggestion-pick"
+            className="flex-1 px-[var(--space-3)] py-[var(--space-2)] bg-transparent border-none text-[var(--fg-primary)] text-[var(--font-size-base)] font-[inherit] text-left cursor-pointer whitespace-nowrap overflow-hidden text-ellipsis transition-[background] duration-100 hover:bg-[var(--bg-overlay)] hover:text-[var(--accent)]"
             // mousedown で preventDefault することで onBlur より先に処理し、フォーカスを奪わない
             onMouseDown={(e) => {
               e.preventDefault();
@@ -26,7 +34,7 @@ export function SearchSuggestions({ items, onPick, onRemove, onClearAll, visible
           </button>
           <button
             type="button"
-            className="search-suggestion-remove"
+            className="shrink-0 px-[var(--space-3)] py-[var(--space-2)] bg-transparent border-none text-[var(--fg-muted)] text-[var(--font-size-base)] font-[inherit] cursor-pointer opacity-60 leading-none transition-opacity duration-100 hover:opacity-100 hover:text-[var(--fg-primary)]"
             aria-label={`"${item}" を履歴から削除`}
             onMouseDown={(e) => {
               e.preventDefault();
@@ -37,10 +45,10 @@ export function SearchSuggestions({ items, onPick, onRemove, onClearAll, visible
           </button>
         </li>
       ))}
-      <li className="search-suggestion-clear-row">
+      <li className="border-t border-[var(--border-subtle)] mt-[var(--space-1)] pt-[var(--space-1)]">
         <button
           type="button"
-          className="search-suggestion-clear-all"
+          className="w-full px-[var(--space-3)] py-[var(--space-2)] bg-transparent border-none text-[var(--fg-muted)] text-[var(--font-size-sm)] font-[inherit] text-left cursor-pointer transition-[background] duration-100 hover:bg-[var(--bg-overlay)] hover:text-[var(--fg-primary)]"
           onMouseDown={(e) => {
             e.preventDefault();
             onClearAll();

--- a/apps/web/client/components/Stats.tsx
+++ b/apps/web/client/components/Stats.tsx
@@ -19,22 +19,35 @@ function formatDate(iso: string): string {
 }
 
 function FeedActivityTable({ rows }: { rows: FeedActivity[] }) {
-  if (rows.length === 0) return <p className="stats-empty">過去 30 日に記事なし</p>;
+  if (rows.length === 0)
+    return (
+      <p className="text-[var(--fg-muted)] text-[var(--font-size-sm)] m-0">過去 30 日に記事なし</p>
+    );
   return (
-    <table className="stats-feed-table">
+    <table className="w-full border-collapse text-[var(--font-size-sm)]">
       <thead>
         <tr>
-          <th>フィード</th>
-          <th className="stats-feed-table-num">30 日</th>
-          <th className="stats-feed-table-date">最終記事</th>
+          <th className="py-[var(--space-2)] px-[var(--space-2)] text-left border-b border-[var(--border-subtle)] text-[var(--fg-muted)] font-semibold text-[var(--font-size-xs)] uppercase tracking-[0.05em]">
+            フィード
+          </th>
+          <th className="py-[var(--space-2)] px-[var(--space-2)] text-right border-b border-[var(--border-subtle)] text-[var(--fg-muted)] font-semibold text-[var(--font-size-xs)] uppercase tracking-[0.05em] w-[60px]">
+            30 日
+          </th>
+          <th className="py-[var(--space-2)] px-[var(--space-2)] text-left border-b border-[var(--border-subtle)] text-[var(--fg-muted)] font-semibold text-[var(--font-size-xs)] uppercase tracking-[0.05em] whitespace-nowrap w-[160px]">
+            最終記事
+          </th>
         </tr>
       </thead>
       <tbody>
         {rows.map((row) => (
           <tr key={row.feed_id}>
-            <td>{row.feed_name}</td>
-            <td className="stats-feed-table-num">{row.articles_30d}</td>
-            <td className="stats-feed-table-date">
+            <td className="py-[var(--space-2)] px-[var(--space-2)] text-left border-b border-[var(--border-subtle)] text-[var(--fg-primary)]">
+              {row.feed_name}
+            </td>
+            <td className="py-[var(--space-2)] px-[var(--space-2)] text-right border-b border-[var(--border-subtle)] text-[var(--fg-primary)] w-[60px]">
+              {row.articles_30d}
+            </td>
+            <td className="py-[var(--space-2)] px-[var(--space-2)] text-left border-b border-[var(--border-subtle)] text-[var(--fg-muted)] whitespace-nowrap w-[160px]">
               {row.last_published_at ? formatDate(row.last_published_at) : "—"}
             </td>
           </tr>
@@ -50,15 +63,19 @@ export function StatsPanel({ stats }: StatsProps) {
     stats.category_trend_30d.some((p) => TREND_CATEGORIES.some((c) => p[c] > 0));
 
   return (
-    <section className="stats-panel">
-      <h2 className="stats-panel-title">カテゴリ別 30 日トレンド</h2>
+    <section className="mb-[var(--space-6)] p-[var(--space-4)] bg-[var(--bg-elevated)] border border-[var(--border-subtle)] rounded-[var(--radius-lg)]">
+      <h2 className="text-[var(--font-size-sm)] font-semibold text-[var(--fg-muted)] m-0 mb-[var(--space-3)] uppercase tracking-[0.05em]">
+        カテゴリ別 30 日トレンド
+      </h2>
       {hasTrend ? (
         <StatsChart data={stats.category_trend_30d} categories={TREND_CATEGORIES} />
       ) : (
-        <p className="stats-empty">過去 30 日のデータがありません</p>
+        <p className="text-[var(--fg-muted)] text-[var(--font-size-sm)] m-0">
+          過去 30 日のデータがありません
+        </p>
       )}
 
-      <h2 className="stats-panel-title" style={{ marginTop: "24px" }}>
+      <h2 className="text-[var(--font-size-sm)] font-semibold text-[var(--fg-muted)] m-0 mb-[var(--space-3)] mt-[24px] uppercase tracking-[0.05em]">
         フィード別アクティビティ (30 日)
       </h2>
       <FeedActivityTable rows={stats.feed_activity} />

--- a/apps/web/client/components/StatsChart.tsx
+++ b/apps/web/client/components/StatsChart.tsx
@@ -37,13 +37,13 @@ export function StatsChart({ data, categories }: StatsChartProps) {
   const labelIndices = new Set([0, Math.floor((barCount - 1) / 2), barCount - 1]);
 
   return (
-    <figure className="stats-chart-fig">
+    <figure className="m-0">
       {/* 凡例 */}
-      <div className="stats-chart-legend">
+      <div className="flex flex-wrap gap-[var(--space-3)] mb-[var(--space-2)] text-[var(--font-size-sm)] text-[var(--fg-muted)]">
         {categories.map((cat) => (
-          <span key={cat} className="stats-chart-legend-item">
+          <span key={cat} className="flex items-center gap-[var(--space-1)]">
             <span
-              className="stats-chart-legend-dot"
+              className="inline-block w-[10px] h-[10px] rounded-[var(--radius-sm)] shrink-0"
               style={{ background: CATEGORY_COLORS[cat] ?? "#999" }}
             />
             {cat}
@@ -56,7 +56,7 @@ export function StatsChart({ data, categories }: StatsChartProps) {
         preserveAspectRatio="none"
         aria-label="カテゴリ別 30 日記事数トレンド"
         role="img"
-        className="stats-chart-svg"
+        className="block w-full h-auto [aspect-ratio:800/160] text-[var(--fg-primary)]"
       >
         {/* y 軸グリッド線 (0 / 50% / 100%) */}
         {[0, 0.5, 1].map((ratio) => {

--- a/apps/web/client/components/StatsDashboard.tsx
+++ b/apps/web/client/components/StatsDashboard.tsx
@@ -4,12 +4,22 @@ import type { AuthorCount, PublisherCount, Stats } from "../hooks/useStats";
 
 function SummaryCard({ label, value }: { label: string; value: number }) {
   return (
-    <div className="stats-card">
-      <div className="stats-card-label">{label}</div>
-      <div className="stats-card-value">{value.toLocaleString("ja-JP")}</div>
+    <div className="p-[var(--space-4)] bg-[var(--bg-elevated)] border border-[var(--border-subtle)] rounded-[var(--radius-lg)] flex flex-col gap-[var(--space-1)] transition-[box-shadow] duration-200 hover:shadow-[var(--shadow-sm)]">
+      <div className="text-[var(--font-size-xs)] font-semibold text-[var(--fg-muted)] uppercase tracking-[0.06em]">
+        {label}
+      </div>
+      <div className="text-[var(--font-size-2xl)] font-bold text-[var(--fg-primary)] leading-[1.1] tracking-[-0.02em]">
+        {value.toLocaleString("ja-JP")}
+      </div>
     </div>
   );
 }
+
+// stats セクション共通スタイル
+const sectionClass =
+  "p-[var(--space-4)] bg-[var(--bg-elevated)] border border-[var(--border-subtle)] rounded-[var(--radius-lg)]";
+const sectionTitleClass =
+  "text-[var(--font-size-sm)] font-semibold text-[var(--fg-muted)] m-0 mb-[var(--space-4)] uppercase tracking-[0.05em]";
 
 function BarRow({
   label,
@@ -24,26 +34,30 @@ function BarRow({
 }) {
   const pct = maxCount > 0 ? Math.round((count / maxCount) * 100) : 0;
   return (
-    <div className="stats-bar-row">
+    <div className="grid [grid-template-columns:minmax(120px,180px)_1fr_60px] items-center gap-[var(--space-3)]">
       {onClick ? (
         <button
           type="button"
-          className="stats-bar-label stats-bar-label-clickable"
+          className="text-[var(--font-size-sm)] text-[var(--fg-primary)] whitespace-nowrap overflow-hidden text-ellipsis bg-transparent border-none cursor-pointer p-0 font-[inherit] text-left transition-[color] duration-100 hover:text-[var(--accent)] hover:underline focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2 focus-visible:rounded-[var(--radius-sm)]"
           onClick={onClick}
           title={`${label} の記事一覧`}
         >
           {label}
         </button>
       ) : (
-        <span className="stats-bar-label">{label}</span>
+        <span className="text-[var(--font-size-sm)] text-[var(--fg-primary)] whitespace-nowrap overflow-hidden text-ellipsis">
+          {label}
+        </span>
       )}
       <div
-        className="stats-bar"
+        className="h-[8px] rounded-[var(--radius-full)] bg-[var(--accent)] opacity-70 min-w-[2px] transition-opacity duration-100 hover:opacity-100"
         role="img"
         aria-label={`${label}: ${count}件`}
         style={{ width: `${pct}%` }}
       />
-      <span className="stats-bar-count">{count.toLocaleString("ja-JP")}</span>
+      <span className="text-[var(--font-size-sm)] text-[var(--fg-muted)] text-right [font-variant-numeric:tabular-nums]">
+        {count.toLocaleString("ja-JP")}
+      </span>
     </div>
   );
 }
@@ -58,9 +72,9 @@ function AuthorsSection({
   const top = authors.slice(0, 10);
   const max = top[0]?.count ?? 1;
   return (
-    <section className="stats-section">
-      <h3 className="stats-section-title">著者別 (30 日・上位 10 件)</h3>
-      <div className="stats-bar-list">
+    <section className={sectionClass}>
+      <h3 className={sectionTitleClass}>著者別 (30 日・上位 10 件)</h3>
+      <div className="grid gap-[var(--space-2)]">
         {top.map((a) => (
           <BarRow
             key={a.author}
@@ -79,9 +93,9 @@ function PublishersSection({ publishers }: { publishers: PublisherCount[] }) {
   const top = publishers.slice(0, 10);
   const max = top[0]?.count ?? 1;
   return (
-    <section className="stats-section">
-      <h3 className="stats-section-title">フィード別 (30 日・上位 10 件)</h3>
-      <div className="stats-bar-list">
+    <section className={sectionClass}>
+      <h3 className={sectionTitleClass}>フィード別 (30 日・上位 10 件)</h3>
+      <div className="grid gap-[var(--space-2)]">
         {top.map((p) => (
           <BarRow key={p.feed_id} label={p.name} count={p.count} maxCount={max} />
         ))}
@@ -94,9 +108,9 @@ function LangSection({ byLang }: { byLang: Record<string, number> }) {
   const entries = Object.entries(byLang).toSorted((a, b) => b[1] - a[1]);
   const max = entries[0]?.[1] ?? 1;
   return (
-    <section className="stats-section">
-      <h3 className="stats-section-title">言語別 (30 日)</h3>
-      <div className="stats-bar-list">
+    <section className={sectionClass}>
+      <h3 className={sectionTitleClass}>言語別 (30 日)</h3>
+      <div className="grid gap-[var(--space-2)]">
         {entries.map(([lang, count]) => (
           <BarRow key={lang} label={lang} count={count} maxCount={max} />
         ))}
@@ -109,9 +123,9 @@ function CategorySection({ byCategory }: { byCategory: Record<string, number> })
   const entries = Object.entries(byCategory).toSorted((a, b) => b[1] - a[1]);
   const max = entries[0]?.[1] ?? 1;
   return (
-    <section className="stats-section">
-      <h3 className="stats-section-title">カテゴリ別 (累計)</h3>
-      <div className="stats-bar-list">
+    <section className={sectionClass}>
+      <h3 className={sectionTitleClass}>カテゴリ別 (累計)</h3>
+      <div className="grid gap-[var(--space-2)]">
         {entries.map(([cat, count]) => (
           <BarRow key={cat} label={cat} count={count} maxCount={max} />
         ))}
@@ -152,8 +166,18 @@ export function StatsDashboard({ onNavigateToAuthor }: StatsDashboardProps = {})
     };
   }, []);
 
-  if (loading) return <div className="loader">読み込み中…</div>;
-  if (error) return <div className="error">エラー: {error}</div>;
+  if (loading)
+    return (
+      <div className="text-center text-[var(--fg-muted)] p-[var(--space-8)_var(--space-3)] border border-dashed border-[var(--border-subtle)] rounded-[var(--radius-lg)] mt-[var(--space-4)] text-[var(--font-size-base)] leading-[var(--line-height-relaxed)]">
+        読み込み中…
+      </div>
+    );
+  if (error)
+    return (
+      <div className="text-center text-[var(--danger)] p-[var(--space-8)_var(--space-3)] border border-[rgba(207,34,46,0.3)] rounded-[var(--radius-lg)] mt-[var(--space-4)] bg-[var(--danger-soft)] text-[var(--font-size-base)] leading-[var(--line-height-relaxed)]">
+        エラー: {error}
+      </div>
+    );
   if (!stats) return null;
 
   // PR #148 で追加されたフィールドにフォールバック
@@ -163,9 +187,9 @@ export function StatsDashboard({ onNavigateToAuthor }: StatsDashboardProps = {})
   const totalArticles = stats.total;
 
   return (
-    <div className="stats-dashboard">
+    <div className="grid gap-[var(--space-6)] py-[var(--space-2)]">
       {/* サマリカード */}
-      <div className="stats-cards">
+      <div className="grid [grid-template-columns:repeat(2,1fr)] gap-[var(--space-3)] sm:[grid-template-columns:repeat(4,1fr)]">
         <SummaryCard label="総記事数" value={totalArticles} />
         <SummaryCard label="直近 24h" value={articles24h} />
         <SummaryCard label="直近 7 日" value={articles7d} />

--- a/apps/web/tests/client/CalendarHeatmap.test.tsx
+++ b/apps/web/tests/client/CalendarHeatmap.test.tsx
@@ -61,7 +61,7 @@ describe("CalendarHeatmap", () => {
     const { container } = render(<CalendarHeatmap days={90} />);
     // セルが描画されるまで待つ
     await screen.findByText("活動カレンダー");
-    const cells = container.querySelectorAll(".calendar-heatmap-cell[data-level]");
+    const cells = container.querySelectorAll("[data-level]");
     // 90セル分 (range内) + 凡例の5セル = 95以上
     expect(cells.length).toBeGreaterThanOrEqual(90);
   });
@@ -72,7 +72,7 @@ describe("CalendarHeatmap", () => {
     const { container } = render(<CalendarHeatmap days={90} />);
     await screen.findByText("活動カレンダー");
     // count=3 → level=2 のセルが存在する
-    const level2Cells = container.querySelectorAll('.calendar-heatmap-cell[data-level="2"]');
+    const level2Cells = container.querySelectorAll('[data-level="2"]');
     expect(level2Cells.length).toBeGreaterThan(0);
   });
 
@@ -82,7 +82,7 @@ describe("CalendarHeatmap", () => {
     const { container } = render(<CalendarHeatmap days={90} />);
     await screen.findByText("活動カレンダー");
     // aria-label="M月D日: 5件" の形式のセルが存在する
-    const cells = container.querySelectorAll(".calendar-heatmap-cell[aria-label]");
+    const cells = container.querySelectorAll("[data-level][aria-label]");
     expect(cells.length).toBeGreaterThan(0);
     const labels = Array.from(cells).map((c) => c.getAttribute("aria-label") ?? "");
     expect(labels.some((l) => l.includes("5件"))).toBe(true);
@@ -94,7 +94,7 @@ describe("CalendarHeatmap", () => {
     mockFetch(days);
     const { container } = render(<CalendarHeatmap days={90} />);
     await screen.findByText("活動カレンダー");
-    const level0Cells = container.querySelectorAll('.calendar-heatmap-cell[data-level="0"]');
+    const level0Cells = container.querySelectorAll('[data-level="0"]');
     // 90セル (range内) + 凡例1セル
     expect(level0Cells.length).toBeGreaterThanOrEqual(90);
   });
@@ -104,7 +104,7 @@ describe("CalendarHeatmap", () => {
     mockFetch(days);
     const { container } = render(<CalendarHeatmap days={90} />);
     await screen.findByText("活動カレンダー");
-    const level4Cells = container.querySelectorAll('.calendar-heatmap-cell[data-level="4"]');
+    const level4Cells = container.querySelectorAll('[data-level="4"]');
     // 90セル (range内) + 凡例1セル
     expect(level4Cells.length).toBeGreaterThanOrEqual(90);
   });


### PR DESCRIPTION
## Summary
- FilterBar, SearchInput, SearchSuggestions, PresetBar の legacy className を Tailwind v4 utility class に移行
- Stats, StatsChart, StatsDashboard, CalendarHeatmap の legacy className を移行
- ヒートマップセルは `bg-[var(--heatmap-l0..l4)]` の任意プロパティ式で CSS 変数を参照
- index.css の legacy CSS は最終 cleanup PR で削除予定

## Bundle size
| | CSS raw | CSS gzip | JS raw | JS gzip |
|---|---|---|---|---|
| Before (main) | 46.94 kB | 8.54 kB | 247.63 kB | 75.93 kB |
| After | 54.58 kB | 9.66 kB | 256.13 kB | 77.32 kB |

CSS の増加は Tailwind utility class が追加されたことによるもの (legacy class が残存しているため一時的)。最終 cleanup PR で legacy CSS 削除後に縮小予定。

Closes #249
Refs #245

## Test plan
- [x] pnpm build (成功)
- [x] pnpm test (507 passed)
- [x] pnpm run check (既存の 1 error / 3 warning は main 時点から同一、本 PR での増加なし)