### PR TITLE
chore(types): remove dead exports from worker/types.ts

### DIFF
--- a/apps/web/tests/worker/api/health.test.ts
+++ b/apps/web/tests/worker/api/health.test.ts
@@ -3,7 +3,8 @@ import { env, SELF } from "cloudflare:test";
 import { insertArticles } from "../../../worker/db/articles";
 import { syncFeeds, recordFetchSuccess, recordFetchError } from "../../../worker/db/feeds";
 import { startRun, finishRun } from "../../../worker/db/runs";
-import type { FeedConfig, FeedHealth, HealthResponse } from "../../../worker/types";
+import type { FeedConfig, FeedHealth } from "../../../worker/types";
+import type { HealthResponse } from "../../../worker/api/types";
 
 const FEED: FeedConfig = {
   id: "health-test-feed",

--- a/apps/web/worker/api/health.ts
+++ b/apps/web/worker/api/health.ts
@@ -4,8 +4,8 @@ import { countFeeds } from "../db/feeds";
 import { countAllArticles, countArticlesSince } from "../db/articles";
 import { getLatestCompletedRun } from "../db/runs";
 import { loadAllFeeds } from "../feed-config";
-import type { Env, FeedHealth, HealthResponse } from "../types";
-import type { HealthFeedsResponse } from "./types";
+import type { Env, FeedHealth } from "../types";
+import type { HealthFeedsResponse, HealthResponse } from "./types";
 
 const app = new Hono<{ Bindings: Env }>();
 

--- a/apps/web/worker/types.ts
+++ b/apps/web/worker/types.ts
@@ -28,23 +28,6 @@ export interface Env {
 export type FeedCategory = "bigtech" | "ai" | "jp" | "zenn";
 export type FeedLang = "ja" | "en";
 
-/**
- * Branded string types — DB / API 境界を越えても id と guid が混在しないことを型で保証する。
- * 実体は string なので JSON シリアライズや D1 bind でそのまま使える。
- */
-export type FeedId = string & { readonly __brand: "FeedId" };
-export type ArticleGuid = string & { readonly __brand: "ArticleGuid" };
-
-/** raw string を FeedId に昇格させる境界ファクトリ (feeds.yaml / D1 読み込み時に使う) */
-export function asFeedId(s: string): FeedId {
-  return s as FeedId;
-}
-
-/** raw string を ArticleGuid に昇格させる境界ファクトリ */
-export function asArticleGuid(s: string): ArticleGuid {
-  return s as ArticleGuid;
-}
-
 export interface FeedConfig {
   id: string;
   name: string;
@@ -74,23 +57,6 @@ export interface Article {
   lang: FeedLang;
 }
 
-export interface ArticlesResponse {
-  articles: Article[];
-  nextCursor: string | null;
-}
-
-export interface FeedSummary {
-  id: string;
-  name: string;
-  url: string;
-  category: FeedCategory;
-  lang: FeedLang;
-  enabled: boolean;
-  last_fetched_at: string | null;
-  last_status: string | null;
-  article_count: number;
-}
-
 export interface HealthCronRun {
   id: number;
   started_at: string;
@@ -99,21 +65,6 @@ export interface HealthCronRun {
   feeds_ok: number;
   feeds_failed: number;
   articles_inserted: number;
-}
-
-export interface HealthResponse {
-  ok: boolean;
-  version: string;
-  now: string;
-  feeds: {
-    total: number;
-    enabled: number;
-  };
-  articles: {
-    total: number;
-    last_24h: number;
-  };
-  last_cron_run: HealthCronRun | null;
 }
 
 export interface FeedHealth {


### PR DESCRIPTION
## 概要

`worker/types.ts` から dead exports を削除。grep による実使用の調査結果をもとに、本当に未使用であることを確認してから削除した。

## 削除した型と未使用根拠

| 型 / 関数 | 根拠 |
|-----------|------|
| `ArticlesResponse` | `apps/web/worker/` 内のどのファイルからも import なし。`client/types/api.ts` に独立した同名型あり（worker とは別管理）|
| `FeedSummary` | 同上。`client/types/api.ts` に独立した同名型あり |
| `HealthResponse` | `api/types.ts:116` に同一 shape の定義が重複。`worker/api/health.ts` と `tests/worker/api/health.test.ts` が `worker/types.ts` 側を参照していたため、import 先を `api/types.ts` に切り替えたうえで削除 |
| `FeedId`, `ArticleGuid` | ブランド型の定義のみで、キャストして使用している箇所がゼロ |
| `asFeedId`, `asArticleGuid` | 上記に対応するファクトリ関数。どこからも呼ばれていない |

## 変更ファイル

- `apps/web/worker/types.ts` — dead exports 削除
- `apps/web/worker/api/health.ts` — `HealthResponse` の import 先を `./types` に変更
- `apps/web/tests/worker/api/health.test.ts` — 同上

## 検証

- `pnpm build` pass
- `pnpm test` pass (513 tests)
- 変更した 3 ファイルの lint エラーゼロ (`vp lint`)

Closes #281