### PR TITLE
fix(reports): pin claude-code-base-action to @beta

### DIFF
--- a/.github/workflows/report-daily.yml
+++ b/.github/workflows/report-daily.yml
@@ -35,7 +35,7 @@ jobs:
       # cf-typegen は build に依存するため明示的に走らせない (skill は recent.mjs しか使わない)。
 
       - name: Run tech-news-digest skill
-        uses: anthropics/claude-code-base-action@v1
+        uses: anthropics/claude-code-base-action@beta
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/report-monthly.yml
+++ b/.github/workflows/report-monthly.yml
@@ -33,7 +33,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Run tech-news-weekly skill (monthly)
-        uses: anthropics/claude-code-base-action@v1
+        uses: anthropics/claude-code-base-action@beta
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/report-weekly.yml
+++ b/.github/workflows/report-weekly.yml
@@ -32,7 +32,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Run tech-news-weekly skill
-        uses: anthropics/claude-code-base-action@v1
+        uses: anthropics/claude-code-base-action@beta
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary

- `anthropics/claude-code-base-action` には `v1` タグが存在せず (`v0.0.x` と `beta` のみ)、`@v1` を指定していた report-daily / weekly / monthly が `Unable to resolve action ... @v1` で起動直後に失敗していた
- 公式 README の例に揃えて `@beta` 固定にする

## 影響範囲

- `.github/workflows/report-daily.yml`
- `.github/workflows/report-weekly.yml`
- `.github/workflows/report-monthly.yml`

## Test plan

- [ ] merge 後 `Report Daily` を `workflow_dispatch` で再実行し、Skill ステップが action を解決できることを確認