### PR TITLE
perf(stats): batch D1 queries into single round-trip

### DIFF
--- a/apps/web/worker/api/stats.ts
+++ b/apps/web/worker/api/stats.ts
@@ -1,10 +1,10 @@
 import { Hono } from "hono";
-import {
-  getByLang30d,
-  getCategoryTrend30d,
-  getFeedActivity30d,
-  getTopAuthors30d,
-  getTopPublishers30d,
+import type {
+  CategoryTrendPoint,
+  FeedActivityRow,
+  TopAuthorRow,
+  TopPublisherRow,
+  ByLang30d,
 } from "../db/articles";
 import type { Env } from "../types";
 import type { StatsResponse } from "./types";
@@ -29,51 +29,133 @@ const STALE_FEEDS_SQL = `
 // stale_feeds はフィード数 (最大数百) に依存するが、全件表示が運用上必要なため除外しない。
 
 app.get("/", async (c) => {
-  const totalRow = await c.env.DB.prepare(
-    "SELECT COUNT(*) AS n, MAX(published_at) AS last_published, MAX(fetched_at) AS last_fetched FROM articles",
-  ).first<{ n: number; last_published: string | null; last_fetched: string | null }>();
+  const db = c.env.DB;
 
-  const byCategory = await c.env.DB.prepare(
-    `SELECT category, COUNT(*) AS n FROM articles GROUP BY category`,
-  ).all<{ category: string; n: number }>();
+  // 10 クエリを 1 回の db.batch で発行してラウンドトリップを 1 本に削減する
+  const [
+    totalResult,
+    byCategoryResult,
+    byLangResult,
+    recentResult,
+    staleResult,
+    categoryTrendRaw,
+    feedActivityRaw,
+    topAuthorsRaw,
+    topPublishersRaw,
+    byLang30dRaw,
+  ] = await db.batch([
+    db.prepare(
+      "SELECT COUNT(*) AS n, MAX(published_at) AS last_published, MAX(fetched_at) AS last_fetched FROM articles",
+    ),
+    db.prepare(`SELECT category, COUNT(*) AS n FROM articles GROUP BY category`),
+    db.prepare(`SELECT lang, COUNT(*) AS n FROM articles GROUP BY lang`),
+    db.prepare(
+      `SELECT COUNT(*) AS n FROM articles WHERE published_at >= datetime('now', '-1 day')`,
+    ),
+    db.prepare(STALE_FEEDS_SQL),
+    db.prepare(
+      `SELECT date(published_at) AS date, category, COUNT(*) AS n
+       FROM articles
+       WHERE published_at >= date('now', '-30 days')
+       GROUP BY date(published_at), category
+       ORDER BY date(published_at) ASC`,
+    ),
+    db.prepare(
+      `SELECT a.feed_id,
+              COALESCE(f.name, a.feed_id) AS feed_name,
+              COUNT(*) AS articles_30d,
+              MAX(a.published_at) AS last_published_at
+       FROM articles a
+       LEFT JOIN feeds f ON f.id = a.feed_id
+       WHERE a.published_at >= date('now', '-30 days')
+       GROUP BY a.feed_id
+       ORDER BY articles_30d DESC`,
+    ),
+    db.prepare(
+      `SELECT author, COUNT(*) AS count
+       FROM articles
+       WHERE author IS NOT NULL
+         AND author != ''
+         AND category != 'zenn'
+         AND published_at >= datetime('now', '-30 days')
+       GROUP BY author
+       ORDER BY count DESC
+       LIMIT 10`,
+    ),
+    db.prepare(
+      `SELECT a.feed_id,
+              COALESCE(f.name, a.feed_id) AS feed_name,
+              COUNT(*) AS count
+       FROM articles a
+       LEFT JOIN feeds f ON f.id = a.feed_id
+       WHERE a.published_at >= datetime('now', '-30 days')
+       GROUP BY a.feed_id
+       ORDER BY count DESC
+       LIMIT 10`,
+    ),
+    db.prepare(
+      `SELECT lang, COUNT(*) AS count
+       FROM articles
+       WHERE published_at >= datetime('now', '-30 days')
+       GROUP BY lang`,
+    ),
+  ]);
 
-  const byLang = await c.env.DB.prepare(
-    `SELECT lang, COUNT(*) AS n FROM articles GROUP BY lang`,
-  ).all<{ lang: string; n: number }>();
+  const totalRow = (totalResult.results?.[0] ?? null) as {
+    n: number;
+    last_published: string | null;
+    last_fetched: string | null;
+  } | null;
+  const recentRow = (recentResult.results?.[0] ?? null) as { n: number } | null;
 
-  const recent = await c.env.DB.prepare(
-    `SELECT COUNT(*) AS n FROM articles WHERE published_at >= datetime('now', '-1 day')`,
-  ).first<{ n: number }>();
+  // getCategoryTrend30d と同等の 0 埋め処理
+  const today = new Date();
+  today.setUTCHours(0, 0, 0, 0);
+  const points: CategoryTrendPoint[] = [];
+  for (let i = 29; i >= 0; i--) {
+    const d = new Date(today);
+    d.setUTCDate(today.getUTCDate() - i);
+    points.push({ date: d.toISOString().slice(0, 10), ai: 0, bigtech: 0, jp: 0, zenn: 0 });
+  }
+  const trendMap = new Map<string, CategoryTrendPoint>();
+  for (const p of points) trendMap.set(p.date, p);
+  for (const row of (categoryTrendRaw.results ?? []) as {
+    date: string;
+    category: string;
+    n: number;
+  }[]) {
+    const point = trendMap.get(row.date);
+    if (!point) continue;
+    const cat = row.category as keyof Omit<CategoryTrendPoint, "date">;
+    if (cat in point) (point[cat] as number) += row.n;
+  }
 
-  const staleRows = await c.env.DB.prepare(STALE_FEEDS_SQL).all<{
-    id: string;
-    name: string;
-    last_status: string | null;
-    last_fetched_at: string | null;
-    last_error: string | null;
-  }>();
-
-  const [categoryTrend30d, feedActivity, topAuthors30d, topPublishers30d, byLang30d] =
-    await Promise.all([
-      getCategoryTrend30d(c.env.DB),
-      getFeedActivity30d(c.env.DB),
-      getTopAuthors30d(c.env.DB),
-      getTopPublishers30d(c.env.DB),
-      getByLang30d(c.env.DB),
-    ]);
+  // getByLang30d と同等の集計
+  const byLang30d: ByLang30d = { ja: 0, en: 0 };
+  for (const row of (byLang30dRaw.results ?? []) as { lang: string; count: number }[]) {
+    if (row.lang === "ja") byLang30d.ja = row.count;
+    else if (row.lang === "en") byLang30d.en = row.count;
+  }
 
   return c.json<StatsResponse>({
     total: totalRow?.n ?? 0,
     last_published_at: totalRow?.last_published ?? null,
     last_fetched_at: totalRow?.last_fetched ?? null,
-    last24h: recent?.n ?? 0,
-    by_category: Object.fromEntries((byCategory.results ?? []).map((r) => [r.category, r.n])),
-    by_lang: Object.fromEntries((byLang.results ?? []).map((r) => [r.lang, r.n])),
-    stale_feeds: staleRows.results ?? [],
-    category_trend_30d: categoryTrend30d,
-    feed_activity: feedActivity,
-    top_authors_30d: topAuthors30d,
-    top_publishers_30d: topPublishers30d,
+    last24h: recentRow?.n ?? 0,
+    by_category: Object.fromEntries(
+      ((byCategoryResult.results ?? []) as { category: string; n: number }[]).map((r) => [
+        r.category,
+        r.n,
+      ]),
+    ),
+    by_lang: Object.fromEntries(
+      ((byLangResult.results ?? []) as { lang: string; n: number }[]).map((r) => [r.lang, r.n]),
+    ),
+    stale_feeds: (staleResult.results ?? []) as StatsResponse["stale_feeds"],
+    category_trend_30d: points,
+    feed_activity: (feedActivityRaw.results ?? []) as FeedActivityRow[],
+    top_authors_30d: (topAuthorsRaw.results ?? []) as TopAuthorRow[],
+    top_publishers_30d: (topPublishersRaw.results ?? []) as TopPublisherRow[],
     by_lang_30d: byLang30d,
   });
 });


### PR DESCRIPTION
## Summary

- `/api/stats` で発行していた D1 クエリ 10 本（シリアル 5 本 + `Promise.all` 5 本）を `db.batch([...])` で 1 ラウンドトリップに統合
- レスポンス shape (`StatsResponse`) は一切変更なし
- `getCategoryTrend30d` / `getByLang30d` の JS 後処理ロジックはインラインで同等実装

## クエリ数の変化

| 変更前 | 変更後 |
|--------|--------|
| シリアル 5 回 await + `Promise.all` 5 並列 = 合計 10 ラウンドトリップ | `db.batch` 1 回 = 1 ラウンドトリップ |

## CPU 時間影響の見積り

D1 へのネットワーク往復 (Workers ↔ D1) がシリアル 5 本分削減されるため、
`/api/stats` の CPU 時間を数 ms〜十数 ms 程度削減できる見込み。
Cloudflare Workers 無料枠の 10ms CPU/req 制限に対してより余裕が生まれる。

## Test plan

- [x] `pnpm build` pass
- [x] `pnpm test` pass (507 tests)
- [x] `pnpm check` pass (既存の型エラーのみ、今回の変更由来の新規エラーなし)

Closes #259