### PR TITLE
fix(collector): subrequest 削減と orphan feed 整理 / cron 緩和

### DIFF
--- a/apps/web/tests/worker/db/feeds.test.ts
+++ b/apps/web/tests/worker/db/feeds.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it } from "vite-plus/test";
+import { env } from "cloudflare:test";
+import { loadFeedHeadersAll, syncFeeds, updateFeedHeaders } from "../../../worker/db/feeds";
+import type { FeedConfig } from "../../../worker/types";
+
+const FEED_A: FeedConfig = {
+  id: "feed-a",
+  name: "Feed A",
+  url: "https://a.test/rss",
+  category: "bigtech",
+  lang: "en",
+  enabled: true,
+};
+
+const FEED_B: FeedConfig = {
+  id: "feed-b",
+  name: "Feed B",
+  url: "https://b.test/rss",
+  category: "ai",
+  lang: "en",
+  enabled: true,
+};
+
+const FEED_C: FeedConfig = {
+  id: "feed-c",
+  name: "Feed C",
+  url: "https://c.test/rss",
+  category: "jp",
+  lang: "ja",
+  enabled: true,
+};
+
+describe("syncFeeds orphan cleanup", () => {
+  it("disables feeds in D1 that are no longer present in yaml", async () => {
+    // 最初は 3 件が enabled
+    await syncFeeds(env.DB, [FEED_A, FEED_B, FEED_C]);
+    const before = await env.DB.prepare(
+      `SELECT id, enabled FROM feeds WHERE id IN ('feed-a','feed-b','feed-c') ORDER BY id`,
+    ).all<{ id: string; enabled: number }>();
+    expect(before.results).toEqual([
+      { id: "feed-a", enabled: 1 },
+      { id: "feed-b", enabled: 1 },
+      { id: "feed-c", enabled: 1 },
+    ]);
+
+    // yaml から feed-c を取り除いた状態で再 sync
+    await syncFeeds(env.DB, [FEED_A, FEED_B]);
+
+    const after = await env.DB.prepare(
+      `SELECT id, enabled FROM feeds WHERE id IN ('feed-a','feed-b','feed-c') ORDER BY id`,
+    ).all<{ id: string; enabled: number }>();
+    expect(after.results).toEqual([
+      { id: "feed-a", enabled: 1 },
+      { id: "feed-b", enabled: 1 },
+      { id: "feed-c", enabled: 0 },
+    ]);
+  });
+
+  it("does not touch already-disabled orphan feeds (idempotent)", async () => {
+    await syncFeeds(env.DB, [FEED_A, FEED_B, FEED_C]);
+    await syncFeeds(env.DB, [FEED_A, FEED_B]); // feed-c を一度 disable
+
+    const beforeRow = await env.DB.prepare(
+      `SELECT updated_at FROM feeds WHERE id = 'feed-c'`,
+    ).first<{ updated_at: string }>();
+
+    // 同じ yaml で再 sync しても feed-c の updated_at は変わらない (enabled=1 の行だけ対象)
+    await syncFeeds(env.DB, [FEED_A, FEED_B]);
+
+    const afterRow = await env.DB.prepare(
+      `SELECT updated_at FROM feeds WHERE id = 'feed-c'`,
+    ).first<{ updated_at: string }>();
+
+    expect(afterRow?.updated_at).toBe(beforeRow?.updated_at);
+  });
+
+  it("re-enables a feed if it returns to yaml (yaml is the source of truth)", async () => {
+    await syncFeeds(env.DB, [FEED_A, FEED_B, FEED_C]);
+    await syncFeeds(env.DB, [FEED_A, FEED_B]); // feed-c disable
+
+    // feed-c が yaml に戻ったら enabled=1 に戻る
+    await syncFeeds(env.DB, [FEED_A, FEED_B, FEED_C]);
+
+    const row = await env.DB.prepare(`SELECT enabled FROM feeds WHERE id = 'feed-c'`).first<{
+      enabled: number;
+    }>();
+    expect(row?.enabled).toBe(1);
+  });
+});
+
+describe("loadFeedHeadersAll", () => {
+  beforeEach(async () => {
+    await syncFeeds(env.DB, [FEED_A, FEED_B, FEED_C]);
+  });
+
+  it("returns an empty Map when feedIds is empty", async () => {
+    const map = await loadFeedHeadersAll(env.DB, []);
+    expect(map.size).toBe(0);
+  });
+
+  it("returns saved etag/last_modified for each feed in one query", async () => {
+    await updateFeedHeaders(env.DB, "feed-a", '"a-etag"', "Mon, 01 Jan 2024 00:00:00 GMT");
+    await updateFeedHeaders(env.DB, "feed-b", '"b-etag"', null);
+
+    const map = await loadFeedHeadersAll(env.DB, ["feed-a", "feed-b", "feed-c"]);
+    expect(map.size).toBe(3);
+    expect(map.get("feed-a")).toEqual({
+      last_etag: '"a-etag"',
+      last_modified: "Mon, 01 Jan 2024 00:00:00 GMT",
+    });
+    expect(map.get("feed-b")).toEqual({ last_etag: '"b-etag"', last_modified: null });
+    expect(map.get("feed-c")).toEqual({ last_etag: null, last_modified: null });
+  });
+
+  it("omits unknown feed ids from the returned Map", async () => {
+    const map = await loadFeedHeadersAll(env.DB, ["feed-a", "non-existent"]);
+    expect(map.has("feed-a")).toBe(true);
+    expect(map.has("non-existent")).toBe(false);
+  });
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -18,6 +18,9 @@ export default defineConfig(async () => {
             ADMIN_TOKEN_NEXT: "test-admin-token-next",
             // フィード収集テストで外部 fetch が失敗するため短くしてタイムアウトを速める
             COLLECTOR_TIMEOUT_MS: "500",
+            // 本番は 1 並列だが、テストでは全 yaml feed を直列に回すと per-feed retry で
+            // 25-30s deadline を超えるため 4 並列に上書きする (Medium レート制限テストではない)
+            COLLECTOR_CONCURRENCY: "4",
           },
         },
       }),

--- a/apps/web/worker/collector/index.ts
+++ b/apps/web/worker/collector/index.ts
@@ -7,9 +7,10 @@ import { D1CostAccumulator, writeCollectorEvent, writeD1CostEvent } from "./metr
 import { maybeAlert, sendAlert } from "./alert";
 import { deleteOlderThan, insertArticles, type InsertableArticle } from "../db/articles";
 import {
+  type FeedHeaders,
   getEnabledFeedIds,
   getFeedStreaks,
-  loadFeedHeaders,
+  loadFeedHeadersAll,
   recordFetchError,
   recordFetchSuccess,
   syncFeeds,
@@ -177,6 +178,7 @@ function isSafeUrl(url: string): boolean {
 async function collectFeed(
   env: Env,
   feed: FeedConfig,
+  savedHeaders: FeedHeaders,
   summaryMax: number,
   timeoutMs: number,
   maxRetries: number,
@@ -184,8 +186,8 @@ async function collectFeed(
   const fetchedAt = new Date().toISOString();
   const t0 = performance.now();
   try {
-    // 前回の conditional GET ヘッダを読み込んでリクエストに付与する
-    const savedHeaders = await loadFeedHeaders(env.DB, feed.id);
+    // savedHeaders は collectAll 冒頭で全 enabled feed 分を 1 query でまとめて取得済み。
+    // feed あたり 1 read を消費しないので Worker の subrequest 上限対策になる。
     const result = await fetchFeed(feed.url, timeoutMs, maxRetries, {
       etag: savedHeaders.last_etag,
       lastModified: savedHeaders.last_modified,
@@ -304,8 +306,21 @@ export async function collectFeeds(env: Env, feedIds?: string[]): Promise<Collec
   const maxRetries = Number(env.COLLECTOR_RETRIES ?? "2") || 2;
   const summaryMax = Number(env.SUMMARY_MAX_LENGTH ?? "500") || 500;
 
+  const headersMap = await loadFeedHeadersAll(
+    env.DB,
+    activeFeeds.map((f) => f.id),
+  );
+  const emptyHeaders: FeedHeaders = { last_etag: null, last_modified: null };
+
   const results = await runWithConcurrency(activeFeeds, concurrency, (feed) =>
-    collectFeed(env, feed, summaryMax, timeoutMs, maxRetries),
+    collectFeed(
+      env,
+      feed,
+      headersMap.get(feed.id) ?? emptyHeaders,
+      summaryMax,
+      timeoutMs,
+      maxRetries,
+    ),
   );
 
   const inserted = results.reduce((acc, r) => acc + r.inserted, 0);
@@ -458,9 +473,22 @@ export async function collectAll(
     }
   }
 
+  const headersMap = await loadFeedHeadersAll(
+    env.DB,
+    activeFeeds.map((f) => f.id),
+  );
+  const emptyHeaders: FeedHeaders = { last_etag: null, last_modified: null };
+
   const results = await runWithConcurrency(activeFeeds, concurrency, async (feed) => {
     const feedStart = Date.now();
-    const result = await collectFeed(env, feed, summaryMax, timeoutMs, maxRetries);
+    const result = await collectFeed(
+      env,
+      feed,
+      headersMap.get(feed.id) ?? emptyHeaders,
+      summaryMax,
+      timeoutMs,
+      maxRetries,
+    );
     const durationMs = Date.now() - feedStart;
 
     // 各フィードの結果を記録する。失敗しても collectFeed の結果は返す。

--- a/apps/web/worker/db/feeds.ts
+++ b/apps/web/worker/db/feeds.ts
@@ -28,6 +28,29 @@ export async function loadFeedHeaders(db: D1Database, feedId: string): Promise<F
 }
 
 /**
+ * 複数 feed の conditional GET ヘッダを 1 query でまとめて返す。
+ * collectAll では feed ごとに loadFeedHeaders を呼ぶと subrequest を消費するため、
+ * Worker の subrequest 上限対策として一括取得する。
+ * 該当行が無い feed は Map に含まれず、呼び出し側で null ペアにフォールバックする。
+ */
+export async function loadFeedHeadersAll(
+  db: D1Database,
+  feedIds: string[],
+): Promise<Map<string, FeedHeaders>> {
+  if (feedIds.length === 0) return new Map();
+  const placeholders = feedIds.map((_, i) => `?${i + 1}`).join(",");
+  const rows = await db
+    .prepare(`SELECT id, last_etag, last_modified FROM feeds WHERE id IN (${placeholders})`)
+    .bind(...feedIds)
+    .all<{ id: string; last_etag: string | null; last_modified: string | null }>();
+  const map = new Map<string, FeedHeaders>();
+  for (const row of rows.results ?? []) {
+    map.set(row.id, { last_etag: row.last_etag, last_modified: row.last_modified });
+  }
+  return map;
+}
+
+/**
  * 200 応答時のレスポンスヘッダを保存する。
  * null を渡すと既存値を NULL 上書きする (サーバが ETag を返さなくなった場合)。
  */
@@ -70,6 +93,21 @@ export async function syncFeeds(db: D1Database, feeds: FeedConfig[]): Promise<vo
   for (let i = 0; i < stmts.length; i += BATCH_SIZE) {
     await db.batch(stmts.slice(i, i + BATCH_SIZE));
   }
+
+  // yaml に存在しない feed を D1 で disable する (orphan cleanup)。
+  // 削除しない理由: 過去記事は articles.feed_id 経由で feed 名・カテゴリを引いているため、
+  // レコード自体は残し enabled=0 で stats の stale 判定や collector 対象から除外する。
+  const ids = feeds.map((f) => f.id);
+  const placeholders = ids.map((_, i) => `?${i + 1}`).join(",");
+  await db
+    .prepare(
+      `UPDATE feeds
+       SET enabled = 0,
+           updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+       WHERE enabled = 1 AND id NOT IN (${placeholders})`,
+    )
+    .bind(...ids)
+    .run();
 }
 
 export async function recordFetchSuccess(

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -78,8 +78,9 @@ const handler: ExportedHandler<Env> = {
         }),
       );
     }
-    // Run retention once per day at UTC 17:00 to avoid peak write hours
-    if (utcHour === 17) {
+    // Run retention once per day at UTC 18:00 (JST 03:00) — 低トラフィック帯。
+    // cron `0 */6 * * *` は UTC 00,06,12,18 のみ起動するため 17 ではなく 18 に揃える。
+    if (utcHour === 18) {
       ctx.waitUntil(
         pruneOldArticles(env.DB, Number(env.RETENTION_DAYS ?? "0")).then((r) => {
           console.log(`[retention] deleted=${r.deleted}`);

--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -18,12 +18,16 @@ database_id = "a6cd7dbc-9f26-46d9-83c8-4a7b89405b7b"
 migrations_dir = "../../migrations"
 
 [triggers]
-# 0 */3 * * * : 3 時間ごと (UTC 00,03,...,21) — RSS 収集 + Slack 日次 (00:00 のみ) + retention (17:00 のみ)
+# 0 */6 * * * : 6 時間ごと (UTC 00,06,12,18) — RSS 収集 + Slack 日次 (00:00 のみ)
+# Medium 等の外部レート制限と Worker 1 invocation あたりの subrequest 上限を緩和するため
+# 3h → 6h に頻度を下げている。新着の取り込みは最大 6 時間遅れる。
 # Slack 投稿には SLACK_WEBHOOK_URL を `wrangler secret put SLACK_WEBHOOK_URL` で登録する
-crons = ["0 */3 * * *"]
+crons = ["0 */6 * * *"]
 
 [vars]
-COLLECTOR_CONCURRENCY = "4"
+# 並列 1: 同一ホスト (Medium) への並列アクセスで 429 を多発させないため。
+# fetch の wallclock は Cron の wall-time 上限内で十分収まる。
+COLLECTOR_CONCURRENCY = "1"
 COLLECTOR_TIMEOUT_MS = "10000"
 COLLECTOR_RETRIES = "2"
 SUMMARY_MAX_LENGTH = "500"
@@ -58,7 +62,7 @@ database_name = "tech-news-bot-db"
 database_id = "a6cd7dbc-9f26-46d9-83c8-4a7b89405b7b"
 
 [env.preview.vars]
-COLLECTOR_CONCURRENCY = "4"
+COLLECTOR_CONCURRENCY = "1"
 COLLECTOR_TIMEOUT_MS = "10000"
 COLLECTOR_RETRIES = "2"
 SUMMARY_MAX_LENGTH = "500"


### PR DESCRIPTION
## 概要

cron 起動時の以下のエラーへの対策と、Mercari Engineering Blog · stale 再発の解消。

- HTTP 429 Too Many Requests (Netflix / Airbnb / Cohere — Medium 系)
- Too many subrequests by single Worker invocation (Wantedly / PFN / Zenn 4 件)
- Mercari Engineering Blog が yaml から削除済みなのに stats の stale 一覧に残り続ける

Closes #267

## 変更内容

- **Mercari stale 再発防止**: `syncFeeds` に「yaml に存在しない feed を D1 で `enabled=0` にする」orphan cleanup を追加。yaml を source of truth にする。
- **subrequest 削減**: `loadFeedHeadersAll` を新規追加し、`collectAll` 冒頭で全 enabled feed の conditional GET ヘッダを 1 query で取得。feed あたり 1 read 消費していたものを集約 (43 read → 1 read)。
- **Medium 429 緩和**: `COLLECTOR_CONCURRENCY` 4 → 1。同一ホストへの並列アクセスをやめる。
- **外部負荷半減**: cron `0 */3 * * *` → `0 */6 * * *`。Slack 日次 (UTC 00:00) は引き続き当たる。新着遅延は最大 6h。
- **retention dead code 修正**: `worker/index.ts` の retention 起動条件 `utcHour === 17` は元の 3h cron でも当たらず dead code。新 cron に合わせて `=== 18` に修正 (JST 03:00、低トラフィック帯)。
- **テスト env**: 全 yaml feed を直列で回すと 25/30s deadline 超過するため、`vitest.config.ts` で `COLLECTOR_CONCURRENCY=4` を上書き。
- **テスト追加**: `tests/worker/db/feeds.test.ts` で orphan disable の正常系/冪等性/再 enable と `loadFeedHeadersAll` を検証。

## テスト

- [x] `pnpm --filter @tnb/web run test` — 513 passed (28 files)
- [x] `vp check` — 0 errors (3 warnings は既存 `tests/client/*.test.tsx` の vi.fn 型注釈で本 PR の変更外)
- [x] `pnpm typecheck` — 0 errors
- [ ] deploy 後、stats から Mercari Engineering Blog が消えることを確認 (collectAll が 1 回走った後)
- [ ] deploy 後、Worker logs で `Too many subrequests` / `429` の出現頻度低下を確認
- [ ] deploy 後、UTC 18:00 (JST 03:00) に retention が走ることを確認