### PR TITLE
refactor(collector): unify collectFeeds into collectAll wrapper

### DIFF
--- a/apps/web/tests/worker/api/admin.test.ts
+++ b/apps/web/tests/worker/api/admin.test.ts
@@ -122,6 +122,22 @@ describe("POST /api/admin/collector/run", () => {
     }
   }, 60_000);
 
+  it("200: /collector/run 経由でも collector_runs に run が記録される", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/collector/run", {
+      method: "POST",
+      headers: { ...AUTH_HEADER, "content-type": "application/json" },
+      body: JSON.stringify({ feed_ids: [REAL_FEED_ID] }),
+    });
+    expect(res.status).toBe(200);
+
+    // 同期実行なので応答が返った時点で collector_runs に行が存在するはず
+    const runs = await listRuns(env.DB, 10);
+    expect(runs.length).toBeGreaterThan(0);
+    // 最新 run は completed_at が設定されている
+    const latest = runs[0];
+    expect(latest.completed_at).toBeTruthy();
+  }, 60_000);
+
   it("401: 認証なし → 401", async () => {
     const res = await SELF.fetch("https://example.com/api/admin/collector/run", {
       method: "POST",

--- a/apps/web/worker/collector/index.ts
+++ b/apps/web/worker/collector/index.ts
@@ -284,75 +284,6 @@ async function runWithConcurrency<T, R>(
   return results;
 }
 
-/**
- * 特定の feed_ids のみを対象に収集する。admin 手動トリガー用。
- * - feedIds 未指定時は全 enabled feed を対象にする
- * - feedIds 指定時は enabled かつ指定 ID に含まれるものだけを対象にする
- */
-export async function collectFeeds(env: Env, feedIds?: string[]): Promise<CollectAllResult> {
-  const start = Date.now();
-  const feeds = loadEnabledFeeds();
-  await syncFeeds(env.DB, feeds);
-
-  const d1EnabledIds = await getEnabledFeedIds(env.DB);
-  const activeFeeds = feeds.filter((f) => {
-    if (!d1EnabledIds.has(f.id)) return false;
-    if (feedIds !== undefined) return feedIds.includes(f.id);
-    return true;
-  });
-
-  const concurrency = Number(env.COLLECTOR_CONCURRENCY ?? "4") || 4;
-  const timeoutMs = Number(env.COLLECTOR_TIMEOUT_MS ?? "10000") || 10000;
-  const maxRetries = Number(env.COLLECTOR_RETRIES ?? "2") || 2;
-  const summaryMax = Number(env.SUMMARY_MAX_LENGTH ?? "500") || 500;
-
-  const headersMap = await loadFeedHeadersAll(
-    env.DB,
-    activeFeeds.map((f) => f.id),
-  );
-  const emptyHeaders: FeedHeaders = { last_etag: null, last_modified: null };
-
-  const results = await runWithConcurrency(activeFeeds, concurrency, (feed) =>
-    collectFeed(
-      env,
-      feed,
-      headersMap.get(feed.id) ?? emptyHeaders,
-      summaryMax,
-      timeoutMs,
-      maxRetries,
-    ),
-  );
-
-  const inserted = results.reduce((acc, r) => acc + r.inserted, 0);
-  const skipped304 = results.filter((r) => r.status === "not_modified").length;
-
-  const durationMs = Date.now() - start;
-  console.log(
-    `[collector] feeds=${activeFeeds.length} skipped304=${skipped304} inserted=${inserted} duration=${durationMs}ms`,
-  );
-  for (const r of results) {
-    if (r.status === "error") {
-      console.warn(`[collector] ${r.feedId} ERROR: ${r.error}`);
-    }
-  }
-
-  if (env.ALERT_WEBHOOK_URL) {
-    const minFailures = Number(env.ALERT_MIN_FAILURES ?? "3") || 3;
-    const feedStreak = Number(env.ALERT_FEED_STREAK ?? "5") || 5;
-    try {
-      const streaks = await getFeedStreaks(env.DB);
-      await maybeAlert(env.ALERT_WEBHOOK_URL, results, streaks, minFailures, feedStreak);
-    } catch (err) {
-      console.error(
-        `[collector] alert check failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
-  }
-
-  // retention は scheduled() の pruneOldArticles に一本化しているため、ここでは常に 0
-  return { total: activeFeeds.length, inserted, pruned: 0, results, durationMs };
-}
-
 export type ValidateFeedResult =
   | { ok: true; title: string; lang: string | null; item_count: number }
   | { ok: false; error: string };
@@ -427,7 +358,7 @@ export async function validateFeedUrl(url: string): Promise<ValidateFeedResult> 
 
 export async function collectAll(
   env: Env,
-  opts?: { runId?: number; feedIds?: readonly string[] },
+  opts?: { runId?: number; feedIds?: readonly string[]; source?: "cron" | "manual" },
 ): Promise<CollectAllResult> {
   const start = Date.now();
   const startedAt = new Date(start).toISOString();
@@ -527,8 +458,9 @@ export async function collectAll(
     }
   }
 
+  const source = opts?.source ?? "cron";
   console.log(
-    `[collector] feeds=${activeFeeds.length} skipped304=${skipped304} inserted=${inserted} duration=${durationMs}ms`,
+    `[collector] source=${source} feeds=${activeFeeds.length} skipped304=${skipped304} inserted=${inserted} duration=${durationMs}ms`,
   );
 
   // D1 コスト集計を AE に送信する (best-effort)
@@ -579,4 +511,14 @@ export async function collectAll(
   }
 
   return finalResult;
+}
+
+/**
+ * 特定の feed_ids のみを対象に収集する。admin 手動トリガー用。
+ * collectAll の薄いラッパー。run tracking (collector_runs) も有効。
+ * - feedIds 未指定時は全 enabled feed を対象にする
+ * - feedIds 指定時は enabled かつ指定 ID に含まれるものだけを対象にする
+ */
+export async function collectFeeds(env: Env, feedIds?: string[]): Promise<CollectAllResult> {
+  return collectAll(env, { source: "manual", feedIds });
 }


### PR DESCRIPTION
## 概要
`collectFeeds` (admin 手動トリガー用) を `collectAll` の薄いラッパーに変更し、`/api/admin/collector/run` 経由の実行でも `collector_runs` に実行記録が残るようにする。

Closes #280

## 変更内容
- `apps/web/worker/collector/index.ts`
  - `collectAll` の `opts` に `source?: "cron" | "manual"` を追加 (ログ識別用)
  - `collectFeeds` の実装を削除し、`collectAll(env, { source: "manual", feedIds })` を呼ぶラッパーに変更
  - ログ出力に `source=cron/manual` を追加
- `apps/web/tests/worker/api/admin.test.ts`
  - `POST /api/admin/collector/run` 経由でも `collector_runs` に run が記録されることを検証するテストを追加

## Test plan
- [x] pnpm build pass
- [x] pnpm test (513 tests) pass
- [x] 新規テスト: /collector/run 経由で collector_runs に run が記録される