### PR TITLE
fix(collector): soft-delete orphan feeds and consolidate retention

### DIFF
--- a/apps/web/tests/worker/collector/retention.test.ts
+++ b/apps/web/tests/worker/collector/retention.test.ts
@@ -1,0 +1,58 @@
+/**
+ * retention が collectAll / collectFeeds 内で走らず、
+ * scheduled の utcHour === 17 ブランチでのみ実行されることを確認するテスト。
+ *
+ * - collectAll / collectFeeds は pruned: 0 を返す (D1 書き込みなし)
+ * - pruneOldArticles は retention.test.ts で個別にテスト済み
+ */
+import { beforeEach, describe, expect, it } from "vite-plus/test";
+import { env } from "cloudflare:test";
+import { syncFeeds } from "../../../worker/db/feeds";
+import { insertArticles } from "../../../worker/db/articles";
+import { collectFeeds } from "../../../worker/collector/index";
+import type { Env, FeedConfig } from "../../../worker/types";
+
+const FEED_A: FeedConfig = {
+  id: "feed-retention-test",
+  name: "Retention Test Feed",
+  url: "https://x.test/retention",
+  category: "bigtech",
+  lang: "en",
+  enabled: true,
+};
+
+beforeEach(async () => {
+  await syncFeeds(env.DB, [FEED_A]);
+});
+
+describe("collectFeeds — retention は実行されない", () => {
+  it("古い記事が存在しても collectFeeds は pruned=0 を返す", async () => {
+    // 100 日前の古い記事を挿入 (retention なら削除対象)
+    const oldDate = new Date(Date.now() - 100 * 86400 * 1000).toISOString();
+    await insertArticles(env.DB, [
+      {
+        guid: "old-article-for-retention",
+        feed_id: "feed-retention-test",
+        title: "Old Article",
+        url: "https://x.test/retention/old",
+        summary: null,
+        author: null,
+        published_at: oldDate,
+        category: "bigtech",
+        lang: "en",
+      },
+    ]);
+
+    // 存在しない feedIds を渡すと activeFeeds が空になり、fetch は発生しない
+    // pruned は collectFeeds 内では常に 0
+    const result = await collectFeeds(env as unknown as Env, ["no-such-feed-id"]);
+
+    expect(result.pruned).toBe(0);
+
+    // 古い記事は削除されていないことを確認 (collectFeeds では retention を実行しないため)
+    const row = await env.DB.prepare(
+      "SELECT COUNT(*) AS n FROM articles WHERE guid = 'old-article-for-retention'",
+    ).first<{ n: number }>();
+    expect(row?.n).toBe(1);
+  });
+});

--- a/apps/web/tests/worker/db/feeds.test.ts
+++ b/apps/web/tests/worker/db/feeds.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it } from "vite-plus/test";
+import { env } from "cloudflare:test";
+import { syncFeeds } from "../../../worker/db/feeds";
+import type { FeedConfig } from "../../../worker/types";
+
+const FEED_A: FeedConfig = {
+  id: "feed-a",
+  name: "Feed A",
+  url: "https://x.test/a",
+  category: "bigtech",
+  lang: "en",
+  enabled: true,
+};
+
+const FEED_B: FeedConfig = {
+  id: "feed-b",
+  name: "Feed B",
+  url: "https://x.test/b",
+  category: "ai",
+  lang: "en",
+  enabled: true,
+};
+
+beforeEach(async () => {
+  await syncFeeds(env.DB, [FEED_A, FEED_B]);
+});
+
+describe("syncFeeds — soft-delete orphan feeds", () => {
+  it("yaml から消えたフィードは enabled=0 になる", async () => {
+    // A だけの yaml で再 sync → B が soft-delete される
+    await syncFeeds(env.DB, [FEED_A]);
+
+    const b = await env.DB.prepare("SELECT enabled FROM feeds WHERE id = ?1")
+      .bind("feed-b")
+      .first<{ enabled: number }>();
+    expect(b?.enabled).toBe(0);
+
+    // A は変わらず有効
+    const a = await env.DB.prepare("SELECT enabled FROM feeds WHERE id = ?1")
+      .bind("feed-a")
+      .first<{ enabled: number }>();
+    expect(a?.enabled).toBe(1);
+  });
+
+  it("yaml に再登場したフィードは enabled=1 に戻る", async () => {
+    // まず B を soft-delete する
+    await syncFeeds(env.DB, [FEED_A]);
+    const b = await env.DB.prepare("SELECT enabled FROM feeds WHERE id = ?1")
+      .bind("feed-b")
+      .first<{ enabled: number }>();
+    expect(b?.enabled).toBe(0);
+
+    // B を yaml に戻す → enabled=1 に復活する
+    await syncFeeds(env.DB, [FEED_A, FEED_B]);
+    const bRestored = await env.DB.prepare("SELECT enabled FROM feeds WHERE id = ?1")
+      .bind("feed-b")
+      .first<{ enabled: number }>();
+    expect(bRestored?.enabled).toBe(1);
+  });
+
+  it("既に enabled=0 のフィードは soft-delete で変化しない (idempotent)", async () => {
+    // B を soft-delete
+    await syncFeeds(env.DB, [FEED_A]);
+    // もう一度 A だけで sync しても B は enabled=0 のまま
+    await syncFeeds(env.DB, [FEED_A]);
+
+    const b = await env.DB.prepare("SELECT enabled FROM feeds WHERE id = ?1")
+      .bind("feed-b")
+      .first<{ enabled: number }>();
+    expect(b?.enabled).toBe(0);
+  });
+});

--- a/apps/web/worker/collector/index.ts
+++ b/apps/web/worker/collector/index.ts
@@ -5,7 +5,7 @@ import { parseXml, pickText, asArray } from "../utils/xml";
 import { buildGuids } from "./deduplicator";
 import { D1CostAccumulator, writeCollectorEvent, writeD1CostEvent } from "./metrics";
 import { maybeAlert, sendAlert } from "./alert";
-import { deleteOlderThan, insertArticles, type InsertableArticle } from "../db/articles";
+import { insertArticles, type InsertableArticle } from "../db/articles";
 import {
   getEnabledFeedIds,
   getFeedStreaks,
@@ -311,19 +311,9 @@ export async function collectFeeds(env: Env, feedIds?: string[]): Promise<Collec
   const inserted = results.reduce((acc, r) => acc + r.inserted, 0);
   const skipped304 = results.filter((r) => r.status === "not_modified").length;
 
-  const retentionDays = Number(env.RETENTION_DAYS ?? "90") || 90;
-  let pruned = 0;
-  try {
-    pruned = await deleteOlderThan(env.DB, retentionDays);
-  } catch (err) {
-    console.warn(
-      `[collector] retention prune failed: ${err instanceof Error ? err.message : String(err)}`,
-    );
-  }
-
   const durationMs = Date.now() - start;
   console.log(
-    `[collector] feeds=${activeFeeds.length} skipped304=${skipped304} inserted=${inserted} pruned=${pruned} retentionDays=${retentionDays} duration=${durationMs}ms`,
+    `[collector] feeds=${activeFeeds.length} skipped304=${skipped304} inserted=${inserted} duration=${durationMs}ms`,
   );
   for (const r of results) {
     if (r.status === "error") {
@@ -344,7 +334,7 @@ export async function collectFeeds(env: Env, feedIds?: string[]): Promise<Collec
     }
   }
 
-  return { total: activeFeeds.length, inserted, pruned, results, durationMs };
+  return { total: activeFeeds.length, inserted, pruned: 0, results, durationMs };
 }
 
 export type ValidateFeedResult =
@@ -493,15 +483,9 @@ export async function collectAll(
   const feedsOk = results.filter((r) => r.status === "ok" || r.status === "not_modified").length;
   const feedsFailed = results.filter((r) => r.status === "error").length;
 
-  const retentionDays = Number(env.RETENTION_DAYS ?? "90") || 90;
-  let pruned = 0;
-  try {
-    pruned = await deleteOlderThan(env.DB, retentionDays);
-  } catch (err) {
-    console.warn(
-      `[collector] retention prune failed: ${err instanceof Error ? err.message : String(err)}`,
-    );
-  }
+  // retention は scheduled() の utcHour === 17 ブランチで一本化しているため、
+  // collectAll 内では実行しない (D1 書き込み節約 + 重複排除)
+  const pruned = 0;
 
   const durationMs = Date.now() - start;
   const completedAt = new Date(Date.now()).toISOString();
@@ -519,7 +503,7 @@ export async function collectAll(
   }
 
   console.log(
-    `[collector] feeds=${activeFeeds.length} skipped304=${skipped304} inserted=${inserted} pruned=${pruned} retentionDays=${retentionDays} duration=${durationMs}ms`,
+    `[collector] feeds=${activeFeeds.length} skipped304=${skipped304} inserted=${inserted} duration=${durationMs}ms`,
   );
 
   // D1 コスト集計を AE に送信する (best-effort)

--- a/apps/web/worker/db/articles.ts
+++ b/apps/web/worker/db/articles.ts
@@ -334,18 +334,6 @@ export async function countArticlesSince(db: D1Database, isoDate: string): Promi
   return row?.c ?? 0;
 }
 
-export async function deleteOlderThan(db: D1Database, retentionDays: number): Promise<number> {
-  if (!Number.isFinite(retentionDays) || retentionDays <= 0) return 0;
-  // SQLite で安全のため整数化、少数日は切り捨て
-  const days = Math.floor(retentionDays);
-  const result = await db
-    .prepare(`DELETE FROM articles WHERE published_at < datetime('now', ?1)`)
-    .bind(`-${days} days`)
-    .run();
-  // FTS トリガで複数 changes が返るため、count(*) との差分は取らずに meta は参考値
-  return result.meta?.changes ?? 0;
-}
-
 export interface CategoryTrendPoint {
   date: string;
   ai: number;

--- a/apps/web/worker/db/feeds.ts
+++ b/apps/web/worker/db/feeds.ts
@@ -70,6 +70,22 @@ export async function syncFeeds(db: D1Database, feeds: FeedConfig[]): Promise<vo
   for (let i = 0; i < stmts.length; i += BATCH_SIZE) {
     await db.batch(stmts.slice(i, i + BATCH_SIZE));
   }
+
+  // yaml に存在しない id を soft-delete する。
+  // 完全 DELETE は articles の CASCADE で副作用が大きいため enabled=0 で無効化する。
+  // yaml に再登場した場合は上記 UPSERT で enabled が復活する。
+  const activeIds = feeds.map((f) => f.id);
+  const placeholders = activeIds.map((_, i) => `?${i + 1}`).join(",");
+  await db
+    .prepare(
+      `UPDATE feeds
+       SET enabled = 0,
+           updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+       WHERE id NOT IN (${placeholders})
+         AND enabled = 1`,
+    )
+    .bind(...activeIds)
+    .run();
 }
 
 export async function recordFetchSuccess(

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -78,10 +78,11 @@ const handler: ExportedHandler<Env> = {
         }),
       );
     }
-    // Run retention once per day at UTC 17:00 to avoid peak write hours
+    // Run retention once per day at UTC 17:00 to avoid peak write hours.
+    // collectAll 内では retention を実行しないため、ここが唯一の実行箇所。
     if (utcHour === 17) {
       ctx.waitUntil(
-        pruneOldArticles(env.DB, Number(env.RETENTION_DAYS ?? "0")).then((r) => {
+        pruneOldArticles(env.DB, Number(env.RETENTION_DAYS ?? "90") || 90).then((r) => {
           console.log(`[retention] deleted=${r.deleted}`);
           return r;
         }),


### PR DESCRIPTION
Closes #260

## 概要

collector に関する 2 つの High 優先度負債を一括修正。

---

## 負債 #1: syncFeeds orphan soft-delete

### 症状
`feeds.yaml` から削除したフィードが `feeds` テーブルに残り続け、`stats.stale_feeds` に永続表示される。

### 修正内容
`syncFeeds()` の末尾に「yaml に存在しない id を `enabled = 0` に落とす」UPDATE を追加。

```sql
UPDATE feeds
SET enabled = 0, updated_at = ...
WHERE id NOT IN (<yaml の id リスト>)
  AND enabled = 1
```

- 完全 DELETE は `articles` の `ON DELETE CASCADE` を誘発するため **soft-delete** を採用
- yaml に再登場した id は既存の UPSERT (`enabled = excluded.enabled`) で自動復活

### 影響ファイル
- `apps/web/worker/db/feeds.ts` — syncFeeds に soft-delete 追加

---

## 負債 #2: retention 重複実行の解消

### 症状
`scheduled()` の `utcHour === 17` ブランチで `pruneOldArticles` が実行される一方、`collectAll` と `collectFeeds` 内でも `deleteOlderThan` が呼ばれており、1 cron 実行で retention が最大 3 回走る可能性があった。
また `deleteOlderThan` (SQL ベース) と `pruneOldArticles` (JS cutoff 計算) で実装が分散していた。

### 修正内容
- `collectAll` / `collectFeeds` 内の `deleteOlderThan` 呼び出しを削除
- `deleteOlderThan` を `db/articles.ts` から削除し `pruneOldArticles` に一本化
- `collectAll` / `collectFeeds` の戻り値 `pruned` は常に `0` を返す（型 `CollectAllResult.pruned` は維持）
- `index.ts` の `pruneOldArticles` デフォルト値を `"0"` → `"90"` に修正（以前は RETENTION_DAYS 未設定で no-op になっていた）

### 影響ファイル
- `apps/web/worker/db/articles.ts` — `deleteOlderThan` 削除
- `apps/web/worker/collector/index.ts` — import および呼び出し削除、ログ修正
- `apps/web/worker/index.ts` — デフォルト値修正

---

## テスト

- `apps/web/tests/worker/db/feeds.test.ts` — 新規: syncFeeds soft-delete の動作確認
  - yaml から削除 → enabled=0
  - yaml に復活 → enabled=1
  - 冪等性確認
- `apps/web/tests/worker/collector/retention.test.ts` — 新規: collectFeeds が retention を実行しないことを確認
  - 古い記事が存在しても `pruned=0` を返す
  - 古い記事が削除されていないことを確認

## チェックリスト

- [x] `pnpm build` pass
- [x] `pnpm test` — 全 511 件 pass (29 ファイル)
- [x] `pnpm lint` — 今回追加ファイルに新規エラーなし（既存 warning/error は pre-existing）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for feed synchronization and article retention scheduling.

* **Behavior Changes**
  * Removed feeds are now soft-disabled instead of permanently deleted, allowing re-enablement if reconfigured.
  * Article retention now executes only on a scheduled basis (default 90 days) instead of during regular collection operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->