### PR TITLE
feat(reports): scope CI reports to bigtech only

### DIFF
--- a/.github/workflows/report-daily.yml
+++ b/.github/workflows/report-daily.yml
@@ -50,18 +50,20 @@ jobs:
             - since=today
             - mode=deep
             - target=remote
-            - category 指定なし (全カテゴリ)
+            - category=bigtech
             - lang 指定なし
 
+            Stage 1 では `recent.mjs --category=bigtech --target=remote` を呼んでください。
             Stage 1〜4 を完走したあと、最終的な markdown レポート全文を /tmp/report.md に
-            書き出してください。
+            書き出してください。レポートには `## カテゴリ別ハイライト` 節を含めないでください
+            (bigtech 1 カテゴリのみのため不要)。
             合わせて以下の JSON を /tmp/report-meta.json に書き出してください:
 
             {
               "kind": "daily",
               "period_start": "<since の ISO 8601>",
               "period_end":   "<実行時刻の ISO 8601>",
-              "category": null,
+              "category": "bigtech",
               "lang": null,
               "source_skill": "tech-news-digest",
               "generated_at": "<実行時刻の ISO 8601>",

--- a/.github/workflows/report-monthly.yml
+++ b/.github/workflows/report-monthly.yml
@@ -48,18 +48,20 @@ jobs:
             - since=month
             - target=remote
             - limit=500
-            - category 指定なし (全カテゴリ)
+            - category=bigtech
             - lang 指定なし
 
+            Stage 1 では `recent.mjs --category=bigtech --target=remote --limit=500` を呼んでください。
             Stage 1〜4 を完走したあと、最終的な markdown レポート全文を /tmp/report.md に
-            書き出してください。
+            書き出してください。レポートには `## カテゴリ別ハイライト` 節を含めないでください
+            (bigtech 1 カテゴリのみのため不要)。
             合わせて以下の JSON を /tmp/report-meta.json に書き出してください:
 
             {
               "kind": "monthly",
               "period_start": "<実行時刻 -30 日 の ISO 8601>",
               "period_end":   "<実行時刻の ISO 8601>",
-              "category": null,
+              "category": "bigtech",
               "lang": null,
               "source_skill": "tech-news-weekly",
               "generated_at": "<実行時刻の ISO 8601>",

--- a/.github/workflows/report-weekly.yml
+++ b/.github/workflows/report-weekly.yml
@@ -46,18 +46,20 @@ jobs:
             tech-news-weekly skill を以下の引数で起動してください:
             - since=week
             - target=remote
-            - category 指定なし (全カテゴリ)
+            - category=bigtech
             - lang 指定なし
 
+            Stage 1 では `recent.mjs --category=bigtech --target=remote` を呼んでください。
             Stage 1〜4 を完走したあと、最終的な markdown レポート全文を /tmp/report.md に
-            書き出してください。
+            書き出してください。レポートには `## カテゴリ別ハイライト` 節を含めないでください
+            (bigtech 1 カテゴリのみのため不要)。
             合わせて以下の JSON を /tmp/report-meta.json に書き出してください:
 
             {
               "kind": "weekly",
               "period_start": "<実行時刻 -7 日 の ISO 8601>",
               "period_end":   "<実行時刻の ISO 8601>",
-              "category": null,
+              "category": "bigtech",
               "lang": null,
               "source_skill": "tech-news-weekly",
               "generated_at": "<実行時刻の ISO 8601>",

--- a/docs/reports-pipeline.md
+++ b/docs/reports-pipeline.md
@@ -122,11 +122,11 @@ CORS は付けず、Bearer `ADMIN_TOKEN` (rotation 中は `ADMIN_TOKEN_NEXT` も
 
 各 workflow は `.github/workflows/` 配下に置く。
 
-| File                 | スケジュール (UTC) | スケジュール (JST) | 起動する skill     | skill 引数               |
-| -------------------- | ------------------ | ------------------ | ------------------ | ------------------------ |
-| `report-daily.yml`   | `0 22 * * *`       | 毎日 07:00         | `tech-news-digest` | `since=today, deep`      |
-| `report-weekly.yml`  | `0 22 * * 0`       | 毎週月曜 07:00     | `tech-news-weekly` | `since=week`             |
-| `report-monthly.yml` | `0 22 1 * *`       | 毎月 2 日 07:00    | `tech-news-weekly` | `since=month, limit=500` |
+| File                 | スケジュール (UTC) | スケジュール (JST) | 起動する skill     | skill 引数                                 |
+| -------------------- | ------------------ | ------------------ | ------------------ | ------------------------------------------ |
+| `report-daily.yml`   | `0 22 * * *`       | 毎日 07:00         | `tech-news-digest` | `since=today, deep, category=bigtech`      |
+| `report-weekly.yml`  | `0 22 * * 0`       | 毎週月曜 07:00     | `tech-news-weekly` | `since=week, category=bigtech`             |
+| `report-monthly.yml` | `0 22 1 * *`       | 毎月 2 日 07:00    | `tech-news-weekly` | `since=month, limit=500, category=bigtech` |
 
 > monthly は GitHub Actions cron が `L` (月末) を非対応のため、「翌月 2 日 JST 07:00 に
 > 過去 30 日を集計」として暦月とほぼ等価のレポートを作る。`since=month` は skill 仕様で
@@ -149,12 +149,14 @@ tech-news-digest skill を以下の引数で起動してください:
 - since=today
 - mode=deep
 - target=remote
-- category 指定なし (全カテゴリ)
+- category=bigtech
 - lang 指定なし
 
+Stage 1 では `recent.mjs --category=bigtech --target=remote` を呼んでください。
 Stage 1〜4 を完走したあと、最終的な markdown レポート全文を /tmp/report.md に
-書き出してください。
-合わせて meta JSON を /tmp/report-meta.json に書き出してください: { kind, period_start, ... }
+書き出してください。レポートには `## カテゴリ別ハイライト` 節を含めないでください
+(bigtech 1 カテゴリのみのため不要)。
+合わせて meta JSON を /tmp/report-meta.json に書き出してください: { kind, period_start, ..., category: "bigtech" }
 ```
 
 ### concurrency


### PR DESCRIPTION
## Summary

- `report-daily.yml` / `report-weekly.yml` / `report-monthly.yml` の skill prompt を `category=bigtech` 専用に変更
- 各 prompt に `recent.mjs --category=bigtech --target=remote` を明示し、`## カテゴリ別ハイライト` 節を削除するよう指示
- meta JSON テンプレートの `category: null` を `category: "bigtech"` に変更 (3 workflow 共通)
- `docs/reports-pipeline.md` の Workflow 一覧表と prompt 例を新しい引数に更新

DB の UNIQUE index は `COALESCE(category, '__all__')` 形式なので、既存の `category=NULL` 行とは別 row として共存し衝突しない。

## Test plan

- [x] YAML 構文チェック (`python3 -c "import yaml; yaml.safe_load(...)"`) pass
- [x] `pnpm check` (lint / typecheck) のエラーは pre-existing 35 件のみで変更起因なし
- [ ] merge 後に `Report Daily` を `workflow_dispatch` で手動実行し、`reports` テーブルに `category='bigtech'` の行が入ることを確認

Closes #297