### PR TITLE
ci: parallelize check / build / test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -26,10 +26,70 @@ jobs:
         run: |
           set -o pipefail
           vp check 2>&1 | tee /tmp/vp-check.log | tail -500 || (tail -500 /tmp/vp-check.log; exit 1)
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "pnpm"
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: "24"
+          cache: true
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm cf-typegen
       - name: vp build
         run: vp run build
-      - name: vp test
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-dist
+          path: apps/web/dist/
+          retention-days: 1
+
+  # vitest-pool-workers は apps/web/dist/client が必要なので build に依存する
+  test:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "pnpm"
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: "24"
+          cache: true
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm cf-typegen
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: web-dist
+          path: apps/web/dist/
+      - name: vp test (worker / vitest-pool-workers)
         working-directory: apps/web
         run: vp test run
-      - name: vp test:client
+
+  test-client:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "pnpm"
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: "24"
+          cache: true
+      - run: pnpm install --frozen-lockfile
+      - name: vp test:client (happy-dom)
         run: pnpm test:client


### PR DESCRIPTION
## Summary

- 1 ジョブで順次実行していた CI を 4 ジョブに分割し、`check` / `build` / `test-client` を並列起動するよう変更
- `test` (worker) は `build` の artifact が必要なため `needs: [build]` を付与
- 既存のジョブ名 `test` は維持しているため Required check の設定に影響なし

## Job map

```
push / PR
├── check        vp check (lint + format + typecheck)
├── build        vp run build  →  upload artifact web-dist
│   └── test     (needs: build) download artifact → vp test run
└── test-client  pnpm test:client (happy-dom)
```

## 想定速度向上

従来は直列で約 check (2 min) + build (1.5 min) + test-worker (2 min) + test-client (30 s) ≒ 6 min。
並列化後は max(check, build) + test-worker ≈ 1.5 + 2 = 3.5 min（約 40% 短縮）。

Closes #279