### PR TITLE
chore(security): tighten dependabot frequency and audit blocking

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,10 @@
 version: 2
 updates:
-  # pnpm workspace 全体の依存を月次で自動 PR
+  # pnpm workspace 全体の依存を週次で自動 PR (security fix の遅延を最大 1 週間に抑える)
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     ignore:
       # Node.js LTS 24 を当面利用するため、@types/node の major bump は対象外にする
       - dependency-name: "@types/node"
@@ -29,8 +29,8 @@ updates:
           - "@cloudflare/*"
           - "wrangler"
 
-  # GitHub Actions のバージョンを月次で自動 PR
+  # GitHub Actions のバージョンを週次で自動 PR
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,7 +19,6 @@ jobs:
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile
       # devDependencies を除外して本番依存のみ監査。
-      # 脆弱性があっても merge を止めない (warning として記録するだけ)。
+      # high 以上の severity で CI を blocking する (moderate 以下は false positive が多いため除外)。
       - name: pnpm audit (prod only)
-        run: pnpm audit --prod
-        continue-on-error: true
+        run: pnpm audit --audit-level=high --prod


### PR DESCRIPTION
## Summary

- `.github/dependabot.yml`: `interval: "monthly"` → `interval: "weekly"` に変更 (npm + github-actions エコシステム両方)。security fix の遅延を最大 4 週間 → 最大 1 週間に短縮。
- `.github/workflows/security.yml`: `continue-on-error: true` を削除 + `pnpm audit --audit-level=high --prod` に変更。high 以上の severity で CI を blocking する (moderate 以下は false positive が多いため除外)。

## 変更前後

| ファイル | 変更前 | 変更後 |
|---|---|---|
| `dependabot.yml` | `interval: "monthly"` | `interval: "weekly"` |
| `security.yml` | `pnpm audit --prod` + `continue-on-error: true` | `pnpm audit --audit-level=high --prod` (blocking) |

## pnpm audit 結果

```
$ pnpm audit --audit-level=high --prod
No known vulnerabilities found
```

現時点で high severity の advisory は 0 件。CI は即時 pass する。

## Test plan

- [ ] CI (Security Audit workflow) が main push で green になることを確認
- [ ] 次週以降 Dependabot PR が weekly で来ることを確認

Closes #275