### PR TITLE
fix(notify): return posted=false when slack webhook fails

### DIFF
--- a/apps/web/tests/worker/notify/slack-daily.test.ts
+++ b/apps/web/tests/worker/notify/slack-daily.test.ts
@@ -256,14 +256,18 @@ describe("postDailyDigest", () => {
     expect(Array.isArray(body.blocks)).toBe(true);
   });
 
-  it("does not throw on non-2xx response", async () => {
+  it("returns posted=false with error when webhook returns non-2xx", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(null, { status: 500 }));
-    await expect(postDailyDigest(WEBHOOK_URL, [], "2026-04-28")).resolves.toBeDefined();
+    const result = await postDailyDigest(WEBHOOK_URL, [], "2026-04-28");
+    expect(result.posted).toBe(false);
+    expect(result.error).toBe("status 500");
   });
 
-  it("does not throw on network error", async () => {
+  it("returns posted=false with error message when fetch throws", async () => {
     vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(new TypeError("Failed to fetch"));
-    await expect(postDailyDigest(WEBHOOK_URL, [], "2026-04-28")).resolves.toBeDefined();
+    const result = await postDailyDigest(WEBHOOK_URL, [], "2026-04-28");
+    expect(result.posted).toBe(false);
+    expect(result.error).toBe("Failed to fetch");
   });
 });
 

--- a/apps/web/worker/notify/slack-daily.ts
+++ b/apps/web/worker/notify/slack-daily.ts
@@ -19,8 +19,10 @@ export interface DailyDigestArticle {
 }
 
 export interface DailyDigestResult {
-  /** 投稿が行われた (webhookUrl が設定されていた) 場合 true */
+  /** 投稿が行われた (webhookUrl が設定されていて fetch が 2xx だった) 場合 true */
   posted: boolean;
+  /** fetch が non-2xx または例外の場合に設定されるエラー説明 */
+  error?: string;
 }
 
 /** 過去 24 時間の記事を D1 から取得する */
@@ -105,7 +107,7 @@ export function buildPayload(
 
 /**
  * Slack incoming webhook に日次ダイジェストを投稿する。
- * SLACK_WEBHOOK_URL が未設定なら no-op (ログのみ)。fetch 失敗は console.error のみ。
+ * SLACK_WEBHOOK_URL が未設定なら no-op (ログのみ)。fetch 失敗 / non-2xx は posted=false で返す。
  * Discord は blocks を無視して text フィールドをメッセージとして表示する。
  */
 export async function postDailyDigest(
@@ -130,12 +132,14 @@ export async function postDailyDigest(
       signal: controller.signal,
     });
     if (!res.ok) {
+      const error = `status ${res.status}`;
       console.error(`[slack-daily] webhook returned non-2xx: ${res.status} ${res.statusText}`);
+      return { posted: false, error };
     }
   } catch (err) {
-    console.error(
-      `[slack-daily] failed to post: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`[slack-daily] failed to post: ${message}`);
+    return { posted: false, error: message };
   } finally {
     clearTimeout(timer);
   }


### PR DESCRIPTION
## 概要

`postDailyDigest` が webhook fetch の失敗時でも `{ posted: true }` を返していたバグを修正。

## 修正前後の挙動

| ケース | 修正前 | 修正後 |
|---|---|---|
| `webhookUrl` 未設定 | `{ posted: false }` | `{ posted: false }` (変更なし) |
| fetch 成功 (2xx) | `{ posted: true }` | `{ posted: true }` (変更なし) |
| fetch non-2xx (例: 500) | `{ posted: true }` | `{ posted: false, error: "status 500" }` |
| fetch 例外 (ネットワークエラー等) | `{ posted: true }` | `{ posted: false, error: "<message>" }` |

## 変更内容

- `DailyDigestResult` に `error?: string` を追加
- `postDailyDigest` で non-2xx → `{ posted: false, error: \`status \${res.status}\` }` を返すよう修正
- `postDailyDigest` で fetch 例外 → `{ posted: false, error: err.message }` を返すよう修正
- テスト: "does not throw on ..." を "returns posted=false with error ..." に差し替え、戻り値を明示的に検証

## テスト

- webhook 200 → `{ posted: true }` ✅
- webhook 500 → `{ posted: false, error: "status 500" }` ✅ (追加)
- fetch throw → `{ posted: false, error: "Failed to fetch" }` ✅ (追加)
- 513 tests passed

Closes #276