### PR TITLE
feat(reports): automated reports pipeline (GitHub Actions → D1)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,21 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      # GitHub に登録した WORKER_ADMIN_TOKEN を Worker の ADMIN_TOKEN secret に同期する。
+      # 二重登録を避けるため secret は GH 側を single source of truth として扱う。
+      - name: Sync admin secret to Worker
+        working-directory: apps/web
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          WORKER_ADMIN_TOKEN: ${{ secrets.WORKER_ADMIN_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -n "${WORKER_ADMIN_TOKEN:-}" ]; then
+            printf '%s' "$WORKER_ADMIN_TOKEN" | pnpm exec wrangler secret put ADMIN_TOKEN
+          else
+            echo "WORKER_ADMIN_TOKEN GitHub secret not set; skipping sync."
+          fi
       - name: Deploy worker
         working-directory: apps/web
         run: pnpm exec wrangler deploy

--- a/.github/workflows/report-daily.yml
+++ b/.github/workflows/report-daily.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Save report to D1 via admin API
         env:
-          ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+          ADMIN_TOKEN: ${{ secrets.WORKER_ADMIN_TOKEN }}
           # 本番 Worker の URL (custom domain がない前提)
           WORKER_URL: https://tech-news-bot.rikeda71.workers.dev
         run: |

--- a/.github/workflows/report-daily.yml
+++ b/.github/workflows/report-daily.yml
@@ -1,0 +1,110 @@
+name: Report Daily
+
+# 毎朝 JST 07:00 に tech-news-digest skill を Claude Code で起動し、
+# 生成された markdown を D1 reports テーブルに保存する。
+# 詳細は docs/reports-pipeline.md 参照。
+on:
+  schedule:
+    - cron: "0 22 * * *" # UTC 22:00 = JST 07:00
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  generate-and-save:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    concurrency:
+      group: report-daily
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+
+      # Claude Code が tools/d1-client/recent.mjs を呼ぶときに wrangler が必要。
+      # cf-typegen は build に依存するため明示的に走らせない (skill は recent.mjs しか使わない)。
+
+      - name: Run tech-news-digest skill
+        uses: anthropics/claude-code-base-action@v1
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_tools: "Bash,Read,Write,WebFetch,Skill"
+          # daily digest 生成プロンプト。skill 起動と最終ファイル書き出しを明示する。
+          prompt: |
+            あなたは tech-news-bot の自動レポート生成エージェントです。
+
+            tech-news-digest skill を以下の引数で起動してください:
+            - since=today
+            - mode=deep
+            - target=remote
+            - category 指定なし (全カテゴリ)
+            - lang 指定なし
+
+            Stage 1〜4 を完走したあと、最終的な markdown レポート全文を /tmp/report.md に
+            書き出してください。
+            合わせて以下の JSON を /tmp/report-meta.json に書き出してください:
+
+            {
+              "kind": "daily",
+              "period_start": "<since の ISO 8601>",
+              "period_end":   "<実行時刻の ISO 8601>",
+              "category": null,
+              "lang": null,
+              "source_skill": "tech-news-digest",
+              "generated_at": "<実行時刻の ISO 8601>",
+              "dedup_total": <number>,
+              "by_category": <object>,
+              "by_feed": <object>
+            }
+
+            注意:
+            - recent.mjs を呼ぶときは --target=remote を必ず指定してください。
+            - 最終 markdown 出力以外のアシスタント発話は最小限に抑えてください。
+            - WebFetch が失敗した記事には (summary based) を末尾に付けてください。
+
+      - name: Save report to D1 via admin API
+        env:
+          ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+          # 本番 Worker の URL (custom domain がない前提)
+          WORKER_URL: https://tech-news-bot.rikeda71.workers.dev
+        run: |
+          set -euo pipefail
+          if [ ! -f /tmp/report.md ] || [ ! -f /tmp/report-meta.json ]; then
+            echo "Skill did not produce required output files; aborting."
+            exit 1
+          fi
+
+          # report-meta.json は kind / period_start / period_end / category / lang /
+          # source_skill / generated_at と追加メタ (dedup_total, by_category, ...) を含む。
+          # API body は { ...meta, content, meta } の形に jq で組み立てる。
+          jq \
+            --rawfile content /tmp/report.md \
+            '{
+              kind: .kind,
+              period_start: .period_start,
+              period_end: .period_end,
+              category: .category,
+              lang: .lang,
+              source_skill: .source_skill,
+              generated_at: .generated_at,
+              content: $content,
+              meta: { dedup_total: .dedup_total, by_category: .by_category, by_feed: .by_feed }
+            }' /tmp/report-meta.json > /tmp/report-payload.json
+
+          curl -fsS -X POST "$WORKER_URL/api/admin/reports" \
+            -H "Authorization: Bearer $ADMIN_TOKEN" \
+            -H "Content-Type: application/json" \
+            --data-binary @/tmp/report-payload.json

--- a/.github/workflows/report-monthly.yml
+++ b/.github/workflows/report-monthly.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Save report to D1 via admin API
         env:
-          ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+          ADMIN_TOKEN: ${{ secrets.WORKER_ADMIN_TOKEN }}
           WORKER_URL: https://tech-news-bot.rikeda71.workers.dev
         run: |
           set -euo pipefail

--- a/.github/workflows/report-monthly.yml
+++ b/.github/workflows/report-monthly.yml
@@ -1,0 +1,104 @@
+name: Report Monthly
+
+# 毎月 2 日 JST 07:00 (= UTC 1 日 22:00) に tech-news-weekly skill を since=month で起動し、
+# 過去 30 日分のレポートを生成して D1 reports テーブルに保存する。
+# GitHub Actions cron は L (月末) 非対応なので "翌月 2 日 07:00 JST に直近 30 日" で
+# 暦月とほぼ等価のレポートを得る。詳細は docs/reports-pipeline.md 参照。
+on:
+  schedule:
+    - cron: "0 22 1 * *" # UTC 1 日 22:00 = JST 2 日 07:00
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  generate-and-save:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    concurrency:
+      group: report-monthly
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Run tech-news-weekly skill (monthly)
+        uses: anthropics/claude-code-base-action@v1
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_tools: "Bash,Read,Write,WebFetch,Skill"
+          # monthly digest 生成プロンプト。tech-news-weekly skill を since=month で起動する。
+          prompt: |
+            あなたは tech-news-bot の自動レポート生成エージェントです。
+
+            tech-news-weekly skill を以下の引数で起動してください:
+            - since=month
+            - target=remote
+            - limit=500
+            - category 指定なし (全カテゴリ)
+            - lang 指定なし
+
+            Stage 1〜4 を完走したあと、最終的な markdown レポート全文を /tmp/report.md に
+            書き出してください。
+            合わせて以下の JSON を /tmp/report-meta.json に書き出してください:
+
+            {
+              "kind": "monthly",
+              "period_start": "<実行時刻 -30 日 の ISO 8601>",
+              "period_end":   "<実行時刻の ISO 8601>",
+              "category": null,
+              "lang": null,
+              "source_skill": "tech-news-weekly",
+              "generated_at": "<実行時刻の ISO 8601>",
+              "dedup_total": <number>,
+              "by_category": <object>,
+              "by_feed": <object>
+            }
+
+            注意:
+            - recent.mjs を呼ぶときは --target=remote と --limit=500 を必ず指定してください。
+            - 最終 markdown 出力以外のアシスタント発話は最小限に抑えてください。
+            - WebFetch が失敗した記事には (summary based) を末尾に付けてください。
+
+      - name: Save report to D1 via admin API
+        env:
+          ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+          WORKER_URL: https://tech-news-bot.rikeda71.workers.dev
+        run: |
+          set -euo pipefail
+          if [ ! -f /tmp/report.md ] || [ ! -f /tmp/report-meta.json ]; then
+            echo "Skill did not produce required output files; aborting."
+            exit 1
+          fi
+
+          jq \
+            --rawfile content /tmp/report.md \
+            '{
+              kind: .kind,
+              period_start: .period_start,
+              period_end: .period_end,
+              category: .category,
+              lang: .lang,
+              source_skill: .source_skill,
+              generated_at: .generated_at,
+              content: $content,
+              meta: { dedup_total: .dedup_total, by_category: .by_category, by_feed: .by_feed }
+            }' /tmp/report-meta.json > /tmp/report-payload.json
+
+          curl -fsS -X POST "$WORKER_URL/api/admin/reports" \
+            -H "Authorization: Bearer $ADMIN_TOKEN" \
+            -H "Content-Type: application/json" \
+            --data-binary @/tmp/report-payload.json

--- a/.github/workflows/report-weekly.yml
+++ b/.github/workflows/report-weekly.yml
@@ -1,0 +1,102 @@
+name: Report Weekly
+
+# 毎週月曜 JST 07:00 に tech-news-weekly skill を Claude Code で起動し、
+# 生成された markdown を D1 reports テーブルに保存する。
+# 詳細は docs/reports-pipeline.md 参照。
+on:
+  schedule:
+    - cron: "0 22 * * 0" # UTC 日曜 22:00 = JST 月曜 07:00
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  generate-and-save:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    concurrency:
+      group: report-weekly
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Run tech-news-weekly skill
+        uses: anthropics/claude-code-base-action@v1
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_tools: "Bash,Read,Write,WebFetch,Skill"
+          # weekly digest 生成プロンプト。skill 起動と最終ファイル書き出しを明示する。
+          prompt: |
+            あなたは tech-news-bot の自動レポート生成エージェントです。
+
+            tech-news-weekly skill を以下の引数で起動してください:
+            - since=week
+            - target=remote
+            - category 指定なし (全カテゴリ)
+            - lang 指定なし
+
+            Stage 1〜4 を完走したあと、最終的な markdown レポート全文を /tmp/report.md に
+            書き出してください。
+            合わせて以下の JSON を /tmp/report-meta.json に書き出してください:
+
+            {
+              "kind": "weekly",
+              "period_start": "<実行時刻 -7 日 の ISO 8601>",
+              "period_end":   "<実行時刻の ISO 8601>",
+              "category": null,
+              "lang": null,
+              "source_skill": "tech-news-weekly",
+              "generated_at": "<実行時刻の ISO 8601>",
+              "dedup_total": <number>,
+              "by_category": <object>,
+              "by_feed": <object>
+            }
+
+            注意:
+            - recent.mjs を呼ぶときは --target=remote を必ず指定してください。
+            - 最終 markdown 出力以外のアシスタント発話は最小限に抑えてください。
+            - WebFetch が失敗した記事には (summary based) を末尾に付けてください。
+
+      - name: Save report to D1 via admin API
+        env:
+          ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+          WORKER_URL: https://tech-news-bot.rikeda71.workers.dev
+        run: |
+          set -euo pipefail
+          if [ ! -f /tmp/report.md ] || [ ! -f /tmp/report-meta.json ]; then
+            echo "Skill did not produce required output files; aborting."
+            exit 1
+          fi
+
+          jq \
+            --rawfile content /tmp/report.md \
+            '{
+              kind: .kind,
+              period_start: .period_start,
+              period_end: .period_end,
+              category: .category,
+              lang: .lang,
+              source_skill: .source_skill,
+              generated_at: .generated_at,
+              content: $content,
+              meta: { dedup_total: .dedup_total, by_category: .by_category, by_feed: .by_feed }
+            }' /tmp/report-meta.json > /tmp/report-payload.json
+
+          curl -fsS -X POST "$WORKER_URL/api/admin/reports" \
+            -H "Authorization: Bearer $ADMIN_TOKEN" \
+            -H "Content-Type: application/json" \
+            --data-binary @/tmp/report-payload.json

--- a/.github/workflows/report-weekly.yml
+++ b/.github/workflows/report-weekly.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Save report to D1 via admin API
         env:
-          ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+          ADMIN_TOKEN: ${{ secrets.WORKER_ADMIN_TOKEN }}
           WORKER_URL: https://tech-news-bot.rikeda71.workers.dev
         run: |
           set -euo pipefail

--- a/apps/web/tests/worker/api/reports.test.ts
+++ b/apps/web/tests/worker/api/reports.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from "vite-plus/test";
+import { SELF } from "cloudflare:test";
+import type {
+  AdminReportDetailResponse,
+  AdminReportListResponse,
+  AdminReportSaveResponse,
+} from "../../../worker/api/types";
+
+const AUTH = { authorization: "Bearer test-admin-token" };
+const NEXT_AUTH = { authorization: "Bearer test-admin-token-next" };
+const JSON_HEADERS = { ...AUTH, "content-type": "application/json" };
+
+interface ReportPayload {
+  kind: "daily" | "weekly" | "monthly";
+  period_start: string;
+  period_end: string;
+  category: string | null;
+  lang: string | null;
+  content: string;
+  meta?: unknown;
+  source_skill: string;
+  generated_at: string;
+}
+
+function buildPayload(overrides: Partial<ReportPayload> = {}): ReportPayload {
+  return {
+    kind: "daily",
+    period_start: "2026-04-28T00:00:00.000Z",
+    period_end: "2026-04-29T00:00:00.000Z",
+    category: null,
+    lang: null,
+    content: "# Daily Tech News\n\nSample content.",
+    meta: { dedup_total: 42, by_category: { bigtech: 30, ai: 12 } },
+    source_skill: "tech-news-digest",
+    generated_at: "2026-04-29T00:01:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("POST /api/admin/reports", () => {
+  it("401: rejects unauthenticated request", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(buildPayload()),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("200: accepts current ADMIN_TOKEN", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(buildPayload()),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as AdminReportSaveResponse;
+    expect(body.ok).toBe(true);
+    expect(typeof body.id).toBe("number");
+    expect(body.id).toBeGreaterThan(0);
+  });
+
+  it("200: accepts ADMIN_TOKEN_NEXT (rotation)", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: { ...NEXT_AUTH, "content-type": "application/json" },
+      body: JSON.stringify(buildPayload({ period_start: "2026-04-27T00:00:00.000Z" })),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("200: upsert preserves id, overwrites content for same period", async () => {
+    const first = await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(buildPayload({ content: "first" })),
+    });
+    const firstBody = (await first.json()) as AdminReportSaveResponse;
+    const second = await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(buildPayload({ content: "second" })),
+    });
+    const secondBody = (await second.json()) as AdminReportSaveResponse;
+    expect(secondBody.id).toBe(firstBody.id);
+
+    const detail = await SELF.fetch(`https://example.com/api/admin/reports/${secondBody.id}`, {
+      headers: AUTH,
+    });
+    const detailBody = (await detail.json()) as AdminReportDetailResponse;
+    expect(detailBody.report.content).toBe("second");
+  });
+
+  it("200: differentiates rows by category (NULL vs bigtech)", async () => {
+    const r1 = await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(buildPayload({ category: null, content: "all" })),
+    });
+    const r2 = await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(buildPayload({ category: "bigtech", content: "bigtech only" })),
+    });
+    const id1 = ((await r1.json()) as AdminReportSaveResponse).id;
+    const id2 = ((await r2.json()) as AdminReportSaveResponse).id;
+    expect(id1).not.toBe(id2);
+  });
+
+  it("400: rejects invalid kind", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(buildPayload({ kind: "yearly" as never })),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("400: rejects invalid ISO 8601 period_start", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(buildPayload({ period_start: "yesterday" })),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("400: rejects empty content", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(buildPayload({ content: "" })),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("400: rejects invalid category", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(buildPayload({ category: "unknown" })),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("400: rejects empty body", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("400: rejects invalid JSON body", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: "not-json",
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/admin/reports", () => {
+  it("401: rejects unauthenticated request", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/reports");
+    expect(res.status).toBe(401);
+  });
+
+  it("200: returns inserted reports in DESC order of generated_at", async () => {
+    await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(
+        buildPayload({
+          period_start: "2026-04-26T00:00:00.000Z",
+          generated_at: "2026-04-27T00:00:00.000Z",
+          content: "older",
+        }),
+      ),
+    });
+    await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(
+        buildPayload({
+          period_start: "2026-04-28T00:00:00.000Z",
+          generated_at: "2026-04-29T00:00:00.000Z",
+          content: "newer",
+        }),
+      ),
+    });
+
+    const res = await SELF.fetch("https://example.com/api/admin/reports", {
+      headers: AUTH,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as AdminReportListResponse;
+    expect(body.reports.length).toBeGreaterThanOrEqual(2);
+    expect(body.reports[0].generated_at >= body.reports[1].generated_at).toBe(true);
+  });
+
+  it("200: filters by kind", async () => {
+    await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(buildPayload({ kind: "weekly" })),
+    });
+    const res = await SELF.fetch("https://example.com/api/admin/reports?kind=weekly", {
+      headers: AUTH,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as AdminReportListResponse;
+    expect(body.reports.every((r) => r.kind === "weekly")).toBe(true);
+  });
+
+  it("400: rejects invalid kind", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/reports?kind=invalid", {
+      headers: AUTH,
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/admin/reports/:id", () => {
+  it("404: missing id", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/reports/999999", {
+      headers: AUTH,
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("400: invalid id", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/reports/abc", {
+      headers: AUTH,
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("200: returns full content + meta_json", async () => {
+    const post = await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(buildPayload({ content: "with meta" })),
+    });
+    const id = ((await post.json()) as AdminReportSaveResponse).id;
+    const res = await SELF.fetch(`https://example.com/api/admin/reports/${id}`, {
+      headers: AUTH,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as AdminReportDetailResponse;
+    expect(body.report.content).toBe("with meta");
+    expect(body.report.meta_json).toContain("dedup_total");
+  });
+});

--- a/apps/web/worker/api/reports.ts
+++ b/apps/web/worker/api/reports.ts
@@ -1,0 +1,204 @@
+import { Hono } from "hono";
+import type { Context } from "hono";
+import type { Env } from "../types";
+import { getReport, listReports, upsertReport } from "../db/reports";
+import type { ReportInput, ReportKind } from "../db/reports";
+import type {
+  AdminReportDetailResponse,
+  AdminReportListResponse,
+  AdminReportSaveResponse,
+} from "./types";
+
+const app = new Hono<{ Bindings: Env }>();
+
+const VALID_KINDS = new Set<ReportKind>(["daily", "weekly", "monthly"]);
+const VALID_CATEGORIES = new Set(["bigtech", "ai", "jp", "zenn"]);
+const VALID_LANGS = new Set(["ja", "en"]);
+// content が極端に長くなるのを防ぐ (D1 の row size と Worker の CPU 時間を意識)。
+// 1MB は markdown レポートとしては十分すぎる量。
+const MAX_CONTENT_BYTES = 1_000_000;
+
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+function isValidAdminToken(
+  provided: string,
+  current: string | undefined,
+  next: string | undefined,
+): boolean {
+  if (current && timingSafeEqual(provided, current)) return true;
+  if (next && timingSafeEqual(provided, next)) return true;
+  return false;
+}
+
+// admin token を検証して、失敗時に Response を返す。成功時は null を返す。
+function authGuard(c: Context<{ Bindings: Env }>): Response | null {
+  const current = c.env.ADMIN_TOKEN;
+  const next = c.env.ADMIN_TOKEN_NEXT;
+  if (!current) {
+    return c.json({ error: "ADMIN_TOKEN is not configured" }, 503);
+  }
+  const auth = c.req.header("authorization") ?? "";
+  const token = auth.replace(/^Bearer\s+/i, "");
+  if (!token || !isValidAdminToken(token, current, next)) {
+    return c.json({ error: "unauthorized" }, 401);
+  }
+  return null;
+}
+
+function isISO8601(s: unknown): s is string {
+  if (typeof s !== "string" || s.length === 0) return false;
+  const d = new Date(s);
+  return !Number.isNaN(d.getTime()) && d.toISOString() === s;
+}
+
+interface PostBody {
+  kind?: unknown;
+  period_start?: unknown;
+  period_end?: unknown;
+  category?: unknown;
+  lang?: unknown;
+  content?: unknown;
+  meta?: unknown;
+  source_skill?: unknown;
+  generated_at?: unknown;
+}
+
+// body をバリデートして ReportInput を構築する。エラーは error 文字列を返す。
+function parseInput(
+  body: PostBody,
+): { ok: true; input: ReportInput } | { ok: false; error: string } {
+  if (typeof body.kind !== "string" || !VALID_KINDS.has(body.kind as ReportKind)) {
+    return { ok: false, error: "kind must be one of: daily | weekly | monthly" };
+  }
+  if (!isISO8601(body.period_start)) {
+    return { ok: false, error: "period_start must be ISO 8601 string" };
+  }
+  if (!isISO8601(body.period_end)) {
+    return { ok: false, error: "period_end must be ISO 8601 string" };
+  }
+  if (!isISO8601(body.generated_at)) {
+    return { ok: false, error: "generated_at must be ISO 8601 string" };
+  }
+  if (typeof body.content !== "string" || body.content.length === 0) {
+    return { ok: false, error: "content must be non-empty string" };
+  }
+  if (body.content.length > MAX_CONTENT_BYTES) {
+    return { ok: false, error: `content exceeds ${MAX_CONTENT_BYTES} bytes` };
+  }
+  if (typeof body.source_skill !== "string" || body.source_skill.length === 0) {
+    return { ok: false, error: "source_skill must be non-empty string" };
+  }
+
+  let category: string | null = null;
+  if (body.category !== undefined && body.category !== null) {
+    if (typeof body.category !== "string" || !VALID_CATEGORIES.has(body.category)) {
+      return { ok: false, error: "category must be one of: bigtech | ai | jp | zenn (or null)" };
+    }
+    category = body.category;
+  }
+
+  let lang: string | null = null;
+  if (body.lang !== undefined && body.lang !== null) {
+    if (typeof body.lang !== "string" || !VALID_LANGS.has(body.lang)) {
+      return { ok: false, error: "lang must be one of: ja | en (or null)" };
+    }
+    lang = body.lang;
+  }
+
+  let metaJson: string | null = null;
+  if (body.meta !== undefined && body.meta !== null) {
+    try {
+      metaJson = JSON.stringify(body.meta);
+    } catch {
+      return { ok: false, error: "meta must be JSON-serializable" };
+    }
+  }
+
+  return {
+    ok: true,
+    input: {
+      kind: body.kind as ReportKind,
+      period_start: body.period_start,
+      period_end: body.period_end,
+      category,
+      lang,
+      content: body.content,
+      meta_json: metaJson,
+      source_skill: body.source_skill,
+      generated_at: body.generated_at,
+    },
+  };
+}
+
+app.post("/", async (c) => {
+  if (c.env.READONLY === "1") {
+    return c.json({ error: "read-only mode" }, 403);
+  }
+  const denied = authGuard(c);
+  if (denied) return denied;
+
+  const rawBody = await c.req.text().catch(() => "");
+  if (rawBody.trim() === "") {
+    return c.json({ error: "request body is required" }, 400);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawBody);
+  } catch {
+    return c.json({ error: "invalid JSON body" }, 400);
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return c.json({ error: "request body must be a JSON object" }, 400);
+  }
+  const validated = parseInput(parsed as PostBody);
+  if (!validated.ok) {
+    return c.json({ error: validated.error }, 400);
+  }
+
+  const { id } = await upsertReport(c.env.DB, validated.input);
+  return c.json<AdminReportSaveResponse>({ ok: true, id });
+});
+
+app.get("/", async (c) => {
+  const denied = authGuard(c);
+  if (denied) return denied;
+
+  const kindParam = c.req.query("kind");
+  let kind: ReportKind | undefined;
+  if (kindParam !== undefined) {
+    if (!VALID_KINDS.has(kindParam as ReportKind)) {
+      return c.json({ error: "kind must be one of: daily | weekly | monthly" }, 400);
+    }
+    kind = kindParam as ReportKind;
+  }
+
+  const limitParam = Number(c.req.query("limit") ?? "20");
+  const limit = Number.isFinite(limitParam) ? Math.min(Math.max(limitParam, 1), 100) : 20;
+
+  const reports = await listReports(c.env.DB, { kind, limit });
+  return c.json<AdminReportListResponse>({ reports });
+});
+
+app.get("/:id", async (c) => {
+  const denied = authGuard(c);
+  if (denied) return denied;
+
+  const idParam = Number(c.req.param("id"));
+  if (!Number.isFinite(idParam) || idParam <= 0) {
+    return c.json({ error: "invalid id" }, 400);
+  }
+  const detail = await getReport(c.env.DB, idParam);
+  if (!detail) {
+    return c.json({ error: "report not found" }, 404);
+  }
+  return c.json<AdminReportDetailResponse>({ report: detail });
+});
+
+export default app;

--- a/apps/web/worker/api/router.ts
+++ b/apps/web/worker/api/router.ts
@@ -8,6 +8,7 @@ import feeds from "./feeds";
 import health from "./health";
 import stats from "./stats";
 import admin from "./admin";
+import reports from "./reports";
 import docs from "./docs";
 import { catalogHandler } from "./catalog";
 
@@ -38,6 +39,9 @@ api.route("/categories", categories);
 api.route("/feeds", feeds);
 api.route("/health", health);
 api.route("/stats", stats);
+// /admin/reports は別ハンドラに分離 (admin の中で /reports をルーティングしない設計)。
+// Hono は path matching が前方一致でなく完全一致なので衝突しない。
+api.route("/admin/reports", reports);
 api.route("/admin", admin);
 api.route("/", docs);
 

--- a/apps/web/worker/api/types.ts
+++ b/apps/web/worker/api/types.ts
@@ -16,6 +16,7 @@ import type {
   ByLang30d,
 } from "../db/articles";
 import type { FeedWithStats, CategorySummary } from "../db/feeds";
+import type { ReportDetailRow, ReportRow } from "../db/reports";
 import type { RunRow, RunFeedRow } from "../db/runs";
 
 // ---- /api/articles ----
@@ -188,6 +189,19 @@ export interface AdminCronHealthResponse {
 export interface AdminFeedEnabledResponse {
   id: string;
   enabled: boolean;
+}
+
+export interface AdminReportSaveResponse {
+  ok: true;
+  id: number;
+}
+
+export interface AdminReportListResponse {
+  reports: ReportRow[];
+}
+
+export interface AdminReportDetailResponse {
+  report: ReportDetailRow;
 }
 
 export interface AdminCollectorRunResponse {

--- a/apps/web/worker/db/reports.ts
+++ b/apps/web/worker/db/reports.ts
@@ -1,0 +1,108 @@
+// reports テーブルへのアクセス層。GitHub Actions から定期投入される
+// 自動生成レポート (markdown) の upsert / list / get を提供する。
+
+export type ReportKind = "daily" | "weekly" | "monthly";
+
+export interface ReportInput {
+  kind: ReportKind;
+  period_start: string;
+  period_end: string;
+  category: string | null;
+  lang: string | null;
+  content: string;
+  meta_json: string | null;
+  source_skill: string;
+  generated_at: string;
+}
+
+export interface ReportRow {
+  id: number;
+  kind: ReportKind;
+  period_start: string;
+  period_end: string;
+  category: string | null;
+  lang: string | null;
+  source_skill: string;
+  generated_at: string;
+}
+
+export interface ReportDetailRow extends ReportRow {
+  content: string;
+  meta_json: string | null;
+}
+
+const ALL_SENTINEL = "__all__";
+
+// (kind, period_start, period_end, category, lang) で upsert する。
+// UNIQUE index が COALESCE(category, '__all__') で張られているため、
+// ON CONFLICT の target にも同じ式を指定する必要がある (SQLite 3.24+ の挙動)。
+export async function upsertReport(db: D1Database, input: ReportInput): Promise<{ id: number }> {
+  const result = await db
+    .prepare(
+      `INSERT INTO reports
+         (kind, period_start, period_end, category, lang,
+          content, meta_json, source_skill, generated_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+       ON CONFLICT (
+         kind, period_start, period_end,
+         COALESCE(category, '${ALL_SENTINEL}'),
+         COALESCE(lang, '${ALL_SENTINEL}')
+       )
+       DO UPDATE SET
+         content      = excluded.content,
+         meta_json    = excluded.meta_json,
+         source_skill = excluded.source_skill,
+         generated_at = excluded.generated_at
+       RETURNING id`,
+    )
+    .bind(
+      input.kind,
+      input.period_start,
+      input.period_end,
+      input.category,
+      input.lang,
+      input.content,
+      input.meta_json,
+      input.source_skill,
+      input.generated_at,
+    )
+    .first<{ id: number }>();
+  if (!result) {
+    throw new Error("upsertReport returned no row");
+  }
+  return { id: result.id };
+}
+
+export async function listReports(
+  db: D1Database,
+  filter: {
+    kind?: ReportKind;
+    limit: number;
+  },
+): Promise<ReportRow[]> {
+  const limit = Math.max(1, Math.min(filter.limit, 100));
+  let query = `SELECT id, kind, period_start, period_end, category, lang,
+                      source_skill, generated_at
+               FROM reports`;
+  const binds: unknown[] = [];
+  if (filter.kind) {
+    query += ` WHERE kind = ?1`;
+    binds.push(filter.kind);
+  }
+  query += ` ORDER BY generated_at DESC LIMIT ${limit}`;
+  const stmt = binds.length > 0 ? db.prepare(query).bind(...binds) : db.prepare(query);
+  const result = await stmt.all<ReportRow>();
+  return result.results ?? [];
+}
+
+export async function getReport(db: D1Database, id: number): Promise<ReportDetailRow | null> {
+  const row = await db
+    .prepare(
+      `SELECT id, kind, period_start, period_end, category, lang,
+              content, meta_json, source_skill, generated_at
+       FROM reports WHERE id = ?1`,
+    )
+    .bind(id)
+    .first<ReportDetailRow>();
+  return row ?? null;
+}

--- a/docs/reports-pipeline.md
+++ b/docs/reports-pipeline.md
@@ -168,15 +168,21 @@ Stage 1〜4 を完走したあと、最終的な markdown レポート全文を 
 
 repository secrets に以下を登録する。
 
-| Secret                    | 用途                                                 | 取得元                                            |
-| ------------------------- | ---------------------------------------------------- | ------------------------------------------------- |
-| `CLAUDE_CODE_OAUTH_TOKEN` | `claude-code-base-action` の認証 (subscription 経由) | `claude /install-github-app` で発行               |
-| `ADMIN_TOKEN`             | `/api/admin/reports` の Bearer 認証                  | Worker secret と同値 (rotation 手順は別 doc 参照) |
-| `CLOUDFLARE_API_TOKEN`    | `wrangler d1 execute --remote` を打つために必要      | Cloudflare dashboard → API Tokens                 |
-| `CLOUDFLARE_ACCOUNT_ID`   | wrangler の account 自動選択                         | Cloudflare dashboard                              |
+| Secret                    | 用途                                                 | 取得元                                          |
+| ------------------------- | ---------------------------------------------------- | ----------------------------------------------- |
+| `CLAUDE_CODE_OAUTH_TOKEN` | `claude-code-base-action` の認証 (subscription 経由) | `claude /install-github-app` で発行             |
+| `WORKER_ADMIN_TOKEN`      | `/api/admin/reports` の Bearer 認証                  | `openssl rand -hex 32` などで生成 (GH 側で管理) |
+| `CLOUDFLARE_API_TOKEN`    | `wrangler d1 execute --remote` を打つために必要      | Cloudflare dashboard → API Tokens               |
+| `CLOUDFLARE_ACCOUNT_ID`   | wrangler の account 自動選択                         | Cloudflare dashboard                            |
 
 `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` は既に deploy workflow で使っている
 ものを流用できる。
+
+`WORKER_ADMIN_TOKEN` は **GitHub Actions secret 側を single source of truth** として扱う。
+deploy workflow に "Sync admin secret to Worker" ステップが入っていて、
+`wrangler secret put ADMIN_TOKEN` で Worker secret 側に同値を流し込む。
+これにより GH と Cloudflare の 2 箇所に同じ値を二重登録する手間を省ける。
+ローテーションするときも GH 側の値を更新して deploy を回せば Worker secret も自動的に追随する。
 
 ---
 
@@ -184,8 +190,9 @@ repository secrets に以下を登録する。
 
 ### 初回セットアップ
 
-1. PR を merge し本番 deploy が完了していること (migration 0010 が `pnpm migrate:prod` で適用済み)
-2. `CLAUDE_CODE_OAUTH_TOKEN` / `ADMIN_TOKEN` を GitHub Actions secrets に登録
+1. `CLAUDE_CODE_OAUTH_TOKEN` / `WORKER_ADMIN_TOKEN` を GitHub Actions secrets に登録
+   - `WORKER_ADMIN_TOKEN`: `openssl rand -hex 32 | gh secret set WORKER_ADMIN_TOKEN` などでランダム生成して登録する。Worker 側 secret は次の deploy で自動同期される
+2. PR を merge し本番 deploy を回す (deploy workflow が migration 0010 を適用 + `WORKER_ADMIN_TOKEN` を Worker の `ADMIN_TOKEN` secret に同期)
 3. GitHub Actions UI から `Report Daily` を `workflow_dispatch` で手動実行
 4. D1 に行が入ったか確認:
 
@@ -213,13 +220,13 @@ UNIQUE index が `(kind, period, category)` で張られているため、catego
 
 ### トラブルシュート
 
-| 症状                            | 確認ポイント                                                           |
-| ------------------------------- | ---------------------------------------------------------------------- |
-| Skill ステップで 401            | `CLAUDE_CODE_OAUTH_TOKEN` が失効していないか                           |
-| `recent.mjs` が 0 件            | `CLOUDFLARE_API_TOKEN` の権限 / `CLOUDFLARE_ACCOUNT_ID`                |
-| `/api/admin/reports` が 401     | `ADMIN_TOKEN` の値が Worker 側 secret と一致しているか                 |
-| `/api/admin/reports` が 400     | content 空 / ISO 8601 不正 / category 範囲外。step 出力の error を読む |
-| `/tmp/report.md` が生成されない | skill が Stage 4 まで到達していない。prompt のログを確認               |
+| 症状                            | 確認ポイント                                                                                             |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Skill ステップで 401            | `CLAUDE_CODE_OAUTH_TOKEN` が失効していないか                                                             |
+| `recent.mjs` が 0 件            | `CLOUDFLARE_API_TOKEN` の権限 / `CLOUDFLARE_ACCOUNT_ID`                                                  |
+| `/api/admin/reports` が 401     | `WORKER_ADMIN_TOKEN` (GH) と Worker 側 `ADMIN_TOKEN` secret が同値か (deploy ジョブで sync 済みかも確認) |
+| `/api/admin/reports` が 400     | content 空 / ISO 8601 不正 / category 範囲外。step 出力の error を読む                                   |
+| `/tmp/report.md` が生成されない | skill が Stage 4 まで到達していない。prompt のログを確認                                                 |
 
 ---
 

--- a/docs/reports-pipeline.md
+++ b/docs/reports-pipeline.md
@@ -1,0 +1,227 @@
+# 自動レポート pipeline
+
+GitHub Actions 上で `tech-news-*` skill を定期実行し、生成された markdown レポートを D1 (`reports` テーブル) に保存する仕組み。
+
+設計の経緯と詳細は issue #270 を参照。
+
+---
+
+## 全体像
+
+```
+GitHub Actions (cron / workflow_dispatch)
+   ↓ 1. skill 起動 (anthropics/claude-code-base-action@v1)
+Claude Code
+   ↓ 2. tools/d1-client/recent.mjs --target=remote で記事取得
+D1 (本番) ── articles
+   ↓ 3. WebFetch で本文取得 + markdown 生成
+/tmp/report.md, /tmp/report-meta.json
+   ↓ 4. curl POST /api/admin/reports (Bearer ADMIN_TOKEN)
+Worker (Hono)
+   ↓ 5. upsertReport
+D1 (本番) ── reports
+```
+
+Worker の cron trigger は無料枠で 1 個までしか持てない (#230 の collector で消費済み) ため、
+GitHub Actions 側で cron スケジュールを持たせる方針にしている。Claude Code subscription を
+使うため `claude-code-base-action` の `claude_code_oauth_token` を利用する (Anthropic API key 不要)。
+
+---
+
+## D1 スキーマ
+
+`migrations/0010_reports.sql` を参照。
+
+```sql
+CREATE TABLE reports (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  kind          TEXT NOT NULL CHECK (kind IN ('daily', 'weekly', 'monthly')),
+  period_start  TEXT NOT NULL,
+  period_end    TEXT NOT NULL,
+  category      TEXT,                -- NULL = 全カテゴリ
+  lang          TEXT,                -- NULL = 全言語
+  content       TEXT NOT NULL,       -- markdown 本体
+  meta_json     TEXT,                -- dedup_total / by_category / by_feed など
+  source_skill  TEXT NOT NULL,       -- "tech-news-digest" など
+  generated_at  TEXT NOT NULL        -- ISO 8601
+);
+```
+
+### UNIQUE index と NULL 扱い
+
+SQLite では NULL は UNIQUE 制約上 distinct 扱いになるため、`(kind, period, NULL)` の重複が
+通ってしまう。これを避けるために UNIQUE index は `COALESCE(category, '__all__')` 形で
+張り、ON CONFLICT 句にも同じ式を指定する。
+
+```sql
+CREATE UNIQUE INDEX idx_reports_unique_period
+  ON reports (
+    kind, period_start, period_end,
+    COALESCE(category, '__all__'),
+    COALESCE(lang, '__all__')
+  );
+```
+
+upsert はこの index に基づいて行われ、同期間 / 同カテゴリ / 同言語のレポートは何度
+書き込んでも 1 行に収束する (= 再実行が idempotent)。
+
+---
+
+## 管理 API
+
+`/api/admin/reports` は GitHub Actions からのみ叩かれる server-to-server エンドポイント。
+CORS は付けず、Bearer `ADMIN_TOKEN` (rotation 中は `ADMIN_TOKEN_NEXT` も) で保護する。
+
+| Method | Path                     | 用途                             |
+| ------ | ------------------------ | -------------------------------- |
+| POST   | `/api/admin/reports`     | レポートの upsert                |
+| GET    | `/api/admin/reports`     | レポート一覧 (kind フィルタ可)   |
+| GET    | `/api/admin/reports/:id` | content + meta_json まで含む詳細 |
+
+### POST body
+
+```jsonc
+{
+  "kind": "daily",                    // "daily" | "weekly" | "monthly"
+  "period_start": "ISO 8601",
+  "period_end":   "ISO 8601",
+  "category": null,                   // null | "bigtech" | "ai" | "jp" | "zenn"
+  "lang": null,                       // null | "ja" | "en"
+  "content": "# Daily Tech News ...", // markdown 本体 (≤ 1MB)
+  "meta": { "dedup_total": 42, ... }, // 任意 JSON (meta_json として保存)
+  "source_skill": "tech-news-digest",
+  "generated_at": "ISO 8601"
+}
+```
+
+バリデーション:
+
+- `content` は非空 / `MAX_CONTENT_BYTES = 1_000_000` 以下
+- `category` / `lang` は許可リスト + `null`
+- 各 ISO 8601 は `new Date(s).toISOString() === s` で round-trip チェック
+- `READONLY=1` の場合は POST が 403
+
+### Response
+
+```jsonc
+// POST
+{ "ok": true, "id": 123 }
+
+// GET (list)
+{ "reports": [ { id, kind, period_start, ... }, ... ] }
+
+// GET (detail)
+{ "report": { ..., content, meta_json } }
+```
+
+詳細な type は `apps/web/worker/api/types.ts` の `AdminReport*Response` を参照。
+
+---
+
+## Workflow 一覧
+
+各 workflow は `.github/workflows/` 配下に置く。
+
+| File               | スケジュール (UTC) | スケジュール (JST) | 起動する skill     | category / lang |
+| ------------------ | ------------------ | ------------------ | ------------------ | --------------- |
+| `report-daily.yml` | `0 22 * * *`       | 毎日 07:00         | `tech-news-digest` | 全カテゴリ      |
+
+> 当面は daily のみ。weekly / monthly が必要になったら同じ pattern で workflow を追加
+> する (skill だけ `tech-news-weekly` に差し替え、`since=week` / `since=month` を渡す)。
+
+### Workflow の構造 (共通)
+
+1. `actions/checkout` + `pnpm/action-setup` + `actions/setup-node` + `pnpm install`
+2. `anthropics/claude-code-base-action@v1`
+   - `claude_code_oauth_token`: subscription 経由で発行された OAuth token
+   - `allowed_tools`: `"Bash,Read,Write,WebFetch,Skill"`
+   - env: `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID` (recent.mjs が wrangler 経由で D1 にアクセスする際に必要)
+   - prompt: skill 起動 + `/tmp/report.md` / `/tmp/report-meta.json` への書き出しを指示
+3. `jq` で markdown と meta JSON を 1 つの payload にまとめ、`curl POST /api/admin/reports` で Worker に投入
+
+prompt の本体例 (`report-daily.yml`):
+
+```
+tech-news-digest skill を以下の引数で起動してください:
+- since=today
+- mode=deep
+- target=remote
+- category 指定なし (全カテゴリ)
+- lang 指定なし
+
+Stage 1〜4 を完走したあと、最終的な markdown レポート全文を /tmp/report.md に
+書き出してください。
+合わせて meta JSON を /tmp/report-meta.json に書き出してください: { kind, period_start, ... }
+```
+
+### concurrency
+
+各 workflow に `concurrency: { group: report-<kind>, cancel-in-progress: false }` を
+付け、手動 dispatch と cron が重なってもキューイングする (途中で止めない)。
+
+---
+
+## GitHub Secrets
+
+repository secrets に以下を登録する。
+
+| Secret                    | 用途                                                 | 取得元                                            |
+| ------------------------- | ---------------------------------------------------- | ------------------------------------------------- |
+| `CLAUDE_CODE_OAUTH_TOKEN` | `claude-code-base-action` の認証 (subscription 経由) | `claude /install-github-app` で発行               |
+| `ADMIN_TOKEN`             | `/api/admin/reports` の Bearer 認証                  | Worker secret と同値 (rotation 手順は別 doc 参照) |
+| `CLOUDFLARE_API_TOKEN`    | `wrangler d1 execute --remote` を打つために必要      | Cloudflare dashboard → API Tokens                 |
+| `CLOUDFLARE_ACCOUNT_ID`   | wrangler の account 自動選択                         | Cloudflare dashboard                              |
+
+`CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` は既に deploy workflow で使っている
+ものを流用できる。
+
+---
+
+## 運用手順
+
+### 初回セットアップ
+
+1. PR を merge し本番 deploy が完了していること (migration 0010 が `pnpm migrate:prod` で適用済み)
+2. `CLAUDE_CODE_OAUTH_TOKEN` / `ADMIN_TOKEN` を GitHub Actions secrets に登録
+3. GitHub Actions UI から `Report Daily` を `workflow_dispatch` で手動実行
+4. D1 に行が入ったか確認:
+
+   ```bash
+   pnpm exec wrangler d1 execute tech-news-bot-db --remote \
+     --command 'SELECT id, kind, generated_at, length(content) AS bytes FROM reports ORDER BY id DESC LIMIT 5;'
+   ```
+
+### 再実行 (失敗した日のレポートを作り直す)
+
+GitHub Actions UI から `workflow_dispatch` で再実行するだけで OK。
+同じ `(kind, period_start, period_end, category, lang)` の組み合わせは upsert で上書きされる。
+
+### weekly / monthly を追加するとき
+
+1. `.github/workflows/report-weekly.yml` (例) を `report-daily.yml` をベースに作成
+2. cron を `"0 22 * * 0"` (毎週日曜 JST 07:00) などに変更
+3. prompt の skill を `tech-news-weekly` / `since=week` などに差し替え
+4. meta JSON の `kind` を `weekly` に変更
+
+### トラブルシュート
+
+| 症状                            | 確認ポイント                                                           |
+| ------------------------------- | ---------------------------------------------------------------------- |
+| Skill ステップで 401            | `CLAUDE_CODE_OAUTH_TOKEN` が失効していないか                           |
+| `recent.mjs` が 0 件            | `CLOUDFLARE_API_TOKEN` の権限 / `CLOUDFLARE_ACCOUNT_ID`                |
+| `/api/admin/reports` が 401     | `ADMIN_TOKEN` の値が Worker 側 secret と一致しているか                 |
+| `/api/admin/reports` が 400     | content 空 / ISO 8601 不正 / category 範囲外。step 出力の error を読む |
+| `/tmp/report.md` が生成されない | skill が Stage 4 まで到達していない。prompt のログを確認               |
+
+---
+
+## 関連ファイル
+
+- `migrations/0010_reports.sql` — テーブル / index 定義
+- `apps/web/worker/db/reports.ts` — D1 アクセス層 (upsert/list/get)
+- `apps/web/worker/api/reports.ts` — Hono ハンドラ + バリデーション
+- `apps/web/worker/api/router.ts` — `/admin/reports` のマウント
+- `apps/web/worker/api/types.ts` — `AdminReport*Response`
+- `apps/web/tests/worker/api/reports.test.ts` — 18 ケースの統合テスト
+- `.github/workflows/report-daily.yml` — daily 用 cron workflow
+- `docs/operations/admin-token-rotation.md` — ADMIN_TOKEN ローテーション手順

--- a/docs/reports-pipeline.md
+++ b/docs/reports-pipeline.md
@@ -122,12 +122,15 @@ CORS は付けず、Bearer `ADMIN_TOKEN` (rotation 中は `ADMIN_TOKEN_NEXT` も
 
 各 workflow は `.github/workflows/` 配下に置く。
 
-| File               | スケジュール (UTC) | スケジュール (JST) | 起動する skill     | category / lang |
-| ------------------ | ------------------ | ------------------ | ------------------ | --------------- |
-| `report-daily.yml` | `0 22 * * *`       | 毎日 07:00         | `tech-news-digest` | 全カテゴリ      |
+| File                 | スケジュール (UTC) | スケジュール (JST) | 起動する skill     | skill 引数               |
+| -------------------- | ------------------ | ------------------ | ------------------ | ------------------------ |
+| `report-daily.yml`   | `0 22 * * *`       | 毎日 07:00         | `tech-news-digest` | `since=today, deep`      |
+| `report-weekly.yml`  | `0 22 * * 0`       | 毎週月曜 07:00     | `tech-news-weekly` | `since=week`             |
+| `report-monthly.yml` | `0 22 1 * *`       | 毎月 2 日 07:00    | `tech-news-weekly` | `since=month, limit=500` |
 
-> 当面は daily のみ。weekly / monthly が必要になったら同じ pattern で workflow を追加
-> する (skill だけ `tech-news-weekly` に差し替え、`since=week` / `since=month` を渡す)。
+> monthly は GitHub Actions cron が `L` (月末) を非対応のため、「翌月 2 日 JST 07:00 に
+> 過去 30 日を集計」として暦月とほぼ等価のレポートを作る。`since=month` は skill 仕様で
+> 過去 30 日を意味する (暦月ぴったりではない)。
 
 ### Workflow の構造 (共通)
 
@@ -196,12 +199,17 @@ repository secrets に以下を登録する。
 GitHub Actions UI から `workflow_dispatch` で再実行するだけで OK。
 同じ `(kind, period_start, period_end, category, lang)` の組み合わせは upsert で上書きされる。
 
-### weekly / monthly を追加するとき
+### カテゴリ別レポートを追加するとき
 
-1. `.github/workflows/report-weekly.yml` (例) を `report-daily.yml` をベースに作成
-2. cron を `"0 22 * * 0"` (毎週日曜 JST 07:00) などに変更
-3. prompt の skill を `tech-news-weekly` / `since=week` などに差し替え
-4. meta JSON の `kind` を `weekly` に変更
+現状 daily / weekly / monthly はいずれも全カテゴリを対象にしている。`category=bigtech` 専用
+レポートなどが欲しくなったら、既存 workflow をコピーして以下を変える:
+
+1. ファイル名 / `name:` / `concurrency.group` を `report-<kind>-<category>.yml` 等に変更
+2. prompt の `category 指定なし` を `category=<bigtech|ai|jp|zenn>` に変更
+3. meta JSON の `category` を該当カテゴリ名に変更
+
+UNIQUE index が `(kind, period, category)` で張られているため、category 違いは別行として
+共存する (上書きされない)。
 
 ### トラブルシュート
 
@@ -223,5 +231,7 @@ GitHub Actions UI から `workflow_dispatch` で再実行するだけで OK。
 - `apps/web/worker/api/router.ts` — `/admin/reports` のマウント
 - `apps/web/worker/api/types.ts` — `AdminReport*Response`
 - `apps/web/tests/worker/api/reports.test.ts` — 18 ケースの統合テスト
-- `.github/workflows/report-daily.yml` — daily 用 cron workflow
+- `.github/workflows/report-daily.yml` — daily 用 cron workflow (`tech-news-digest`)
+- `.github/workflows/report-weekly.yml` — weekly 用 cron workflow (`tech-news-weekly`)
+- `.github/workflows/report-monthly.yml` — monthly 用 cron workflow (`tech-news-weekly --since=month`)
 - `docs/operations/admin-token-rotation.md` — ADMIN_TOKEN ローテーション手順

--- a/migrations/0010_reports.sql
+++ b/migrations/0010_reports.sql
@@ -1,0 +1,32 @@
+-- reports: GitHub Actions から定期投入する自動生成レポートを保存する。
+-- (kind, period_start, period_end, category, lang) を unique にして
+-- リトライや再実行が idempotent な upsert になるようにする。
+CREATE TABLE IF NOT EXISTS reports (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  kind          TEXT NOT NULL CHECK (kind IN ('daily', 'weekly', 'monthly')),
+  period_start  TEXT NOT NULL,
+  period_end    TEXT NOT NULL,
+  category      TEXT,
+  lang          TEXT,
+  content       TEXT NOT NULL,
+  meta_json     TEXT,
+  source_skill  TEXT NOT NULL,
+  generated_at  TEXT NOT NULL
+);
+
+-- SQLite では NULL は UNIQUE 制約上 distinct 扱いになり、同 (kind, period, NULL category)
+-- の重複が許容されてしまう。COALESCE 結果で UNIQUE にして "all" を明示扱いする。
+CREATE UNIQUE INDEX IF NOT EXISTS idx_reports_unique_period
+  ON reports (
+    kind,
+    period_start,
+    period_end,
+    COALESCE(category, '__all__'),
+    COALESCE(lang, '__all__')
+  );
+
+CREATE INDEX IF NOT EXISTS idx_reports_kind_generated
+  ON reports (kind, generated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_reports_period
+  ON reports (period_start, period_end);


### PR DESCRIPTION
Closes #270

## Summary

- GitHub Actions の cron で `tech-news-*` skill を回し、生成 markdown を D1 (`reports` テーブル) に保存する pipeline。Worker cron は無料枠で 1 個までしか持てないため (collector で使用済み)、定期実行は GitHub Actions に寄せた。
- Claude Code subscription 経由の OAuth token (`anthropics/claude-code-base-action@v1`) を使うので Anthropic API key は不要。
- daily / weekly / monthly の 3 つの workflow を用意 (詳細 `docs/reports-pipeline.md`)。
- Admin token は GH 側 (`WORKER_ADMIN_TOKEN`) を single source of truth とし、deploy workflow から `wrangler secret put` で Worker の `ADMIN_TOKEN` secret に同期する (二重登録回避)。

## 主な変更

- `migrations/0010_reports.sql`: `reports` テーブル + UNIQUE index。SQLite では NULL が distinct 扱いになるため `COALESCE(category, '__all__'), COALESCE(lang, '__all__')` で UNIQUE を張り、再実行が idempotent な upsert になるようにした
- `apps/web/worker/db/reports.ts`: `upsertReport` / `listReports` / `getReport`
- `apps/web/worker/api/reports.ts`: `/api/admin/reports` POST / GET / GET `:id`。Bearer `ADMIN_TOKEN` (rotation 中は `ADMIN_TOKEN_NEXT` も) で保護、CORS は付けない (server-to-server 専用)
- `apps/web/worker/api/router.ts`: `/admin/reports` を `/admin` より先にマウント
- `apps/web/tests/worker/api/reports.test.ts`: 18 ケース (auth / upsert / バリデーション / list / detail)
- `.github/workflows/report-daily.yml`: 毎日 JST 07:00 / `tech-news-digest` (`since=today, deep`)
- `.github/workflows/report-weekly.yml`: 毎週月曜 JST 07:00 / `tech-news-weekly` (`since=week`)
- `.github/workflows/report-monthly.yml`: 毎月 2 日 JST 07:00 / `tech-news-weekly` (`since=month, limit=500`)
- `.github/workflows/deploy.yml`: "Sync admin secret to Worker" ステップを追加。`WORKER_ADMIN_TOKEN` (GH) を `wrangler secret put ADMIN_TOKEN` で Worker secret に流し込む
- `docs/reports-pipeline.md`: 設計 + 運用手順 (secrets / 再実行 / カテゴリ別追加 / トラブルシュート)

## Test plan

- [x] `vp check` (lint+fmt+typecheck) — 0 errors / 3 warnings (既存)
- [x] `pnpm build`
- [x] `pnpm test` — 525 / 525 passing (新規 18 ケース含む)
- [ ] (merge 後) `Deploy` workflow で `0010_reports.sql` が本番 D1 に自動適用されることを確認
- [ ] (merge 後) `Deploy` workflow の "Sync admin secret to Worker" で Worker の `ADMIN_TOKEN` secret が登録されることを確認
- [ ] (merge 後) `Report Daily` を `workflow_dispatch` で手動実行し、`reports` 行が入ることを確認

## ユーザー側で必要な作業

PR merge 前に以下が repo secret に登録されていれば OK (今回の PR で `WORKER_ADMIN_TOKEN` は登録済み):

| Secret                    | 用途                                                    | 登録方法                                                  |
| ------------------------- | ------------------------------------------------------- | --------------------------------------------------------- |
| `CLAUDE_CODE_OAUTH_TOKEN` | `claude-code-base-action` の認証 (subscription 経由)    | `claude /install-github-app` で発行 → repo secret に登録  |
| `WORKER_ADMIN_TOKEN`      | `/api/admin/reports` Bearer 認証 (Worker secret に同期) | `openssl rand -hex 32 \| gh secret set WORKER_ADMIN_TOKEN` |
| `CLOUDFLARE_API_TOKEN`    | deploy / migration / `wrangler secret put` 用           | 登録済み                                                  |
| `CLOUDFLARE_ACCOUNT_ID`   | wrangler の account 自動選択                            | 登録済み                                                  |

merge 後の流れ:

1. **PR を merge** → `Deploy` workflow が自動で migration (`0010_reports.sql`) 適用 → `WORKER_ADMIN_TOKEN` を Worker の `ADMIN_TOKEN` secret に同期 → worker deploy を順に実行する
2. **手動実行で動作確認**
   GitHub Actions → `Report Daily` → `Run workflow`。完走後 `pnpm exec wrangler d1 execute tech-news-bot-db --remote --command 'SELECT id, kind, generated_at FROM reports ORDER BY id DESC LIMIT 5;'` で行が入ったか確認