### PR TITLE
refactor(web): tailwindize keyframes and base layer

### DIFF
--- a/apps/web/client/components/Toast.tsx
+++ b/apps/web/client/components/Toast.tsx
@@ -21,7 +21,7 @@ function kindMsgClass(kind: ToastData["kind"]) {
 export function Toast({ toast, onDismiss }: Props) {
   return (
     <div
-      className={`flex items-center gap-[var(--space-3)] px-[var(--space-4)] py-[var(--space-3)] bg-[var(--bg-elevated)] border rounded-[var(--radius-lg)] shadow-[var(--shadow-lg)] text-[var(--font-size-base)] min-w-[220px] max-w-[360px] pointer-events-auto [animation:toast-in_0.2s_ease] ${kindBorderClass(toast.kind)}`}
+      className={`flex items-center gap-[var(--space-3)] px-[var(--space-4)] py-[var(--space-3)] bg-[var(--bg-elevated)] border rounded-[var(--radius-lg)] shadow-[var(--shadow-lg)] text-[var(--font-size-base)] min-w-[220px] max-w-[360px] pointer-events-auto animate-toast-in ${kindBorderClass(toast.kind)}`}
       role="status"
       aria-live="polite"
       aria-atomic="true"

--- a/apps/web/client/index.css
+++ b/apps/web/client/index.css
@@ -235,65 +235,75 @@
 
 /* ============================================================
    リセット / ベーススタイル
+   @layer base でラップすることで Tailwind utilities より低い優先度に置く。
+   `:root` / `[data-theme="dark"]` は CSS variable 定義のため layer 外に残す。
    ============================================================ */
 
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-}
+@layer base {
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
 
-html,
-body,
-#root {
-  height: 100%;
-  margin: 0;
-  background: var(--bg-base);
-  color: var(--fg-primary);
-}
+  html,
+  body,
+  #root {
+    height: 100%;
+    margin: 0;
+    background: var(--bg-base);
+    color: var(--fg-primary);
+  }
 
-/* スムーズなテーマ切替 */
-html {
-  transition:
-    background-color var(--transition-base),
-    color var(--transition-base);
-}
+  /* スムーズなテーマ切替 */
+  html {
+    transition:
+      background-color var(--transition-base),
+      color var(--transition-base);
+  }
 
-a {
-  color: var(--accent);
-  text-decoration: none;
-}
+  a {
+    color: var(--accent);
+    text-decoration: none;
+  }
 
-a:hover {
-  text-decoration: underline;
-}
+  a:hover {
+    text-decoration: underline;
+  }
 
-a:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-  border-radius: var(--radius-sm);
-}
+  a:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    border-radius: var(--radius-sm);
+  }
 
-mark {
-  background: var(--mark-bg);
-  color: inherit;
-  padding: 0 2px;
-  border-radius: 2px;
-}
+  mark {
+    background: var(--mark-bg);
+    color: inherit;
+    padding: 0 2px;
+    border-radius: 2px;
+  }
 
-kbd {
-  display: inline-block;
-  padding: 1px var(--space-2);
-  background: var(--bg-overlay);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-sm);
-  font-family: ui-monospace, SFMono-Regular, monospace;
-  font-size: var(--font-size-xs);
+  kbd {
+    display: inline-block;
+    padding: 1px var(--space-2);
+    background: var(--bg-overlay);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-sm);
+    font-family: ui-monospace, SFMono-Regular, monospace;
+    font-size: var(--font-size-xs);
+  }
 }
 
 /* ============================================================
-   Toast 通知 — slide-in アニメーション (Toast.tsx の任意値で参照)
+   Toast 通知 — slide-in アニメーション
+   @theme inline で animate-toast-in utility として登録する。
+   @keyframes は @theme の外に置くのが Tailwind v4 の推奨。
    ============================================================ */
+
+@theme inline {
+  --animate-toast-in: toast-in 0.2s ease;
+}
 
 @keyframes toast-in {
   from {


### PR DESCRIPTION
## 変更内容

PR #255 で legacy CSS を撤去した続きとして、残っていた非 Tailwind idiomatic な部分を整理した。

### 1. `@keyframes toast-in` の utility 化

- `@theme inline { --animate-toast-in: toast-in 0.2s ease; }` を追加
- `@keyframes toast-in` は `@theme` の外に残す（Tailwind v4 推奨パターン）
- `Toast.tsx` の arbitrary value `[animation:toast-in_0.2s_ease]` を `animate-toast-in` utility に置換

### 2. reset/base スタイルを `@layer base` でラップ

- `*`, `html`, `body`, `#root`, `a`, `a:hover`, `a:focus-visible`, `mark`, `kbd` を `@layer base { ... }` 内に移動
- Tailwind utilities より低い cascade layer に配置することで specificity 競合を回避
- `:root` / `[data-theme="dark"]` の CSS variable 定義は layer 外のまま（意図的）

## 検証

- `pnpm build` 通過
- `pnpm check` 通過（既存 warning 3 件のみ、今回変更無関係）
- `pnpm test` 507 件全パス
- ブラウザ目視確認: Chrome extension が接続されていないため手動確認が必要です。Toast の `animate-toast-in` utility は `@theme inline` で定義済みのため、Tailwind によって `animation: toast-in 0.2s ease` に展開されます。

Closes #256