### PR TITLE
refactor(web): split App.tsx into smaller components

### DIFF
--- a/apps/web/client/App.tsx
+++ b/apps/web/client/App.tsx
@@ -1,117 +1,28 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ArticleList } from "./components/ArticleList";
-import { AuthorDetail } from "./components/AuthorDetail";
-import { CategoriesOverview } from "./components/CategoriesOverview";
-import { FeedDetail } from "./components/FeedDetail";
-import { FilterBar } from "./components/FilterBar";
-import { type AppView, Header } from "./components/Header";
-import { PresetBar } from "./components/PresetBar";
-import { SearchInput } from "./components/SearchInput";
-import { SearchSuggestions } from "./components/SearchSuggestions";
-import { ShortcutsHelp } from "./components/ShortcutsHelp";
-import { StatsDashboard } from "./components/StatsDashboard";
-import { StatsPanel } from "./components/Stats";
-import { ToastContainer } from "./components/ToastContainer";
 import { useArticles } from "./hooks/useArticles";
 import { useBookmarks } from "./hooks/useBookmarks";
-import { useFeeds } from "./hooks/useFeeds";
+import { useFilterHandlers } from "./hooks/useFilterHandlers";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
-import { usePresets } from "./hooks/usePresets";
 import { useReadState } from "./hooks/useReadState";
 import { useRecentSearches } from "./hooks/useRecentSearches";
 import { useStarredState } from "./hooks/useStarredState";
 import { useStats } from "./hooks/useStats";
 import { ToastContext, useToastState } from "./hooks/useToast";
 import { useUrlState } from "./hooks/useUrlState";
-import type { FeedCategory, FeedLang } from "./types/api";
-
-function EmptyState({ icon, title, body }: { icon: string; title: string; body: string }) {
-  return (
-    <div className="text-center text-[var(--fg-muted)] py-[var(--space-8)] px-[var(--space-3)] border border-dashed border-[var(--border-subtle)] rounded-[var(--radius-lg)] mt-[var(--space-4)] text-[var(--font-size-base)] leading-[var(--line-height-relaxed)]">
-      <span className="text-[2.5rem] block mb-[var(--space-3)] leading-none">{icon}</span>
-      <div className="text-[var(--font-size-md)] font-semibold text-[var(--fg-secondary)] mb-[var(--space-1)]">
-        {title}
-      </div>
-      <div className="text-[var(--font-size-sm)] text-[var(--fg-muted)]">{body}</div>
-    </div>
-  );
-}
-
-function formatRelative(iso: string): string {
-  const t = new Date(iso).getTime();
-  if (Number.isNaN(t)) return iso;
-  const diffMs = Date.now() - t;
-  const min = Math.round(diffMs / 60_000);
-  if (min < 1) return "今";
-  if (min < 60) return `${min} 分前`;
-  const h = Math.round(min / 60);
-  if (h < 24) return `${h} 時間前`;
-  const d = Math.round(h / 24);
-  return `${d} 日前`;
-}
-
-function readFromUrl(): {
-  feedId: string;
-  dateFrom: string;
-  dateTo: string;
-  unreadOnly: boolean;
-  starredOnly: boolean;
-} {
-  const params = new URLSearchParams(window.location.search);
-  return {
-    feedId: params.get("feed_id") ?? "",
-    dateFrom: params.get("date_from") ?? "",
-    dateTo: params.get("date_to") ?? "",
-    unreadOnly: params.get("unread") === "1",
-    starredOnly: params.get("starred") === "1",
-  };
-}
-
-function buildSearch(
-  category: FeedCategory | "",
-  lang: FeedLang | "",
-  feedId: string,
-  q: string,
-  dateFrom: string,
-  dateTo: string,
-  unreadOnly: boolean,
-  starredOnly: boolean,
-  bookmarksOnly: boolean,
-): string {
-  const params = new URLSearchParams();
-  if (category) params.set("category", category);
-  if (lang) params.set("lang", lang);
-  if (feedId) params.set("feed_id", feedId);
-  if (q) params.set("q", q);
-  if (dateFrom) params.set("date_from", dateFrom);
-  if (dateTo) params.set("date_to", dateTo);
-  // true のときだけ付ける
-  if (unreadOnly) params.set("unread", "1");
-  if (starredOnly) params.set("starred", "1");
-  if (bookmarksOnly) params.set("bookmarks", "only");
-  const s = params.toString();
-  return s ? `?${s}` : window.location.pathname;
-}
-
-/** /feed/<id> パスを解析してフィード詳細ページの feedId を返す。それ以外は null。*/
-function readFeedDetailFromPath(): string | null {
-  const m = window.location.pathname.match(/^\/feed\/(.+)$/);
-  return m ? decodeURIComponent(m[1]) : null;
-}
-
-/** /author/<name> パスを解析して著者名を返す。それ以外は null。*/
-function readAuthorFromPath(): string | null {
-  const m = window.location.pathname.match(/^\/author\/(.+)$/);
-  return m ? decodeURIComponent(m[1]) : null;
-}
-
-function readViewFromUrl(): AppView {
-  if (window.location.pathname === "/stats") return "stats";
-  if (window.location.pathname === "/categories") return "categories";
-  if (readFeedDetailFromPath() !== null) return "feed";
-  if (readAuthorFromPath() !== null) return "author";
-  return "articles";
-}
+import {
+  readAuthorFromPath,
+  readFeedDetailFromPath,
+  readFromUrl,
+  readViewFromUrl,
+} from "./lib/routing";
+import { ArticlesView } from "./components/ArticlesView";
+import { AuthorDetail } from "./components/AuthorDetail";
+import { CategoriesOverview } from "./components/CategoriesOverview";
+import { FeedDetail } from "./components/FeedDetail";
+import { type AppView, Header } from "./components/Header";
+import { ShortcutsHelp } from "./components/ShortcutsHelp";
+import { StatsDashboard } from "./components/StatsDashboard";
+import { ToastContainer } from "./components/ToastContainer";
 
 function AppInner() {
   const [view, setView] = useState<AppView>(readViewFromUrl);
@@ -126,18 +37,19 @@ function AppInner() {
   const [starredOnly, setStarredOnly] = useState<boolean>(() => readFromUrl().starredOnly);
   const [selectedIndex, setSelectedIndex] = useState(-1);
   const [helpOpen, setHelpOpen] = useState(false);
-  const [suggestVisible, setSuggestVisible] = useState(false);
 
   const searchRef = useRef<HTMLInputElement>(null);
-  const blurTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const { feeds } = useFeeds();
   const { stats } = useStats();
   const { isRead } = useReadState();
   const { isStarred } = useStarredState();
   const { bookmarks, toggle: toggleBookmark } = useBookmarks();
-  const { presets, addPreset, removePreset } = usePresets();
   const recentSearches = useRecentSearches();
+
+  const filterHandlers = useFilterHandlers(
+    { category, lang, feedId, q, dateFrom, dateTo, unreadOnly, starredOnly, bookmarkedOnly },
+    { setFeedId, setDateFrom, setDateTo, setUnreadOnly, setStarredOnly, setUrlFilters, setView },
+  );
 
   const handleViewChange = useCallback((next: AppView) => {
     setView(next);
@@ -165,11 +77,6 @@ function AppInner() {
         setFeedDetailId("");
         return;
       }
-      if (nextView === "categories") {
-        setFeedDetailId("");
-        setAuthorName("");
-        return;
-      }
       setFeedDetailId("");
       setAuthorName("");
       const next = readFromUrl();
@@ -183,75 +90,6 @@ function AppInner() {
     return () => window.removeEventListener("popstate", onPop);
   }, []);
 
-  // フィルタ変更時は pushState で履歴に積む
-  // useUrlState が q/category/lang/bookmarksOnly の URL 同期を担うため、
-  // pushState 後に popstate を dispatch して useUrlState のキャッシュを更新する
-  const pushFilter = useCallback(
-    (
-      nextCategory: FeedCategory | "",
-      nextLang: FeedLang | "",
-      nextFeedId: string,
-      nextQ: string,
-      nextDateFrom: string,
-      nextDateTo: string,
-      nextUnreadOnly: boolean,
-      nextStarredOnly: boolean,
-    ) => {
-      const next = buildSearch(
-        nextCategory,
-        nextLang,
-        nextFeedId,
-        nextQ,
-        nextDateFrom,
-        nextDateTo,
-        nextUnreadOnly,
-        nextStarredOnly,
-        bookmarkedOnly,
-      );
-      const current = buildSearch(
-        category,
-        lang,
-        feedId,
-        q,
-        dateFrom,
-        dateTo,
-        unreadOnly,
-        starredOnly,
-        bookmarkedOnly,
-      );
-      if (next !== current) {
-        window.history.pushState(null, "", next);
-        // useUrlState の subscribe リスナー (popstate) を起動してキャッシュを無効化する
-        window.dispatchEvent(new PopStateEvent("popstate"));
-      }
-      setFeedId(nextFeedId);
-      setDateFrom(nextDateFrom);
-      setDateTo(nextDateTo);
-      setUnreadOnly(nextUnreadOnly);
-      setStarredOnly(nextStarredOnly);
-    },
-    [category, lang, feedId, q, dateFrom, dateTo, unreadOnly, starredOnly, bookmarkedOnly],
-  );
-
-  const handleCategoryChange = useCallback(
-    (v: FeedCategory | "") =>
-      pushFilter(v, lang, v ? feedId : "", q, dateFrom, dateTo, unreadOnly, starredOnly),
-    [pushFilter, lang, feedId, q, dateFrom, dateTo, unreadOnly, starredOnly],
-  );
-
-  const handleLangChange = useCallback(
-    (v: FeedLang | "") =>
-      pushFilter(category, v, v ? feedId : "", q, dateFrom, dateTo, unreadOnly, starredOnly),
-    [pushFilter, category, feedId, q, dateFrom, dateTo, unreadOnly, starredOnly],
-  );
-
-  const handleFeedChange = useCallback(
-    (id: string) => pushFilter(category, lang, id, q, dateFrom, dateTo, unreadOnly, starredOnly),
-    [pushFilter, category, lang, q, dateFrom, dateTo, unreadOnly, starredOnly],
-  );
-
-  const handleQChange = useCallback((v: string) => setUrlFilters({ q: v }), [setUrlFilters]);
-
   // filters.q が URL に反映されたタイミングで検索履歴に追加する
   useEffect(() => {
     if (q !== "") {
@@ -260,109 +98,6 @@ function AppInner() {
     // recentSearches.add は安定した参照なので依存配列に含めない
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [q]);
-
-  const handleSearchFocusIn = useCallback(() => {
-    if (blurTimerRef.current !== null) {
-      clearTimeout(blurTimerRef.current);
-      blurTimerRef.current = null;
-    }
-    setSuggestVisible(true);
-  }, []);
-
-  const handleSearchBlur = useCallback(() => {
-    // mousedown の取りこぼし防止のため 150ms 遅延させる
-    blurTimerRef.current = setTimeout(() => {
-      setSuggestVisible(false);
-    }, 150);
-  }, []);
-
-  const handleSuggestPick = useCallback(
-    (picked: string) => {
-      setUrlFilters({ q: picked });
-      recentSearches.add(picked);
-      setSuggestVisible(false);
-      searchRef.current?.focus();
-    },
-    [setUrlFilters, recentSearches],
-  );
-
-  const handleSuggestRemove = useCallback(
-    (item: string) => recentSearches.remove(item),
-    [recentSearches],
-  );
-
-  const handleSuggestClearAll = useCallback(() => recentSearches.clear(), [recentSearches]);
-
-  const handleDateFromChange = useCallback(
-    (v: string) => pushFilter(category, lang, feedId, q, v, dateTo, unreadOnly, starredOnly),
-    [pushFilter, category, lang, feedId, q, dateTo, unreadOnly, starredOnly],
-  );
-
-  const handleDateToChange = useCallback(
-    (v: string) => pushFilter(category, lang, feedId, q, dateFrom, v, unreadOnly, starredOnly),
-    [pushFilter, category, lang, feedId, q, dateFrom, unreadOnly, starredOnly],
-  );
-
-  const handleUnreadOnlyChange = useCallback(
-    (v: boolean) => pushFilter(category, lang, feedId, q, dateFrom, dateTo, v, starredOnly),
-    [pushFilter, category, lang, feedId, q, dateFrom, dateTo, starredOnly],
-  );
-
-  const handleStarredOnlyChange = useCallback(
-    (v: boolean) => pushFilter(category, lang, feedId, q, dateFrom, dateTo, unreadOnly, v),
-    [pushFilter, category, lang, feedId, q, dateFrom, dateTo, unreadOnly],
-  );
-
-  const handleClear = useCallback(
-    () => pushFilter("", "", "", "", "", "", false, false),
-    [pushFilter],
-  );
-
-  const handleApplyPreset = useCallback(
-    (filters: {
-      category?: FeedCategory | "";
-      lang?: FeedLang | "";
-      feedId?: string;
-      q?: string;
-      unreadOnly?: boolean;
-      starredOnly?: boolean;
-      dateFrom?: string;
-      dateTo?: string;
-    }) => {
-      pushFilter(
-        filters.category ?? "",
-        filters.lang ?? "",
-        filters.feedId ?? "",
-        filters.q ?? "",
-        filters.dateFrom ?? "",
-        filters.dateTo ?? "",
-        filters.unreadOnly ?? false,
-        filters.starredOnly ?? false,
-      );
-    },
-    [pushFilter],
-  );
-
-  const handleBookmarkedOnlyToggle = useCallback(() => {
-    setUrlFilters({ bookmarksOnly: !bookmarkedOnly });
-  }, [setUrlFilters, bookmarkedOnly]);
-
-  // カード上のバッジ/取得元クリックでフィルタを適用する
-  const handleFilterByCategory = useCallback(
-    (c: FeedCategory) => pushFilter(c, lang, "", q, dateFrom, dateTo, unreadOnly, starredOnly),
-    [pushFilter, lang, q, dateFrom, dateTo, unreadOnly, starredOnly],
-  );
-
-  // Categories overview からカテゴリカードをクリックした際に articles ページへ遷移してフィルタを適用する
-  const handleSelectCategory = useCallback(
-    (id: FeedCategory) => {
-      window.history.pushState(null, "", "/");
-      window.dispatchEvent(new PopStateEvent("popstate"));
-      setView("articles");
-      pushFilter(id, lang, "", q, dateFrom, dateTo, unreadOnly, starredOnly);
-    },
-    [pushFilter, lang, q, dateFrom, dateTo, unreadOnly, starredOnly],
-  );
 
   // 記事カードの取得元クリックでフィード詳細へ drill-down する
   const handleGoToFeedDetail = useCallback((id: string) => {
@@ -421,10 +156,6 @@ function AppInner() {
     return filtered;
   }, [allArticles, unreadOnly, starredOnly, bookmarkedOnly, isRead, isStarred, bookmarks]);
 
-  const handleSearchFocus = useCallback(() => {
-    searchRef.current?.focus();
-  }, []);
-
   const handleKbNext = useCallback(() => {
     setSelectedIndex((prev) => Math.min(prev + 1, articles.length - 1));
   }, [articles.length]);
@@ -462,6 +193,10 @@ function AppInner() {
     setSelectedIndex(articles.length > 0 ? articles.length - 1 : -1);
   }, [articles.length]);
 
+  const handleSearchFocus = useCallback(() => {
+    searchRef.current?.focus();
+  }, []);
+
   useKeyboardShortcuts({
     onNext: handleKbNext,
     onPrev: handleKbPrev,
@@ -482,157 +217,56 @@ function AppInner() {
       {view === "stats" ? (
         <StatsDashboard onNavigateToAuthor={handleGoToAuthorDetail} />
       ) : view === "categories" ? (
-        <CategoriesOverview onSelectCategory={handleSelectCategory} />
+        <CategoriesOverview onSelectCategory={filterHandlers.handleSelectCategory} />
       ) : view === "feed" && feedDetailId ? (
         <FeedDetail
           feedId={feedDetailId}
           onBack={handleBackFromFeedDetail}
           onFilterByFeedId={handleGoToFeedDetail}
-          onFilterByCategory={handleFilterByCategory}
+          onFilterByCategory={filterHandlers.handleFilterByCategory}
         />
       ) : view === "author" && authorName ? (
         <AuthorDetail
           author={authorName}
           onBack={handleBackFromAuthorDetail}
-          onFilterByCategory={handleFilterByCategory}
+          onFilterByCategory={filterHandlers.handleFilterByCategory}
           onFilterByFeedId={handleGoToFeedDetail}
         />
       ) : (
-        <>
-          <header className="flex justify-between items-center flex-wrap gap-[var(--space-2)] mb-[var(--space-4)]">
-            <span className="text-[var(--fg-muted)] text-[var(--font-size-sm)]">
-              {stats ? `${stats.total.toLocaleString()} 記事 · 直近 24h: ${stats.last24h}` : ""}
-              {feeds.length > 0 ? ` · ${feeds.length} sources` : ""}
-              {stats?.last_fetched_at ? ` · 最終更新 ${formatRelative(stats.last_fetched_at)}` : ""}
-            </span>
-            <button
-              type="button"
-              className={`py-[5px] px-[var(--space-3)] bg-[var(--bg-elevated)] border border-[var(--border-subtle)] rounded-[var(--radius-full)] text-[var(--font-size-sm)] font-[inherit] cursor-pointer whitespace-nowrap shrink-0 transition-[border-color,color,background] duration-100 hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2${bookmarkedOnly ? " bg-[var(--accent-soft)] border-[var(--accent)] text-[var(--accent)] font-semibold" : " text-[var(--fg-muted)]"}`}
-              onClick={handleBookmarkedOnlyToggle}
-              aria-pressed={bookmarkedOnly}
-            >
-              ★ {bookmarks.size} 件{bookmarkedOnly ? " (表示中)" : ""}
-            </button>
-            {stats && stats.stale_feeds.length > 0 && (
-              <details className="w-full mt-[var(--space-2)] py-[var(--space-2)] px-[var(--space-3)] border border-[rgba(207,34,46,0.4)] rounded-[var(--radius-md)] bg-[var(--danger-soft)] text-[var(--font-size-sm)] [&>summary]:cursor-pointer [&>summary]:text-[var(--danger)] [&>summary]:font-semibold [&>ul]:mt-[var(--space-2)] [&>ul]:mb-0 [&>ul]:pl-[20px] [&>ul>li]:mb-[var(--space-1)]">
-                <summary>⚠ {stats.stale_feeds.length} 件の収集に問題があります</summary>
-                <ul>
-                  {stats.stale_feeds.map((f) => (
-                    <li key={f.id}>
-                      <strong>{f.name}</strong>
-                      {f.last_status === "error" ? " · error" : " · stale"}
-                      {f.last_fetched_at ? ` · ${formatRelative(f.last_fetched_at)}` : " · 未取得"}
-                      {f.last_error && (
-                        <div className="text-[var(--fg-muted)] [font-family:ui-monospace,SFMono-Regular,monospace] text-[var(--font-size-xs)] mt-[2px]">
-                          {f.last_error}
-                        </div>
-                      )}
-                    </li>
-                  ))}
-                </ul>
-              </details>
-            )}
-          </header>
-
-          {stats && <StatsPanel stats={stats} />}
-
-          <PresetBar
-            presets={presets}
-            currentFilters={{
-              category,
-              lang,
-              feedId,
-              q,
-              unreadOnly,
-              starredOnly,
-              dateFrom,
-              dateTo,
-            }}
-            onApply={handleApplyPreset}
-            onAdd={addPreset}
-            onRemove={removePreset}
-          />
-
-          <div className="grid grid-cols-1 gap-[var(--space-3)] mb-[var(--space-5)] p-[var(--space-3)] bg-[var(--bg-elevated)] border border-[var(--border-subtle)] rounded-[var(--radius-lg)] min-[720px]:[grid-template-columns:1fr_auto_auto_auto] min-[720px]:items-center">
-            <div className="relative">
-              <SearchInput
-                ref={searchRef}
-                value={q}
-                onChange={handleQChange}
-                onFocus={handleSearchFocusIn}
-                onBlur={handleSearchBlur}
-              />
-              <SearchSuggestions
-                items={recentSearches.items}
-                onPick={handleSuggestPick}
-                onRemove={handleSuggestRemove}
-                onClearAll={handleSuggestClearAll}
-                visible={suggestVisible}
-              />
-            </div>
-            <FilterBar
-              category={category}
-              lang={lang}
-              feedId={feedId}
-              feeds={feeds}
-              dateFrom={dateFrom}
-              dateTo={dateTo}
-              unreadOnly={unreadOnly}
-              starredOnly={starredOnly}
-              onCategoryChange={handleCategoryChange}
-              onLangChange={handleLangChange}
-              onFeedChange={handleFeedChange}
-              onDateFromChange={handleDateFromChange}
-              onDateToChange={handleDateToChange}
-              onUnreadOnlyChange={handleUnreadOnlyChange}
-              onStarredOnlyChange={handleStarredOnlyChange}
-              onClear={handleClear}
-            />
-          </div>
-
-          {loading && (
-            <div className="text-center text-[var(--fg-muted)] py-[var(--space-8)] px-[var(--space-3)] border border-dashed border-[var(--border-subtle)] rounded-[var(--radius-lg)] mt-[var(--space-4)] text-[var(--font-size-base)] leading-[var(--line-height-relaxed)]">
-              読み込み中…
-            </div>
-          )}
-          {error && !loading && (
-            <div className="text-center text-[var(--danger)] py-[var(--space-8)] px-[var(--space-3)] border border-[rgba(207,34,46,0.3)] rounded-[var(--radius-lg)] bg-[var(--danger-soft)] mt-[var(--space-4)] text-[var(--font-size-base)] leading-[var(--line-height-relaxed)]">
-              取得エラー: {error}
-            </div>
-          )}
-          {!loading && !error && articles.length === 0 && bookmarkedOnly && (
-            <EmptyState
-              icon="🔖"
-              title="ブックマークがありません"
-              body="記事カードのブックマークアイコンから追加できます。"
-            />
-          )}
-          {!loading && !error && articles.length === 0 && !bookmarkedOnly && (
-            <EmptyState icon="📭" title="記事がまだありません" body="Cron 実行をお待ちください。" />
-          )}
-
-          {articles.length > 0 && (
-            <ArticleList
-              articles={articles}
-              selectedIndex={selectedIndex}
-              onFilterByCategory={handleFilterByCategory}
-              onFilterByFeedId={handleGoToFeedDetail}
-              onNavigateToAuthor={handleGoToAuthorDetail}
-              q={q}
-            />
-          )}
-
-          {nextCursor && (
-            <button
-              type="button"
-              className="block mx-auto mt-[var(--space-5)] py-[var(--space-2)] px-[var(--space-6)] bg-[var(--bg-overlay)] text-[var(--fg-primary)] border border-[var(--border-subtle)] rounded-[var(--radius-lg)] cursor-pointer text-[var(--font-size-sm)] font-[inherit] font-medium transition-[border-color,background] duration-100 hover:border-[var(--accent)] hover:bg-[var(--bg-elevated)] disabled:opacity-50 disabled:cursor-progress focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2"
-              onClick={loadMore}
-              disabled={loadingMore}
-            >
-              {loadingMore ? "読み込み中…" : "もっと読み込む"}
-            </button>
-          )}
-        </>
+        <ArticlesView
+          searchRef={searchRef}
+          articles={articles}
+          loading={loading}
+          loadingMore={loadingMore}
+          error={error}
+          nextCursor={nextCursor}
+          loadMore={loadMore}
+          selectedIndex={selectedIndex}
+          q={q}
+          category={category}
+          lang={lang}
+          feedId={feedId}
+          dateFrom={dateFrom}
+          dateTo={dateTo}
+          unreadOnly={unreadOnly}
+          starredOnly={starredOnly}
+          bookmarkedOnly={bookmarkedOnly}
+          stats={stats}
+          onQChange={filterHandlers.handleQChange}
+          onCategoryChange={filterHandlers.handleCategoryChange}
+          onLangChange={filterHandlers.handleLangChange}
+          onFeedChange={filterHandlers.handleFeedChange}
+          onDateFromChange={filterHandlers.handleDateFromChange}
+          onDateToChange={filterHandlers.handleDateToChange}
+          onUnreadOnlyChange={filterHandlers.handleUnreadOnlyChange}
+          onStarredOnlyChange={filterHandlers.handleStarredOnlyChange}
+          onClear={filterHandlers.handleClear}
+          onBookmarkedOnlyToggle={filterHandlers.handleBookmarkedOnlyToggle}
+          onApplyPreset={filterHandlers.handleApplyPreset}
+          onFilterByCategory={filterHandlers.handleFilterByCategory}
+          onGoToFeedDetail={handleGoToFeedDetail}
+          onGoToAuthorDetail={handleGoToAuthorDetail}
+        />
       )}
       <ToastContainer />
     </div>

--- a/apps/web/client/components/ArticlesView.tsx
+++ b/apps/web/client/components/ArticlesView.tsx
@@ -1,0 +1,256 @@
+import { useCallback, useRef, useState, type RefObject } from "react";
+import { useBookmarks } from "../hooks/useBookmarks";
+import { useFeeds } from "../hooks/useFeeds";
+import { usePresets } from "../hooks/usePresets";
+import { useRecentSearches } from "../hooks/useRecentSearches";
+import type { Stats } from "../hooks/useStats";
+import type { Article } from "../types/api";
+import type { FeedCategory, FeedLang } from "../types/api";
+import { formatRelative } from "../lib/routing";
+import { ArticleList } from "./ArticleList";
+import { EmptyState } from "./EmptyState";
+import { FilterBar } from "./FilterBar";
+import { PresetBar } from "./PresetBar";
+import { SearchInput } from "./SearchInput";
+import { SearchSuggestions } from "./SearchSuggestions";
+import { StatsPanel } from "./Stats";
+import { StaleFeedsWarning } from "./StaleFeedsWarning";
+
+interface Props {
+  searchRef: RefObject<HTMLInputElement | null>;
+  articles: Article[];
+  loading: boolean;
+  loadingMore: boolean;
+  error: string | null;
+  nextCursor: string | null;
+  loadMore: () => void;
+  selectedIndex: number;
+  q: string;
+  category: FeedCategory | "";
+  lang: FeedLang | "";
+  feedId: string;
+  dateFrom: string;
+  dateTo: string;
+  unreadOnly: boolean;
+  starredOnly: boolean;
+  bookmarkedOnly: boolean;
+  stats: Stats | null;
+  onQChange: (v: string) => void;
+  onCategoryChange: (v: FeedCategory | "") => void;
+  onLangChange: (v: FeedLang | "") => void;
+  onFeedChange: (id: string) => void;
+  onDateFromChange: (v: string) => void;
+  onDateToChange: (v: string) => void;
+  onUnreadOnlyChange: (v: boolean) => void;
+  onStarredOnlyChange: (v: boolean) => void;
+  onClear: () => void;
+  onBookmarkedOnlyToggle: () => void;
+  onApplyPreset: (filters: {
+    category?: FeedCategory | "";
+    lang?: FeedLang | "";
+    feedId?: string;
+    q?: string;
+    unreadOnly?: boolean;
+    starredOnly?: boolean;
+    dateFrom?: string;
+    dateTo?: string;
+  }) => void;
+  onFilterByCategory: (c: FeedCategory) => void;
+  onGoToFeedDetail: (id: string) => void;
+  onGoToAuthorDetail: (name: string) => void;
+}
+
+export function ArticlesView({
+  searchRef,
+  articles,
+  loading,
+  loadingMore,
+  error,
+  nextCursor,
+  loadMore,
+  selectedIndex,
+  q,
+  category,
+  lang,
+  feedId,
+  dateFrom,
+  dateTo,
+  unreadOnly,
+  starredOnly,
+  bookmarkedOnly,
+  stats,
+  onQChange,
+  onCategoryChange,
+  onLangChange,
+  onFeedChange,
+  onDateFromChange,
+  onDateToChange,
+  onUnreadOnlyChange,
+  onStarredOnlyChange,
+  onClear,
+  onBookmarkedOnlyToggle,
+  onApplyPreset,
+  onFilterByCategory,
+  onGoToFeedDetail,
+  onGoToAuthorDetail,
+}: Props) {
+  const { feeds } = useFeeds();
+  const { bookmarks } = useBookmarks();
+  const { presets, addPreset, removePreset } = usePresets();
+  const recentSearches = useRecentSearches();
+
+  const blurTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [suggestVisible, setSuggestVisible] = useState(false);
+
+  const handleSearchFocusIn = useCallback(() => {
+    if (blurTimerRef.current !== null) {
+      clearTimeout(blurTimerRef.current);
+      blurTimerRef.current = null;
+    }
+    setSuggestVisible(true);
+  }, []);
+
+  const handleSearchBlur = useCallback(() => {
+    // mousedown の取りこぼし防止のため 150ms 遅延させる
+    blurTimerRef.current = setTimeout(() => {
+      setSuggestVisible(false);
+    }, 150);
+  }, []);
+
+  const handleSuggestPick = useCallback(
+    (picked: string) => {
+      onQChange(picked);
+      recentSearches.add(picked);
+      setSuggestVisible(false);
+      searchRef.current?.focus();
+    },
+    [onQChange, recentSearches, searchRef],
+  );
+
+  const handleSuggestRemove = useCallback(
+    (item: string) => recentSearches.remove(item),
+    [recentSearches],
+  );
+
+  const handleSuggestClearAll = useCallback(() => recentSearches.clear(), [recentSearches]);
+
+  return (
+    <>
+      <header className="flex justify-between items-center flex-wrap gap-[var(--space-2)] mb-[var(--space-4)]">
+        <span className="text-[var(--fg-muted)] text-[var(--font-size-sm)]">
+          {stats ? `${stats.total.toLocaleString()} 記事 · 直近 24h: ${stats.last24h}` : ""}
+          {feeds.length > 0 ? ` · ${feeds.length} sources` : ""}
+          {stats?.last_fetched_at ? ` · 最終更新 ${formatRelative(stats.last_fetched_at)}` : ""}
+        </span>
+        <button
+          type="button"
+          className={`py-[5px] px-[var(--space-3)] bg-[var(--bg-elevated)] border border-[var(--border-subtle)] rounded-[var(--radius-full)] text-[var(--font-size-sm)] font-[inherit] cursor-pointer whitespace-nowrap shrink-0 transition-[border-color,color,background] duration-100 hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2${bookmarkedOnly ? " bg-[var(--accent-soft)] border-[var(--accent)] text-[var(--accent)] font-semibold" : " text-[var(--fg-muted)]"}`}
+          onClick={onBookmarkedOnlyToggle}
+          aria-pressed={bookmarkedOnly}
+        >
+          ★ {bookmarks.size} 件{bookmarkedOnly ? " (表示中)" : ""}
+        </button>
+        {stats && <StaleFeedsWarning staleFeeds={stats.stale_feeds} />}
+      </header>
+
+      {stats && <StatsPanel stats={stats} />}
+
+      <PresetBar
+        presets={presets}
+        currentFilters={{
+          category,
+          lang,
+          feedId,
+          q,
+          unreadOnly,
+          starredOnly,
+          dateFrom,
+          dateTo,
+        }}
+        onApply={onApplyPreset}
+        onAdd={addPreset}
+        onRemove={removePreset}
+      />
+
+      <div className="grid grid-cols-1 gap-[var(--space-3)] mb-[var(--space-5)] p-[var(--space-3)] bg-[var(--bg-elevated)] border border-[var(--border-subtle)] rounded-[var(--radius-lg)] min-[720px]:[grid-template-columns:1fr_auto_auto_auto] min-[720px]:items-center">
+        <div className="relative">
+          <SearchInput
+            ref={searchRef}
+            value={q}
+            onChange={onQChange}
+            onFocus={handleSearchFocusIn}
+            onBlur={handleSearchBlur}
+          />
+          <SearchSuggestions
+            items={recentSearches.items}
+            onPick={handleSuggestPick}
+            onRemove={handleSuggestRemove}
+            onClearAll={handleSuggestClearAll}
+            visible={suggestVisible}
+          />
+        </div>
+        <FilterBar
+          category={category}
+          lang={lang}
+          feedId={feedId}
+          feeds={feeds}
+          dateFrom={dateFrom}
+          dateTo={dateTo}
+          unreadOnly={unreadOnly}
+          starredOnly={starredOnly}
+          onCategoryChange={onCategoryChange}
+          onLangChange={onLangChange}
+          onFeedChange={onFeedChange}
+          onDateFromChange={onDateFromChange}
+          onDateToChange={onDateToChange}
+          onUnreadOnlyChange={onUnreadOnlyChange}
+          onStarredOnlyChange={onStarredOnlyChange}
+          onClear={onClear}
+        />
+      </div>
+
+      {loading && (
+        <div className="text-center text-[var(--fg-muted)] py-[var(--space-8)] px-[var(--space-3)] border border-dashed border-[var(--border-subtle)] rounded-[var(--radius-lg)] mt-[var(--space-4)] text-[var(--font-size-base)] leading-[var(--line-height-relaxed)]">
+          読み込み中…
+        </div>
+      )}
+      {error && !loading && (
+        <div className="text-center text-[var(--danger)] py-[var(--space-8)] px-[var(--space-3)] border border-[rgba(207,34,46,0.3)] rounded-[var(--radius-lg)] bg-[var(--danger-soft)] mt-[var(--space-4)] text-[var(--font-size-base)] leading-[var(--line-height-relaxed)]">
+          取得エラー: {error}
+        </div>
+      )}
+      {!loading && !error && articles.length === 0 && bookmarkedOnly && (
+        <EmptyState
+          icon="🔖"
+          title="ブックマークがありません"
+          body="記事カードのブックマークアイコンから追加できます。"
+        />
+      )}
+      {!loading && !error && articles.length === 0 && !bookmarkedOnly && (
+        <EmptyState icon="📭" title="記事がまだありません" body="Cron 実行をお待ちください。" />
+      )}
+
+      {articles.length > 0 && (
+        <ArticleList
+          articles={articles}
+          selectedIndex={selectedIndex}
+          onFilterByCategory={onFilterByCategory}
+          onFilterByFeedId={onGoToFeedDetail}
+          onNavigateToAuthor={onGoToAuthorDetail}
+          q={q}
+        />
+      )}
+
+      {nextCursor && (
+        <button
+          type="button"
+          className="block mx-auto mt-[var(--space-5)] py-[var(--space-2)] px-[var(--space-6)] bg-[var(--bg-overlay)] text-[var(--fg-primary)] border border-[var(--border-subtle)] rounded-[var(--radius-lg)] cursor-pointer text-[var(--font-size-sm)] font-[inherit] font-medium transition-[border-color,background] duration-100 hover:border-[var(--accent)] hover:bg-[var(--bg-elevated)] disabled:opacity-50 disabled:cursor-progress focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2"
+          onClick={loadMore}
+          disabled={loadingMore}
+        >
+          {loadingMore ? "読み込み中…" : "もっと読み込む"}
+        </button>
+      )}
+    </>
+  );
+}

--- a/apps/web/client/components/EmptyState.tsx
+++ b/apps/web/client/components/EmptyState.tsx
@@ -1,0 +1,17 @@
+interface Props {
+  icon: string;
+  title: string;
+  body: string;
+}
+
+export function EmptyState({ icon, title, body }: Props) {
+  return (
+    <div className="text-center text-[var(--fg-muted)] py-[var(--space-8)] px-[var(--space-3)] border border-dashed border-[var(--border-subtle)] rounded-[var(--radius-lg)] mt-[var(--space-4)] text-[var(--font-size-base)] leading-[var(--line-height-relaxed)]">
+      <span className="text-[2.5rem] block mb-[var(--space-3)] leading-none">{icon}</span>
+      <div className="text-[var(--font-size-md)] font-semibold text-[var(--fg-secondary)] mb-[var(--space-1)]">
+        {title}
+      </div>
+      <div className="text-[var(--font-size-sm)] text-[var(--fg-muted)]">{body}</div>
+    </div>
+  );
+}

--- a/apps/web/client/components/StaleFeedsWarning.tsx
+++ b/apps/web/client/components/StaleFeedsWarning.tsx
@@ -1,0 +1,30 @@
+import type { StaleFeed } from "../hooks/useStats";
+import { formatRelative } from "../lib/routing";
+
+interface Props {
+  staleFeeds: StaleFeed[];
+}
+
+export function StaleFeedsWarning({ staleFeeds }: Props) {
+  if (staleFeeds.length === 0) return null;
+
+  return (
+    <details className="w-full mt-[var(--space-2)] py-[var(--space-2)] px-[var(--space-3)] border border-[rgba(207,34,46,0.4)] rounded-[var(--radius-md)] bg-[var(--danger-soft)] text-[var(--font-size-sm)] [&>summary]:cursor-pointer [&>summary]:text-[var(--danger)] [&>summary]:font-semibold [&>ul]:mt-[var(--space-2)] [&>ul]:mb-0 [&>ul]:pl-[20px] [&>ul>li]:mb-[var(--space-1)]">
+      <summary>⚠ {staleFeeds.length} 件の収集に問題があります</summary>
+      <ul>
+        {staleFeeds.map((f) => (
+          <li key={f.id}>
+            <strong>{f.name}</strong>
+            {f.last_status === "error" ? " · error" : " · stale"}
+            {f.last_fetched_at ? ` · ${formatRelative(f.last_fetched_at)}` : " · 未取得"}
+            {f.last_error && (
+              <div className="text-[var(--fg-muted)] [font-family:ui-monospace,SFMono-Regular,monospace] text-[var(--font-size-xs)] mt-[2px]">
+                {f.last_error}
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </details>
+  );
+}

--- a/apps/web/client/hooks/useFilterHandlers.ts
+++ b/apps/web/client/hooks/useFilterHandlers.ts
@@ -1,0 +1,207 @@
+import { useCallback } from "react";
+import { buildSearch } from "../lib/routing";
+import type { FeedCategory, FeedLang } from "../types/api";
+
+interface FilterState {
+  category: FeedCategory | "";
+  lang: FeedLang | "";
+  feedId: string;
+  q: string;
+  dateFrom: string;
+  dateTo: string;
+  unreadOnly: boolean;
+  starredOnly: boolean;
+  bookmarkedOnly: boolean;
+}
+
+interface SetFilterState {
+  setFeedId: (v: string) => void;
+  setDateFrom: (v: string) => void;
+  setDateTo: (v: string) => void;
+  setUnreadOnly: (v: boolean) => void;
+  setStarredOnly: (v: boolean) => void;
+  setUrlFilters: (patch: { q?: string; bookmarksOnly?: boolean }) => void;
+  setView: (v: "articles") => void;
+}
+
+export function useFilterHandlers(state: FilterState, setters: SetFilterState) {
+  const { category, lang, feedId, q, dateFrom, dateTo, unreadOnly, starredOnly, bookmarkedOnly } =
+    state;
+  const {
+    setFeedId,
+    setDateFrom,
+    setDateTo,
+    setUnreadOnly,
+    setStarredOnly,
+    setUrlFilters,
+    setView,
+  } = setters;
+
+  const pushFilter = useCallback(
+    (
+      nextCategory: FeedCategory | "",
+      nextLang: FeedLang | "",
+      nextFeedId: string,
+      nextQ: string,
+      nextDateFrom: string,
+      nextDateTo: string,
+      nextUnreadOnly: boolean,
+      nextStarredOnly: boolean,
+    ) => {
+      const next = buildSearch(
+        nextCategory,
+        nextLang,
+        nextFeedId,
+        nextQ,
+        nextDateFrom,
+        nextDateTo,
+        nextUnreadOnly,
+        nextStarredOnly,
+        bookmarkedOnly,
+      );
+      const current = buildSearch(
+        category,
+        lang,
+        feedId,
+        q,
+        dateFrom,
+        dateTo,
+        unreadOnly,
+        starredOnly,
+        bookmarkedOnly,
+      );
+      if (next !== current) {
+        window.history.pushState(null, "", next);
+        // useUrlState の subscribe リスナー (popstate) を起動してキャッシュを無効化する
+        window.dispatchEvent(new PopStateEvent("popstate"));
+      }
+      setFeedId(nextFeedId);
+      setDateFrom(nextDateFrom);
+      setDateTo(nextDateTo);
+      setUnreadOnly(nextUnreadOnly);
+      setStarredOnly(nextStarredOnly);
+    },
+    [
+      category,
+      lang,
+      feedId,
+      q,
+      dateFrom,
+      dateTo,
+      unreadOnly,
+      starredOnly,
+      bookmarkedOnly,
+      setFeedId,
+      setDateFrom,
+      setDateTo,
+      setUnreadOnly,
+      setStarredOnly,
+    ],
+  );
+
+  const handleCategoryChange = useCallback(
+    (v: FeedCategory | "") =>
+      pushFilter(v, lang, v ? feedId : "", q, dateFrom, dateTo, unreadOnly, starredOnly),
+    [pushFilter, lang, feedId, q, dateFrom, dateTo, unreadOnly, starredOnly],
+  );
+
+  const handleLangChange = useCallback(
+    (v: FeedLang | "") =>
+      pushFilter(category, v, v ? feedId : "", q, dateFrom, dateTo, unreadOnly, starredOnly),
+    [pushFilter, category, feedId, q, dateFrom, dateTo, unreadOnly, starredOnly],
+  );
+
+  const handleFeedChange = useCallback(
+    (id: string) => pushFilter(category, lang, id, q, dateFrom, dateTo, unreadOnly, starredOnly),
+    [pushFilter, category, lang, q, dateFrom, dateTo, unreadOnly, starredOnly],
+  );
+
+  const handleQChange = useCallback((v: string) => setUrlFilters({ q: v }), [setUrlFilters]);
+
+  const handleDateFromChange = useCallback(
+    (v: string) => pushFilter(category, lang, feedId, q, v, dateTo, unreadOnly, starredOnly),
+    [pushFilter, category, lang, feedId, q, dateTo, unreadOnly, starredOnly],
+  );
+
+  const handleDateToChange = useCallback(
+    (v: string) => pushFilter(category, lang, feedId, q, dateFrom, v, unreadOnly, starredOnly),
+    [pushFilter, category, lang, feedId, q, dateFrom, unreadOnly, starredOnly],
+  );
+
+  const handleUnreadOnlyChange = useCallback(
+    (v: boolean) => pushFilter(category, lang, feedId, q, dateFrom, dateTo, v, starredOnly),
+    [pushFilter, category, lang, feedId, q, dateFrom, dateTo, starredOnly],
+  );
+
+  const handleStarredOnlyChange = useCallback(
+    (v: boolean) => pushFilter(category, lang, feedId, q, dateFrom, dateTo, unreadOnly, v),
+    [pushFilter, category, lang, feedId, q, dateFrom, dateTo, unreadOnly],
+  );
+
+  const handleClear = useCallback(
+    () => pushFilter("", "", "", "", "", "", false, false),
+    [pushFilter],
+  );
+
+  const handleApplyPreset = useCallback(
+    (filters: {
+      category?: FeedCategory | "";
+      lang?: FeedLang | "";
+      feedId?: string;
+      q?: string;
+      unreadOnly?: boolean;
+      starredOnly?: boolean;
+      dateFrom?: string;
+      dateTo?: string;
+    }) => {
+      pushFilter(
+        filters.category ?? "",
+        filters.lang ?? "",
+        filters.feedId ?? "",
+        filters.q ?? "",
+        filters.dateFrom ?? "",
+        filters.dateTo ?? "",
+        filters.unreadOnly ?? false,
+        filters.starredOnly ?? false,
+      );
+    },
+    [pushFilter],
+  );
+
+  const handleBookmarkedOnlyToggle = useCallback(() => {
+    setUrlFilters({ bookmarksOnly: !bookmarkedOnly });
+  }, [setUrlFilters, bookmarkedOnly]);
+
+  // カード上のバッジ/取得元クリックでフィルタを適用する
+  const handleFilterByCategory = useCallback(
+    (c: FeedCategory) => pushFilter(c, lang, "", q, dateFrom, dateTo, unreadOnly, starredOnly),
+    [pushFilter, lang, q, dateFrom, dateTo, unreadOnly, starredOnly],
+  );
+
+  // Categories overview からカテゴリカードをクリックした際に articles ページへ遷移してフィルタを適用する
+  const handleSelectCategory = useCallback(
+    (id: FeedCategory) => {
+      window.history.pushState(null, "", "/");
+      window.dispatchEvent(new PopStateEvent("popstate"));
+      setView("articles");
+      pushFilter(id, lang, "", q, dateFrom, dateTo, unreadOnly, starredOnly);
+    },
+    [pushFilter, setView, lang, q, dateFrom, dateTo, unreadOnly, starredOnly],
+  );
+
+  return {
+    handleCategoryChange,
+    handleLangChange,
+    handleFeedChange,
+    handleQChange,
+    handleDateFromChange,
+    handleDateToChange,
+    handleUnreadOnlyChange,
+    handleStarredOnlyChange,
+    handleClear,
+    handleApplyPreset,
+    handleBookmarkedOnlyToggle,
+    handleFilterByCategory,
+    handleSelectCategory,
+  };
+}

--- a/apps/web/client/lib/routing.ts
+++ b/apps/web/client/lib/routing.ts
@@ -1,0 +1,78 @@
+import type { AppView } from "../components/Header";
+import type { FeedCategory, FeedLang } from "../types/api";
+
+export function readFromUrl(): {
+  feedId: string;
+  dateFrom: string;
+  dateTo: string;
+  unreadOnly: boolean;
+  starredOnly: boolean;
+} {
+  const params = new URLSearchParams(window.location.search);
+  return {
+    feedId: params.get("feed_id") ?? "",
+    dateFrom: params.get("date_from") ?? "",
+    dateTo: params.get("date_to") ?? "",
+    unreadOnly: params.get("unread") === "1",
+    starredOnly: params.get("starred") === "1",
+  };
+}
+
+export function buildSearch(
+  category: FeedCategory | "",
+  lang: FeedLang | "",
+  feedId: string,
+  q: string,
+  dateFrom: string,
+  dateTo: string,
+  unreadOnly: boolean,
+  starredOnly: boolean,
+  bookmarksOnly: boolean,
+): string {
+  const params = new URLSearchParams();
+  if (category) params.set("category", category);
+  if (lang) params.set("lang", lang);
+  if (feedId) params.set("feed_id", feedId);
+  if (q) params.set("q", q);
+  if (dateFrom) params.set("date_from", dateFrom);
+  if (dateTo) params.set("date_to", dateTo);
+  // true のときだけ付ける
+  if (unreadOnly) params.set("unread", "1");
+  if (starredOnly) params.set("starred", "1");
+  if (bookmarksOnly) params.set("bookmarks", "only");
+  const s = params.toString();
+  return s ? `?${s}` : window.location.pathname;
+}
+
+/** /feed/<id> パスを解析してフィード詳細ページの feedId を返す。それ以外は null。*/
+export function readFeedDetailFromPath(): string | null {
+  const m = window.location.pathname.match(/^\/feed\/(.+)$/);
+  return m ? decodeURIComponent(m[1]) : null;
+}
+
+/** /author/<name> パスを解析して著者名を返す。それ以外は null。*/
+export function readAuthorFromPath(): string | null {
+  const m = window.location.pathname.match(/^\/author\/(.+)$/);
+  return m ? decodeURIComponent(m[1]) : null;
+}
+
+export function readViewFromUrl(): AppView {
+  if (window.location.pathname === "/stats") return "stats";
+  if (window.location.pathname === "/categories") return "categories";
+  if (readFeedDetailFromPath() !== null) return "feed";
+  if (readAuthorFromPath() !== null) return "author";
+  return "articles";
+}
+
+export function formatRelative(iso: string): string {
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return iso;
+  const diffMs = Date.now() - t;
+  const min = Math.round(diffMs / 60_000);
+  if (min < 1) return "今";
+  if (min < 60) return `${min} 分前`;
+  const h = Math.round(min / 60);
+  if (h < 24) return `${h} 時間前`;
+  const d = Math.round(h / 24);
+  return `${d} 日前`;
+}


### PR DESCRIPTION
## Summary

- apps/web/client/App.tsx が 649 行に達し 400 行ガイドラインを超過していたため pure refactor を実施
- 挙動は完全に同じ（API シグネチャ変更・新機能追加なし）
- Closes #257

## 分割マップ

| ファイル | 内容 | 行数 |
|---|---|---|
| App.tsx | routing/kb/navigation ロジックのみ残す | 649→283 |
| lib/routing.ts (新規) | URL helper 群 | 78 |
| hooks/useFilterHandlers.ts (新規) | pushFilter と全フィルタハンドラ | 207 |
| components/EmptyState.tsx (新規) | EmptyState コンポーネント | 17 |
| components/StaleFeedsWarning.tsx (新規) | stale feeds details セクション | 30 |
| components/ArticlesView.tsx (新規) | articles ビュー全体 | 256 |

## Test plan

- [x] pnpm build pass
- [x] pnpm run check pass (errors 0, warnings 3 は既存)
- [x] pnpm test pass (27 files, 507 tests)
- [x] 全ファイルが 400 行以下