### PR TITLE
feat(articles): auto-load more when client filters thin out the list

### DIFF
--- a/apps/web/client/App.tsx
+++ b/apps/web/client/App.tsx
@@ -138,6 +138,12 @@ function AppInner() {
     [category, lang, feedId, q, dateFrom, dateTo],
   );
 
+  // useArticles より先にフィルタ結果を算出できないため、前回レンダリング時の値を ref で保持して渡す。
+  // これにより autoLoad.filteredLength は常に 1 レンダリング遅れの値になるが、
+  // 自動 loadMore の発火条件としては十分な精度がある。
+  const filteredLengthRef = useRef(0);
+  const isFilterActive = unreadOnly || starredOnly || bookmarkedOnly;
+
   const {
     articles: allArticles,
     loading,
@@ -145,7 +151,11 @@ function AppInner() {
     error,
     nextCursor,
     loadMore,
-  } = useArticles(query);
+    autoLoadStopped,
+  } = useArticles(query, {
+    filteredLength: filteredLengthRef.current,
+    isFilterActive,
+  });
 
   // 未読・スター・ブックマークフィルタはクライアントサイドで適用 (サーバー API はこれらを知らないため)
   const articles = useMemo(() => {
@@ -153,6 +163,8 @@ function AppInner() {
     if (unreadOnly) filtered = filtered.filter((a) => !isRead(a.id));
     if (starredOnly) filtered = filtered.filter((a) => isStarred(a.id));
     if (bookmarkedOnly) filtered = filtered.filter((a) => bookmarks.has(a.guid));
+    // 次レンダリングの autoLoad.filteredLength として使う
+    filteredLengthRef.current = filtered.length;
     return filtered;
   }, [allArticles, unreadOnly, starredOnly, bookmarkedOnly, isRead, isStarred, bookmarks]);
 
@@ -241,6 +253,7 @@ function AppInner() {
           error={error}
           nextCursor={nextCursor}
           loadMore={loadMore}
+          autoLoadStopped={autoLoadStopped}
           selectedIndex={selectedIndex}
           q={q}
           category={category}

--- a/apps/web/client/components/ArticlesView.tsx
+++ b/apps/web/client/components/ArticlesView.tsx
@@ -24,6 +24,7 @@ interface Props {
   error: string | null;
   nextCursor: string | null;
   loadMore: () => void;
+  autoLoadStopped: boolean;
   selectedIndex: number;
   q: string;
   category: FeedCategory | "";
@@ -68,6 +69,7 @@ export function ArticlesView({
   error,
   nextCursor,
   loadMore,
+  autoLoadStopped,
   selectedIndex,
   q,
   category,
@@ -248,7 +250,11 @@ export function ArticlesView({
           onClick={loadMore}
           disabled={loadingMore}
         >
-          {loadingMore ? "読み込み中…" : "もっと読み込む"}
+          {loadingMore
+            ? "読み込み中…"
+            : autoLoadStopped
+              ? "自動読み込み停止 / もっと読み込む"
+              : "もっと読み込む"}
         </button>
       )}
     </>

--- a/apps/web/client/hooks/useArticles.ts
+++ b/apps/web/client/hooks/useArticles.ts
@@ -10,12 +10,18 @@ export interface ArticlesQuery {
   dateTo?: string;
 }
 
+// クライアントフィルタが ON の時、この件数を下回ると自動 loadMore を発火する
+const MIN_VISIBLE = 10;
+// D1 free tier の reads 上限を意識し、連続自動ロード回数を制限する
+const AUTO_LOAD_MAX = 5;
+
 interface State {
   articles: Article[];
   nextCursor: string | null;
   loading: boolean;
   loadingMore: boolean;
   error: string | null;
+  autoLoadCount: number;
 }
 
 const initial: State = {
@@ -24,6 +30,7 @@ const initial: State = {
   loading: false,
   loadingMore: false,
   error: null,
+  autoLoadCount: 0,
 };
 
 function buildUrl(query: ArticlesQuery, cursor?: string | null): string {
@@ -39,12 +46,25 @@ function buildUrl(query: ArticlesQuery, cursor?: string | null): string {
   return `/api/articles?${params.toString()}`;
 }
 
-export function useArticles(query: ArticlesQuery) {
+export interface AutoLoadOptions {
+  // クライアントフィルタ後の表示件数 (フィルタ OFF 時は allArticles.length と同じ)
+  filteredLength: number;
+  // unreadOnly / starredOnly / bookmarksOnly のいずれかが ON
+  isFilterActive: boolean;
+}
+
+export function useArticles(query: ArticlesQuery, autoLoad: AutoLoadOptions) {
   const [state, setState] = useState<State>(initial);
   const reqIdRef = useRef(0);
+  // autoLoad は毎レンダリングで新規オブジェクトになるため ref で保持して useEffect の依存を安定させる
+  const autoLoadRef = useRef(autoLoad);
+  autoLoadRef.current = autoLoad;
+  // 自動 loadMore が進行中かどうかを示すフラグ (二重発火防止)
+  const autoLoadingRef = useRef(false);
 
   const fetchInitial = useCallback(async () => {
     const reqId = ++reqIdRef.current;
+    autoLoadingRef.current = false;
     setState((s) => ({ ...s, loading: true, error: null }));
     try {
       const res = await fetch(buildUrl(query));
@@ -57,6 +77,7 @@ export function useArticles(query: ArticlesQuery) {
         loading: false,
         loadingMore: false,
         error: null,
+        autoLoadCount: 0,
       });
     } catch (err) {
       if (reqId !== reqIdRef.current) return;
@@ -66,6 +87,7 @@ export function useArticles(query: ArticlesQuery) {
         loading: false,
         loadingMore: false,
         error: err instanceof Error ? err.message : String(err),
+        autoLoadCount: 0,
       });
     }
   }, [query]);
@@ -90,6 +112,7 @@ export function useArticles(query: ArticlesQuery) {
         loading: false,
         loadingMore: false,
         error: null,
+        autoLoadCount: s.autoLoadCount,
       }));
     } catch (err) {
       if (reqId !== reqIdRef.current) return;
@@ -101,5 +124,57 @@ export function useArticles(query: ArticlesQuery) {
     }
   }, [query, state.nextCursor, state.loadingMore]);
 
-  return { ...state, loadMore, reload: fetchInitial };
+  // フィルタが ON で表示件数が MIN_VISIBLE 未満かつ次ページがある間、自動で次ページを取得する。
+  // autoLoadingRef で進行中フラグを管理し、state.loadingMore の変化による重複発火を防ぐ。
+  // AUTO_LOAD_MAX で D1 free tier の reads 上限を意識した上限を設ける。
+  useEffect(() => {
+    const { isFilterActive, filteredLength } = autoLoadRef.current;
+    if (!isFilterActive) return;
+    if (filteredLength >= MIN_VISIBLE) return;
+    if (!state.nextCursor) return;
+    if (state.loading) return;
+    if (autoLoadingRef.current) return;
+    if (state.autoLoadCount >= AUTO_LOAD_MAX) return;
+
+    autoLoadingRef.current = true;
+    const cursor = state.nextCursor;
+    const reqId = reqIdRef.current;
+
+    setState((s) => ({ ...s, loadingMore: true, autoLoadCount: s.autoLoadCount + 1 }));
+
+    void (async () => {
+      try {
+        const res = await fetch(buildUrl(query, cursor));
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = (await res.json()) as ArticlesResponse;
+        if (reqId !== reqIdRef.current) return;
+        setState((s) => ({
+          ...s,
+          articles: [...s.articles, ...data.articles],
+          nextCursor: data.nextCursor,
+          loadingMore: false,
+        }));
+      } catch (err) {
+        if (reqId !== reqIdRef.current) return;
+        setState((s) => ({
+          ...s,
+          loadingMore: false,
+          error: err instanceof Error ? err.message : String(err),
+        }));
+      } finally {
+        autoLoadingRef.current = false;
+      }
+    })();
+    // state.nextCursor と state.autoLoadCount の変化で次ページがあれば再発火する。
+    // state.loadingMore は autoLoadingRef で代替するため依存から除外。
+    // query の変化は fetchInitial 経由で state.nextCursor がリセットされるため追跡不要。
+  }, [query, state.nextCursor, state.loading, state.autoLoadCount]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const autoLoadStopped =
+    autoLoad.isFilterActive &&
+    autoLoad.filteredLength < MIN_VISIBLE &&
+    state.autoLoadCount >= AUTO_LOAD_MAX &&
+    state.nextCursor !== null;
+
+  return { ...state, loadMore, reload: fetchInitial, autoLoadStopped };
 }

--- a/apps/web/tests/client/useArticles.test.tsx
+++ b/apps/web/tests/client/useArticles.test.tsx
@@ -1,0 +1,261 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import type { Article } from "../../client/types/api";
+
+const { useArticles } = await import("../../client/hooks/useArticles");
+
+function makeArticle(id: number): Article {
+  return {
+    id,
+    guid: `guid-${id}`,
+    feed_id: "test-feed",
+    feed_name: "Test Feed",
+    title: `Article ${id}`,
+    url: `https://example.com/article/${id}`,
+    summary: `Summary ${id}`,
+    author: "Author",
+    published_at: "2024-01-15T10:00:00Z",
+    fetched_at: "2024-01-15T11:00:00Z",
+    category: "ai",
+    lang: "en",
+  };
+}
+
+function makeResponse(articles: Article[], nextCursor: string | null = null) {
+  return {
+    ok: true,
+    json: () => Promise.resolve({ articles, nextCursor }),
+  };
+}
+
+// renderHook 内で毎回 {} を渡すと新規オブジェクトになり query の依存が変化し続けるため定数を使う
+const EMPTY_QUERY = {};
+const NO_FILTER = { filteredLength: 0, isFilterActive: false };
+
+describe("useArticles 基本動作", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("fetch 成功時に記事が返される", async () => {
+    const articles = Array.from({ length: 5 }, (_, i) => makeArticle(i + 1));
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeResponse(articles)));
+
+    const { result } = renderHook(() => useArticles(EMPTY_QUERY, NO_FILTER));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.articles).toHaveLength(5);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("nextCursor が null のとき nextCursor が null になる", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeResponse([makeArticle(1)], null)));
+
+    const { result } = renderHook(() => useArticles(EMPTY_QUERY, NO_FILTER));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.nextCursor).toBeNull();
+  });
+
+  it("fetch エラー時に error が設定される", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+
+    const { result } = renderHook(() => useArticles(EMPTY_QUERY, NO_FILTER));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBeTruthy();
+    expect(result.current.articles).toEqual([]);
+  });
+
+  it("loadMore で次ページが追加される", async () => {
+    const page1 = Array.from({ length: 20 }, (_, i) => makeArticle(i + 1));
+    const page2 = Array.from({ length: 5 }, (_, i) => makeArticle(i + 21));
+    const mockFetch = vi
+      .fn<() => Promise<Response>>()
+      .mockResolvedValueOnce(makeResponse(page1, "cursor-next") as unknown as Response)
+      .mockResolvedValueOnce(makeResponse(page2, null) as unknown as Response);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const { result } = renderHook(() =>
+      useArticles(EMPTY_QUERY, { filteredLength: 20, isFilterActive: false }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.articles).toHaveLength(20);
+
+    await act(async () => {
+      await result.current.loadMore();
+    });
+
+    await waitFor(() => {
+      expect(result.current.articles).toHaveLength(25);
+    });
+
+    expect(result.current.nextCursor).toBeNull();
+  });
+});
+
+describe("useArticles 自動 loadMore", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("isFilterActive=false のとき自動 loadMore は発火しない", async () => {
+    const page1 = Array.from({ length: 20 }, (_, i) => makeArticle(i + 1));
+    const mockFetch = vi
+      .fn<() => Promise<Response>>()
+      .mockResolvedValue(makeResponse(page1, "cursor-next") as unknown as Response);
+    vi.stubGlobal("fetch", mockFetch);
+
+    // filteredLength < MIN_VISIBLE(10) だがフィルタは OFF
+    const { result } = renderHook(() =>
+      useArticles(EMPTY_QUERY, { filteredLength: 3, isFilterActive: false }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    // 自動 loadMore が発火しないため fetch は初回の 1 回のみ
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("フィルタ ON で filteredLength >= MIN_VISIBLE のとき自動 loadMore は発火しない", async () => {
+    const page1 = Array.from({ length: 20 }, (_, i) => makeArticle(i + 1));
+    const mockFetch = vi
+      .fn<() => Promise<Response>>()
+      .mockResolvedValue(makeResponse(page1, "cursor-next") as unknown as Response);
+    vi.stubGlobal("fetch", mockFetch);
+
+    // filteredLength=10 (=MIN_VISIBLE) で閾値以上のため発火しない
+    const { result } = renderHook(() =>
+      useArticles(EMPTY_QUERY, { filteredLength: 10, isFilterActive: true }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("hasMore=false のとき自動 loadMore は発火しない", async () => {
+    const page1 = Array.from({ length: 5 }, (_, i) => makeArticle(i + 1));
+    const mockFetch = vi
+      .fn<() => Promise<Response>>()
+      // nextCursor=null なので hasMore=false
+      .mockResolvedValue(makeResponse(page1, null) as unknown as Response);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const { result } = renderHook(() =>
+      useArticles(EMPTY_QUERY, { filteredLength: 2, isFilterActive: true }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    // nextCursor=null なので自動発火はしない
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("フィルタ ON で filteredLength < MIN_VISIBLE かつ nextCursor がある場合に自動 loadMore が発火する", async () => {
+    const page1 = Array.from({ length: 20 }, (_, i) => makeArticle(i + 1));
+    const page2 = Array.from({ length: 20 }, (_, i) => makeArticle(i + 21));
+    const mockFetch = vi
+      .fn<() => Promise<Response>>()
+      .mockResolvedValueOnce(makeResponse(page1, "cursor-2") as unknown as Response)
+      .mockResolvedValue(makeResponse(page2, null) as unknown as Response);
+    vi.stubGlobal("fetch", mockFetch);
+
+    // filteredLength=2 で MIN_VISIBLE(10) 未満 → 自動発火を期待
+    const { result } = renderHook(() =>
+      useArticles(EMPTY_QUERY, { filteredLength: 2, isFilterActive: true }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    // 自動 loadMore が発火し fetch が 2 回以上呼ばれるまで待つ
+    await waitFor(() => {
+      expect(mockFetch.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+
+    await waitFor(() => {
+      expect(result.current.articles).toHaveLength(40);
+    });
+  });
+
+  it("AUTO_LOAD_MAX (5回) に達すると自動 loadMore が停止する", async () => {
+    // 毎回 nextCursor を返し続けるレスポンスで上限に当たることを確認する
+    const mockFetch = vi.fn<() => Promise<Response>>().mockResolvedValue(
+      makeResponse(
+        Array.from({ length: 20 }, (_, i) => makeArticle(i + 1)),
+        "cursor-next",
+      ) as unknown as Response,
+    );
+    vi.stubGlobal("fetch", mockFetch);
+
+    const { result } = renderHook(() =>
+      useArticles(EMPTY_QUERY, { filteredLength: 2, isFilterActive: true }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    // 初回 + 最大 5 回の自動 loadMore = 合計 6 回で頭打ちになるまで待つ
+    await waitFor(
+      () => {
+        expect(result.current.autoLoadCount).toBe(5);
+      },
+      { timeout: 3000 },
+    );
+
+    // 上限到達後に autoLoadStopped が true になる
+    expect(result.current.autoLoadStopped).toBe(true);
+    // これ以上 fetch が呼ばれないことを確認 (=6 回で打ち止め)
+    expect(mockFetch.mock.calls.length).toBe(6);
+  });
+
+  it("autoLoadStopped は isFilterActive=false のとき false のまま", async () => {
+    const mockFetch = vi.fn<() => Promise<Response>>().mockResolvedValue(
+      makeResponse(
+        Array.from({ length: 5 }, (_, i) => makeArticle(i + 1)),
+        "cursor-next",
+      ) as unknown as Response,
+    );
+    vi.stubGlobal("fetch", mockFetch);
+
+    const { result } = renderHook(() =>
+      useArticles(EMPTY_QUERY, { filteredLength: 2, isFilterActive: false }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.autoLoadStopped).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- `useArticles` に `AutoLoadOptions` (第2引数) と自動 loadMore ロジックを追加
- フィルタ ON かつ `filteredLength < MIN_VISIBLE(10)` のとき、次ページを自動取得
- `autoLoadingRef` で二重発火を防止し、`AUTO_LOAD_MAX(5)` 回に達すると停止
- `autoLoadStopped` フラグを `ArticlesView` に props として渡し、「自動読み込み停止 / もっと読み込む」に切り替え
- `apps/web/tests/client/useArticles.test.tsx` を新規作成 (9 ケース)

## Re-do of closed #293

PR #293 は main の `#263` (App.tsx → ArticlesView 分割) との conflict 解消が複雑となり close した。
本 PR は最新 main 起点で再実装したもの。

## Test plan

- [x] `pnpm build` pass
- [x] `pnpm test` pass (515 tests)
- [x] `pnpm test:client` pass (208 tests、うち useArticles が 9 ケース)
- [ ] 手動: unreadOnly ON でページをリロードし、少ない記事数のとき自動でページが追加されることを確認
- [ ] 手動: 5回上限到達後に「自動読み込み停止 / もっと読み込む」ボタンが表示されることを確認

Closes #277
Re-do of closed #293 (rebase too divergent)