### PR TITLE
security(csp): drop static inline style and add fonts.googleapis.com to style-src

### DIFF
--- a/apps/web/client/components/ArticleCard.tsx
+++ b/apps/web/client/components/ArticleCard.tsx
@@ -132,7 +132,7 @@ export function ArticleCard({
           onClick={() => onFilterByCategory(article.category)}
           title={`${CATEGORY_LABEL[article.category] ?? article.category} で絞り込む`}
         >
-          <span aria-hidden="true" style={{ marginRight: "3px" }}>
+          <span aria-hidden="true" className="mr-[3px]">
             {CATEGORY_ICON[article.category] ?? ""}
           </span>
           {CATEGORY_LABEL[article.category] ?? article.category}

--- a/apps/web/client/components/FeedDetail.tsx
+++ b/apps/web/client/components/FeedDetail.tsx
@@ -143,7 +143,7 @@ export function FeedDetail({ feedId, onBack, onFilterByFeedId, onFilterByCategor
           <span
             className={`inline-flex items-center px-[var(--space-2)] py-0.5 rounded-full text-[var(--font-size-xs)] font-semibold uppercase tracking-[0.04em] border-none font-[inherit] leading-[var(--line-height-tight)] whitespace-nowrap ${catBadgeClass}`}
           >
-            <span aria-hidden="true" style={{ marginRight: "3px" }}>
+            <span aria-hidden="true" className="mr-[3px]">
               {CATEGORY_ICON[feed.category] ?? ""}
             </span>
             {CATEGORY_LABEL[feed.category] ?? feed.category}

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -23,7 +23,8 @@ app.use("*", async (c, next) => {
     [
       "default-src 'self'",
       "img-src 'self' data: https:",
-      "style-src 'self' 'unsafe-inline'",
+      // fonts.googleapis.com の CSS は <link rel="stylesheet"> 経由で読み込むため style-src の対象
+      "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
       "script-src 'self'",
       "connect-src 'self'",
       "frame-ancestors 'none'",


### PR DESCRIPTION
## 概要

Closes #274

CSP `style-src 'unsafe-inline'` の撤去可否を調査し、以下の対応を実施。

## 調査結果

`grep -rn 'style={' apps/web/client/` で 6 箇所がヒット:

| ファイル | 内容 | 種別 |
|---|---|---|
| `FeedDetail.tsx:146` | `style={{ marginRight: "3px" }}` | **静的** → Tailwind 置換済み |
| `ArticleCard.tsx:135` | `style={{ marginRight: "3px" }}` | **静的** → Tailwind 置換済み |
| `StatsChart.tsx:47` | `style={{ background: CATEGORY_COLORS[cat] }}` | 動的カテゴリ色 → `style` 属性が必要 |
| `StatsDashboard.tsx:56` | `style={{ width: \`${pct}%\` }}` | 動的割合 → `style` 属性が必要 |
| `CalendarHeatmap.tsx:152` | `style={{ gridTemplateColumns: \`repeat(${totalWeeks}, 1fr)\` }}` | 動的週数 → `style` 属性が必要 |
| `CalendarHeatmap.tsx:181` | 同上 | 動的週数 → `style` 属性が必要 |

## 判断: `'unsafe-inline'` は残存が必要

動的 4 件 (StatsChart, StatsDashboard, CalendarHeatmap) は実行時に計算された値を `style` 属性に書き込むため、CSS custom property (`style={{ "--w": pct }}`) に移行しても **`style` 属性自体は使い続ける**。`style-src` ディレクティブは `<style>` タグと `style` 属性の両方を制御するため、`'unsafe-inline'` を外すと CSP 違反となる。

（`style-src-attr` を別途設けて属性だけ許可する方法もあるが、現時点ではスコープ外。）

## 追加修正: Google Fonts

`index.html` が `https://fonts.googleapis.com/css2?...` を `<link rel="stylesheet">` で読み込んでいるが、従来の `style-src 'self' 'unsafe-inline'` には `fonts.googleapis.com` が含まれておらず、ブラウザが CSP でブロックする可能性があった。今回 `style-src` に明示追加した。

## 変更ファイル

- `apps/web/client/components/ArticleCard.tsx`: `style={{ marginRight: "3px" }}` → `className="mr-[3px]"`
- `apps/web/client/components/FeedDetail.tsx`: 同上
- `apps/web/worker/index.ts`: `style-src` に `https://fonts.googleapis.com` を追加

## 検証

- `pnpm build`: pass
- `pnpm test`: 513 tests pass
- ブラウザ手動確認: browser tool が利用できないため CI のみで確認