### PR TITLE
feat(reports): add public reports viewer UI

### DIFF
--- a/apps/web/client/App.tsx
+++ b/apps/web/client/App.tsx
@@ -13,6 +13,7 @@ import {
   readAuthorFromPath,
   readFeedDetailFromPath,
   readFromUrl,
+  readReportIdFromPath,
   readViewFromUrl,
 } from "./lib/routing";
 import { ArticlesView } from "./components/ArticlesView";
@@ -20,6 +21,8 @@ import { AuthorDetail } from "./components/AuthorDetail";
 import { CategoriesOverview } from "./components/CategoriesOverview";
 import { FeedDetail } from "./components/FeedDetail";
 import { type AppView, Header } from "./components/Header";
+import { ReportDetail } from "./components/ReportDetail";
+import { ReportsList } from "./components/ReportsList";
 import { ShortcutsHelp } from "./components/ShortcutsHelp";
 import { StatsDashboard } from "./components/StatsDashboard";
 import { ToastContainer } from "./components/ToastContainer";
@@ -28,6 +31,7 @@ function AppInner() {
   const [view, setView] = useState<AppView>(readViewFromUrl);
   const [feedDetailId, setFeedDetailId] = useState<string>(() => readFeedDetailFromPath() ?? "");
   const [authorName, setAuthorName] = useState<string>(() => readAuthorFromPath() ?? "");
+  const [reportId, setReportId] = useState<number>(() => readReportIdFromPath() ?? 0);
   const [urlFilters, setUrlFilters] = useUrlState();
   const { q, category, lang, bookmarksOnly: bookmarkedOnly } = urlFilters;
   const [feedId, setFeedId] = useState<string>(() => readFromUrl().feedId);
@@ -55,7 +59,15 @@ function AppInner() {
     setView(next);
     setFeedDetailId("");
     setAuthorName("");
-    const path = next === "stats" ? "/stats" : next === "categories" ? "/categories" : "/";
+    setReportId(0);
+    const path =
+      next === "stats"
+        ? "/stats"
+        : next === "categories"
+          ? "/categories"
+          : next === "reports"
+            ? "/reports"
+            : "/";
     if (window.location.pathname !== path) {
       window.history.pushState(null, "", path);
     }
@@ -70,15 +82,24 @@ function AppInner() {
       if (nextView === "feed") {
         setFeedDetailId(readFeedDetailFromPath() ?? "");
         setAuthorName("");
+        setReportId(0);
         return;
       }
       if (nextView === "author") {
         setAuthorName(readAuthorFromPath() ?? "");
         setFeedDetailId("");
+        setReportId(0);
+        return;
+      }
+      if (nextView === "report") {
+        setReportId(readReportIdFromPath() ?? 0);
+        setFeedDetailId("");
+        setAuthorName("");
         return;
       }
       setFeedDetailId("");
       setAuthorName("");
+      setReportId(0);
       const next = readFromUrl();
       setFeedId(next.feedId);
       setDateFrom(next.dateFrom);
@@ -124,6 +145,18 @@ function AppInner() {
     window.dispatchEvent(new PopStateEvent("popstate"));
     setView("articles");
     setAuthorName("");
+  }, []);
+
+  const handleSelectReport = useCallback((id: number) => {
+    window.history.pushState(null, "", `/reports/${id}`);
+    setView("report");
+    setReportId(id);
+  }, []);
+
+  const handleBackFromReportDetail = useCallback(() => {
+    window.history.pushState(null, "", "/reports");
+    setView("reports");
+    setReportId(0);
   }, []);
 
   const query = useMemo(
@@ -230,6 +263,10 @@ function AppInner() {
         <StatsDashboard onNavigateToAuthor={handleGoToAuthorDetail} />
       ) : view === "categories" ? (
         <CategoriesOverview onSelectCategory={filterHandlers.handleSelectCategory} />
+      ) : view === "reports" ? (
+        <ReportsList onSelectReport={handleSelectReport} />
+      ) : view === "report" && reportId > 0 ? (
+        <ReportDetail id={reportId} onBack={handleBackFromReportDetail} />
       ) : view === "feed" && feedDetailId ? (
         <FeedDetail
           feedId={feedDetailId}

--- a/apps/web/client/components/Header.tsx
+++ b/apps/web/client/components/Header.tsx
@@ -3,7 +3,15 @@ import { useTheme } from "../hooks/useTheme";
 
 // "feed" は /feed/:id のフィード詳細ページで使用。nav タブには載せない
 // "author" は /author/:name の著者詳細ページで使用。nav タブには載せない
-export type AppView = "articles" | "stats" | "feed" | "author" | "categories";
+// "report" は /reports/:id の詳細ページで使用。nav タブには載せない
+export type AppView =
+  | "articles"
+  | "stats"
+  | "feed"
+  | "author"
+  | "categories"
+  | "reports"
+  | "report";
 
 interface HeaderProps {
   view?: AppView;
@@ -14,6 +22,7 @@ const NAV_TABS: Array<{ id: AppView; label: string; icon: string }> = [
   { id: "articles", label: "Articles", icon: "📰" },
   { id: "stats", label: "Stats", icon: "📊" },
   { id: "categories", label: "カテゴリ", icon: "🗂️" },
+  { id: "reports", label: "レポート", icon: "📝" },
 ];
 
 export function Header({ view, onViewChange }: HeaderProps) {

--- a/apps/web/client/components/ReportDetail.tsx
+++ b/apps/web/client/components/ReportDetail.tsx
@@ -1,0 +1,156 @@
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import type { Components } from "react-markdown";
+import { useReport } from "../hooks/useReports";
+
+const KIND_LABELS: Record<string, string> = {
+  daily: "日次",
+  weekly: "週次",
+  monthly: "月次",
+};
+
+interface MetaJson {
+  dedup_total?: number;
+  by_category?: Record<string, number>;
+  by_feed?: Record<string, number>;
+}
+
+function parseMeta(metaJson: string | null): MetaJson | null {
+  if (!metaJson) return null;
+  try {
+    return JSON.parse(metaJson) as MetaJson;
+  } catch {
+    return null;
+  }
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString("ja-JP", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+// markdown 内のリンクを新タブで開くカスタムレンダラ
+const markdownComponents: Components = {
+  a: ({ href, children, ...props }) => (
+    <a href={href} target="_blank" rel="noopener noreferrer" {...props}>
+      {children}
+    </a>
+  ),
+};
+
+interface Props {
+  id: number;
+  onBack: () => void;
+}
+
+export function ReportDetail({ id, onBack }: Props) {
+  const { data: report, loading, error } = useReport(id);
+
+  if (loading) {
+    return (
+      <div className="py-[var(--space-8)]">
+        <p className="text-[var(--fg-muted)] text-[var(--font-size-sm)]">読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (error || !report) {
+    return (
+      <div className="py-[var(--space-8)]">
+        <button
+          type="button"
+          className="text-[var(--accent)] text-[var(--font-size-sm)] border-none bg-transparent font-[inherit] cursor-pointer p-0 mb-[var(--space-4)] hover:underline focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2"
+          onClick={onBack}
+        >
+          ← 一覧に戻る
+        </button>
+        <p className="text-[var(--fg-muted)] text-[var(--font-size-sm)]">
+          {error ?? "レポートが見つかりません"}
+        </p>
+      </div>
+    );
+  }
+
+  const meta = parseMeta(report.meta_json);
+
+  return (
+    <article>
+      {/* 戻るリンク */}
+      <button
+        type="button"
+        className="text-[var(--accent)] text-[var(--font-size-sm)] border-none bg-transparent font-[inherit] cursor-pointer p-0 mb-[var(--space-4)] hover:underline focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2"
+        onClick={onBack}
+      >
+        ← 一覧に戻る
+      </button>
+
+      {/* ヘッダ情報 */}
+      <div className="p-[var(--space-4)] bg-[var(--bg-elevated)] border border-[var(--border-subtle)] rounded-[var(--radius-lg)] mb-[var(--space-6)]">
+        <div className="flex flex-wrap items-center gap-[var(--space-2)] mb-[var(--space-2)]">
+          <span className="inline-flex items-center px-[var(--space-2)] py-0.5 rounded-full text-[var(--font-size-xs)] font-semibold uppercase tracking-[0.04em] bg-[var(--accent-soft)] text-[var(--accent)]">
+            {KIND_LABELS[report.kind] ?? report.kind}
+          </span>
+          {report.category && (
+            <span className="text-[var(--fg-muted)] text-[var(--font-size-sm)]">
+              {report.category}
+            </span>
+          )}
+          {report.lang && (
+            <span className="text-[var(--fg-muted)] text-[var(--font-size-sm)]">{report.lang}</span>
+          )}
+        </div>
+        <p className="text-[var(--fg-primary)] font-semibold text-[var(--font-size-md)] m-0 mb-[var(--space-1)]">
+          {new Date(report.period_start).toLocaleDateString("ja-JP")} 〜{" "}
+          {new Date(report.period_end).toLocaleDateString("ja-JP")}
+        </p>
+        <p className="text-[var(--fg-muted)] text-[var(--font-size-xs)] m-0">
+          生成: {formatDate(report.generated_at)} · {report.source_skill}
+        </p>
+      </div>
+
+      {/* meta_json カード (dedup_total, by_category, by_feed) */}
+      {meta && (
+        <div className="flex flex-wrap gap-[var(--space-3)] mb-[var(--space-6)]">
+          {meta.dedup_total !== undefined && (
+            <div className="p-[var(--space-3)] bg-[var(--bg-elevated)] border border-[var(--border-subtle)] rounded-[var(--radius-md)] min-w-[120px]">
+              <p className="text-[var(--fg-muted)] text-[var(--font-size-xs)] m-0 mb-[2px]">
+                収集記事 (dedup)
+              </p>
+              <p className="text-[var(--fg-primary)] font-bold text-[var(--font-size-lg)] m-0">
+                {meta.dedup_total}
+              </p>
+            </div>
+          )}
+          {meta.by_category && (
+            <div className="p-[var(--space-3)] bg-[var(--bg-elevated)] border border-[var(--border-subtle)] rounded-[var(--radius-md)]">
+              <p className="text-[var(--fg-muted)] text-[var(--font-size-xs)] m-0 mb-[var(--space-1)]">
+                カテゴリ別
+              </p>
+              <div className="flex flex-wrap gap-[var(--space-2)]">
+                {Object.entries(meta.by_category).map(([cat, count]) => (
+                  <span key={cat} className="text-[var(--font-size-xs)] text-[var(--fg-secondary)]">
+                    {cat}: <strong className="text-[var(--fg-primary)]">{count}</strong>
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* markdown 本文 */}
+      <div className="prose prose-[var(--fg-primary)] max-w-none [&_h1]:text-[var(--font-size-xl)] [&_h1]:font-bold [&_h1]:mb-[var(--space-3)] [&_h1]:text-[var(--fg-primary)] [&_h2]:text-[var(--font-size-lg)] [&_h2]:font-semibold [&_h2]:mb-[var(--space-2)] [&_h2]:mt-[var(--space-6)] [&_h2]:text-[var(--fg-primary)] [&_h3]:text-[var(--font-size-md)] [&_h3]:font-semibold [&_h3]:mb-[var(--space-2)] [&_h3]:mt-[var(--space-4)] [&_h3]:text-[var(--fg-primary)] [&_p]:text-[var(--fg-secondary)] [&_p]:leading-[var(--line-height-relaxed)] [&_p]:mb-[var(--space-3)] [&_a]:text-[var(--accent)] [&_a]:underline [&_ul]:pl-[var(--space-4)] [&_ul]:mb-[var(--space-3)] [&_ol]:pl-[var(--space-4)] [&_ol]:mb-[var(--space-3)] [&_li]:text-[var(--fg-secondary)] [&_li]:mb-[var(--space-1)] [&_code]:bg-[var(--bg-elevated)] [&_code]:px-[var(--space-1)] [&_code]:py-[2px] [&_code]:rounded-[var(--radius-sm)] [&_code]:text-[var(--font-size-sm)] [&_pre]:bg-[var(--bg-elevated)] [&_pre]:p-[var(--space-4)] [&_pre]:rounded-[var(--radius-md)] [&_pre]:overflow-x-auto [&_pre]:mb-[var(--space-3)] [&_blockquote]:border-l-4 [&_blockquote]:border-[var(--border-subtle)] [&_blockquote]:pl-[var(--space-3)] [&_blockquote]:text-[var(--fg-muted)] [&_hr]:border-[var(--border-subtle)] [&_hr]:my-[var(--space-6)] [&_table]:w-full [&_table]:border-collapse [&_th]:border [&_th]:border-[var(--border-subtle)] [&_th]:px-[var(--space-3)] [&_th]:py-[var(--space-2)] [&_th]:bg-[var(--bg-elevated)] [&_th]:text-[var(--fg-primary)] [&_td]:border [&_td]:border-[var(--border-subtle)] [&_td]:px-[var(--space-3)] [&_td]:py-[var(--space-2)] [&_td]:text-[var(--fg-secondary)]">
+        <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+          {report.content}
+        </ReactMarkdown>
+      </div>
+    </article>
+  );
+}

--- a/apps/web/client/components/ReportsList.tsx
+++ b/apps/web/client/components/ReportsList.tsx
@@ -1,0 +1,111 @@
+import { useState } from "react";
+import type { ReportKind } from "../types/api";
+import { useReportsList } from "../hooks/useReports";
+
+const KIND_LABELS: Record<ReportKind, string> = {
+  daily: "日次",
+  weekly: "週次",
+  monthly: "月次",
+};
+
+type KindFilter = ReportKind | undefined;
+
+interface Props {
+  onSelectReport: (id: number) => void;
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString("ja-JP", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function ReportsList({ onSelectReport }: Props) {
+  const [kindFilter, setKindFilter] = useState<KindFilter>(undefined);
+  const { data: reports, loading, error } = useReportsList(kindFilter);
+
+  const chips: Array<{ label: string; value: KindFilter }> = [
+    { label: "すべて", value: undefined },
+    { label: "日次", value: "daily" },
+    { label: "週次", value: "weekly" },
+    { label: "月次", value: "monthly" },
+  ];
+
+  return (
+    <section>
+      <h2 className="text-[var(--font-size-lg)] font-bold mb-[var(--space-4)] text-[var(--fg-primary)]">
+        レポート一覧
+      </h2>
+
+      {/* kind フィルタ chip */}
+      <div className="flex flex-wrap gap-[var(--space-2)] mb-[var(--space-4)]">
+        {chips.map(({ label, value }) => (
+          <button
+            key={label}
+            type="button"
+            className={`inline-flex items-center px-[var(--space-3)] py-[5px] rounded-full text-[var(--font-size-sm)] font-medium border-none font-[inherit] cursor-pointer whitespace-nowrap transition-[background,color] duration-100 focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2${
+              kindFilter === value
+                ? " bg-[var(--accent-soft)] text-[var(--accent)] font-semibold"
+                : " bg-[var(--bg-elevated)] text-[var(--fg-muted)] hover:bg-[var(--bg-overlay)] hover:text-[var(--fg-primary)]"
+            }`}
+            onClick={() => setKindFilter(value)}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {loading && (
+        <p className="text-[var(--fg-muted)] text-[var(--font-size-sm)]">読み込み中...</p>
+      )}
+
+      {error && (
+        <p className="text-[var(--fg-muted)] text-[var(--font-size-sm)]">エラー: {error}</p>
+      )}
+
+      {!loading && !error && reports.length === 0 && (
+        <p className="text-[var(--fg-muted)] text-[var(--font-size-sm)]">
+          レポートがまだありません
+        </p>
+      )}
+
+      {!loading && !error && reports.length > 0 && (
+        <ul className="list-none m-0 p-0 flex flex-col gap-[var(--space-3)]">
+          {reports.map((report) => (
+            <li key={report.id}>
+              <button
+                type="button"
+                className="w-full text-left p-[var(--space-4)] bg-[var(--bg-elevated)] border border-[var(--border-subtle)] rounded-[var(--radius-lg)] transition-[border-color,box-shadow,transform] duration-200 hover:border-[var(--accent)] hover:shadow-[var(--shadow-md)] hover:-translate-y-0.5 cursor-pointer font-[inherit] focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2"
+                onClick={() => onSelectReport(report.id)}
+              >
+                <div className="flex items-center gap-[var(--space-2)] mb-[var(--space-1)]">
+                  <span className="inline-flex items-center px-[var(--space-2)] py-0.5 rounded-full text-[var(--font-size-xs)] font-semibold uppercase tracking-[0.04em] bg-[var(--accent-soft)] text-[var(--accent)]">
+                    {KIND_LABELS[report.kind] ?? report.kind}
+                  </span>
+                  {report.category && (
+                    <span className="text-[var(--fg-muted)] text-[var(--font-size-xs)]">
+                      {report.category}
+                    </span>
+                  )}
+                </div>
+                <p className="text-[var(--fg-primary)] font-medium text-[var(--font-size-md)] m-0 mb-[var(--space-1)]">
+                  {new Date(report.period_start).toLocaleDateString("ja-JP")} 〜{" "}
+                  {new Date(report.period_end).toLocaleDateString("ja-JP")}
+                </p>
+                <p className="text-[var(--fg-muted)] text-[var(--font-size-xs)] m-0">
+                  生成: {formatDate(report.generated_at)} · {report.source_skill}
+                </p>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/apps/web/client/hooks/useReports.ts
+++ b/apps/web/client/hooks/useReports.ts
@@ -1,0 +1,80 @@
+import { useEffect, useState } from "react";
+import type { ReportDetail, ReportListItem, ReportKind } from "../types/api";
+
+interface ListState {
+  data: ReportListItem[];
+  loading: boolean;
+  error: string | null;
+}
+
+interface DetailState {
+  data: ReportDetail | null;
+  loading: boolean;
+  error: string | null;
+}
+
+export function useReportsList(kind?: ReportKind) {
+  const [state, setState] = useState<ListState>({ data: [], loading: true, error: null });
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ data: [], loading: true, error: null });
+
+    const params = new URLSearchParams();
+    if (kind) params.set("kind", kind);
+    params.set("limit", "50");
+
+    void (async () => {
+      try {
+        const res = await fetch(`/api/reports?${params.toString()}`);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const json = (await res.json()) as { reports: ReportListItem[] };
+        if (!cancelled) setState({ data: json.reports, loading: false, error: null });
+      } catch (err) {
+        if (!cancelled)
+          setState({
+            data: [],
+            loading: false,
+            error: err instanceof Error ? err.message : String(err),
+          });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [kind]);
+
+  return state;
+}
+
+export function useReport(id: number) {
+  const [state, setState] = useState<DetailState>({ data: null, loading: true, error: null });
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ data: null, loading: true, error: null });
+
+    void (async () => {
+      try {
+        const res = await fetch(`/api/reports/${id}`);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const json = (await res.json()) as { report: ReportDetail };
+        if (!cancelled) setState({ data: json.report, loading: false, error: null });
+      } catch (err) {
+        if (!cancelled)
+          setState({
+            data: null,
+            loading: false,
+            error: err instanceof Error ? err.message : String(err),
+          });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  return state;
+}

--- a/apps/web/client/lib/routing.ts
+++ b/apps/web/client/lib/routing.ts
@@ -56,9 +56,19 @@ export function readAuthorFromPath(): string | null {
   return m ? decodeURIComponent(m[1]) : null;
 }
 
+/** /reports/:id パスを解析してレポート ID を返す。それ以外は null。*/
+export function readReportIdFromPath(): number | null {
+  const m = window.location.pathname.match(/^\/reports\/(\d+)$/);
+  if (!m) return null;
+  const id = Number(m[1]);
+  return Number.isFinite(id) && id > 0 ? id : null;
+}
+
 export function readViewFromUrl(): AppView {
   if (window.location.pathname === "/stats") return "stats";
   if (window.location.pathname === "/categories") return "categories";
+  if (window.location.pathname === "/reports") return "reports";
+  if (readReportIdFromPath() !== null) return "report";
   if (readFeedDetailFromPath() !== null) return "feed";
   if (readAuthorFromPath() !== null) return "author";
   return "articles";

--- a/apps/web/client/types/api.ts
+++ b/apps/web/client/types/api.ts
@@ -76,3 +76,33 @@ export interface CategorySummary {
 export interface CategoriesResponse {
   categories: CategorySummary[];
 }
+
+// ---- /api/reports ----
+
+export type ReportKind = "daily" | "weekly" | "monthly";
+
+/** /api/reports の一覧アイテム (content を含まない) */
+export interface ReportListItem {
+  id: number;
+  kind: ReportKind;
+  period_start: string;
+  period_end: string;
+  category: string | null;
+  lang: string | null;
+  source_skill: string;
+  generated_at: string;
+}
+
+/** /api/reports/:id の詳細 (content + meta_json を含む) */
+export interface ReportDetail extends ReportListItem {
+  content: string;
+  meta_json: string | null;
+}
+
+export interface ReportListResponse {
+  reports: ReportListItem[];
+}
+
+export interface ReportDetailResponse {
+  report: ReportDetail;
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,7 +23,9 @@
     "fast-xml-parser": "^5.7.2",
     "hono": "^4.12.15",
     "react": "^19.2.5",
-    "react-dom": "^19.2.5"
+    "react-dom": "^19.2.5",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.34.0",

--- a/apps/web/tests/client/ReportDetail.test.tsx
+++ b/apps/web/tests/client/ReportDetail.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import type { ReportDetail } from "../../client/types/api";
+
+function makeDetail(overrides: Partial<ReportDetail> = {}): ReportDetail {
+  return {
+    id: 1,
+    kind: "daily",
+    period_start: "2026-04-28T00:00:00.000Z",
+    period_end: "2026-04-29T00:00:00.000Z",
+    category: null,
+    lang: null,
+    source_skill: "tech-news-digest",
+    generated_at: "2026-04-29T00:01:00.000Z",
+    content: "# Hello\n\nWorld content.",
+    meta_json: null,
+    ...overrides,
+  };
+}
+
+function makeDetailResponse(report: ReportDetail) {
+  return {
+    ok: true,
+    json: () => Promise.resolve({ report }),
+  };
+}
+
+const { ReportDetail: ReportDetailComponent } =
+  await import("../../client/components/ReportDetail");
+
+describe("ReportDetail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("loading 中に '読み込み中...' が表示される", () => {
+    vi.stubGlobal("fetch", vi.fn().mockReturnValue(new Promise(() => {})));
+
+    render(<ReportDetailComponent id={1} onBack={() => {}} />);
+    expect(screen.getByText("読み込み中...")).toBeTruthy();
+  });
+
+  it("markdown の # が h1 としてレンダリングされる", async () => {
+    const detail = makeDetail({ content: "# Heading One\n\nSome text." });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeDetailResponse(detail)));
+
+    render(<ReportDetailComponent id={1} onBack={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("読み込み中...")).toBeNull();
+    });
+
+    const h1 = screen.getByRole("heading", { level: 1 });
+    expect(h1.textContent).toBe("Heading One");
+  });
+
+  it("onBack が '← 一覧に戻る' クリックで呼ばれる", async () => {
+    const detail = makeDetail();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeDetailResponse(detail)));
+
+    const onBack = vi.fn<() => void>();
+    render(<ReportDetailComponent id={1} onBack={onBack} />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("読み込み中...")).toBeNull();
+    });
+
+    await userEvent.click(screen.getByText("← 一覧に戻る"));
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("meta_json に dedup_total があれば表示される", async () => {
+    const detail = makeDetail({
+      meta_json: JSON.stringify({
+        dedup_total: 99,
+        by_category: { bigtech: 50, ai: 49 },
+      }),
+    });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeDetailResponse(detail)));
+
+    render(<ReportDetailComponent id={1} onBack={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("読み込み中...")).toBeNull();
+    });
+
+    expect(screen.getByText("99")).toBeTruthy();
+  });
+
+  it("エラー時に '← 一覧に戻る' が表示される", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 404 }));
+
+    render(<ReportDetailComponent id={999} onBack={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("読み込み中...")).toBeNull();
+    });
+
+    expect(screen.getByText("← 一覧に戻る")).toBeTruthy();
+  });
+});

--- a/apps/web/tests/client/ReportsList.test.tsx
+++ b/apps/web/tests/client/ReportsList.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import type { ReportListItem } from "../../client/types/api";
+
+function makeReport(id: number, kind: "daily" | "weekly" | "monthly" = "daily"): ReportListItem {
+  return {
+    id,
+    kind,
+    period_start: "2026-04-28T00:00:00.000Z",
+    period_end: "2026-04-29T00:00:00.000Z",
+    category: null,
+    lang: null,
+    source_skill: "tech-news-digest",
+    generated_at: "2026-04-29T00:01:00.000Z",
+  };
+}
+
+function makeListResponse(reports: ReportListItem[]) {
+  return {
+    ok: true,
+    json: () => Promise.resolve({ reports }),
+  };
+}
+
+const { ReportsList } = await import("../../client/components/ReportsList");
+
+describe("ReportsList", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("loading 中に '読み込み中...' が表示される", async () => {
+    // resolve しない fetch で loading 状態を保持する
+    vi.stubGlobal("fetch", vi.fn().mockReturnValue(new Promise(() => {})));
+
+    render(<ReportsList onSelectReport={() => {}} />);
+    expect(screen.getByText("読み込み中...")).toBeTruthy();
+  });
+
+  it("レポートが返されたとき一覧が表示される", async () => {
+    const reports = [makeReport(1, "daily"), makeReport(2, "weekly")];
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeListResponse(reports)));
+
+    render(<ReportsList onSelectReport={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("読み込み中...")).toBeNull();
+    });
+
+    // 日次・週次ラベルが表示される
+    expect(screen.getAllByText("日次").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("週次").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("レポートが 0 件のとき '...ありません' が表示される", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeListResponse([])));
+
+    render(<ReportsList onSelectReport={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("レポートがまだありません")).toBeTruthy();
+    });
+  });
+
+  it("レポート行クリックで onSelectReport が呼ばれる", async () => {
+    const reports = [makeReport(42, "daily")];
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeListResponse(reports)));
+
+    const onSelectReport = vi.fn<(id: number) => void>();
+    render(<ReportsList onSelectReport={onSelectReport} />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("読み込み中...")).toBeNull();
+    });
+
+    // 期間テキストが含まれるボタンをクリック
+    const buttons = screen.getAllByRole("button");
+    // chip ボタン (all/daily/weekly/monthly) の後にリストアイテムボタンが来る
+    const reportButton = buttons.find((b) => b.textContent?.includes("2026"));
+    expect(reportButton).toBeTruthy();
+    if (reportButton) {
+      await userEvent.click(reportButton);
+      expect(onSelectReport).toHaveBeenCalledWith(42);
+    }
+  });
+
+  it("kind フィルタ chip をクリックすると fetch URL が変わる", async () => {
+    const mockFetch = vi
+      .fn<() => Promise<Response>>()
+      .mockResolvedValue(makeListResponse([]) as unknown as Response);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const user = userEvent.setup();
+    render(<ReportsList onSelectReport={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("読み込み中...")).toBeNull();
+    });
+
+    // 初回 fetch URL を確認
+    const calls = mockFetch.mock.calls as unknown as Array<[string]>;
+    expect(calls[0]?.[0]).not.toContain("kind=");
+
+    // 週次 chip をクリック
+    await user.click(screen.getByRole("button", { name: "週次" }));
+
+    await waitFor(() => {
+      expect(mockFetch.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+
+    expect((mockFetch.mock.calls as unknown as Array<[string]>)[1]?.[0]).toContain("kind=weekly");
+  });
+});

--- a/apps/web/tests/worker/api/reports-public.test.ts
+++ b/apps/web/tests/worker/api/reports-public.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vite-plus/test";
+import { SELF } from "cloudflare:test";
+import type { AdminReportDetailResponse, AdminReportListResponse } from "../../../worker/api/types";
+
+const ADMIN_AUTH = { authorization: "Bearer test-admin-token" };
+const ADMIN_JSON = { ...ADMIN_AUTH, "content-type": "application/json" };
+
+interface ReportPayload {
+  kind: "daily" | "weekly" | "monthly";
+  period_start: string;
+  period_end: string;
+  category: string | null;
+  lang: string | null;
+  content: string;
+  source_skill: string;
+  generated_at: string;
+}
+
+function buildPayload(overrides: Partial<ReportPayload> = {}): ReportPayload {
+  return {
+    kind: "daily",
+    period_start: "2026-04-28T00:00:00.000Z",
+    period_end: "2026-04-29T00:00:00.000Z",
+    category: null,
+    lang: null,
+    content: "# Daily Report\n\nTest content.",
+    source_skill: "tech-news-digest",
+    generated_at: "2026-04-29T00:01:00.000Z",
+    ...overrides,
+  };
+}
+
+async function insertReport(payload: Partial<ReportPayload> = {}) {
+  const res = await SELF.fetch("https://example.com/api/admin/reports", {
+    method: "POST",
+    headers: ADMIN_JSON,
+    body: JSON.stringify(buildPayload(payload)),
+  });
+  const body = (await res.json()) as { id: number };
+  return body.id;
+}
+
+describe("GET /api/reports (公開一覧)", () => {
+  it("200: 認証なしでアクセスできる", async () => {
+    const res = await SELF.fetch("https://example.com/api/reports");
+    expect(res.status).toBe(200);
+  });
+
+  it("200: 挿入したレポートが含まれる", async () => {
+    await insertReport({ content: "public list test" });
+
+    const res = await SELF.fetch("https://example.com/api/reports");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as AdminReportListResponse;
+    expect(Array.isArray(body.reports)).toBe(true);
+    expect(body.reports.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("200: kind フィルタが効く", async () => {
+    await insertReport({
+      kind: "weekly",
+      period_start: "2026-04-21T00:00:00.000Z",
+      period_end: "2026-04-28T00:00:00.000Z",
+    });
+
+    const res = await SELF.fetch("https://example.com/api/reports?kind=weekly");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as AdminReportListResponse;
+    expect(body.reports.every((r) => r.kind === "weekly")).toBe(true);
+  });
+
+  it("400: 無効な kind を拒否する", async () => {
+    const res = await SELF.fetch("https://example.com/api/reports?kind=invalid");
+    expect(res.status).toBe(400);
+  });
+
+  it("200: limit が clamp される (limit=0 → 1 件)", async () => {
+    await insertReport();
+
+    const res = await SELF.fetch("https://example.com/api/reports?limit=0");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as AdminReportListResponse;
+    // limit=0 は 1 に clamp されるため最大 1 件
+    expect(body.reports.length).toBeLessThanOrEqual(1);
+  });
+
+  it("CORS ヘッダが付く", async () => {
+    const allowedOrigin = "https://tech-news-bot.rikeda71.workers.dev";
+    const res = await SELF.fetch("https://example.com/api/reports", {
+      headers: { origin: allowedOrigin },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("access-control-allow-origin")).toBe(allowedOrigin);
+  });
+});
+
+describe("GET /api/reports/:id (公開詳細)", () => {
+  it("200: 認証なしでアクセスできる", async () => {
+    const id = await insertReport({ content: "detail content" });
+
+    const res = await SELF.fetch(`https://example.com/api/reports/${id}`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as AdminReportDetailResponse;
+    expect(body.report.content).toBe("detail content");
+  });
+
+  it("404: 存在しない id", async () => {
+    const res = await SELF.fetch("https://example.com/api/reports/999999");
+    expect(res.status).toBe(404);
+  });
+
+  it("400: 無効な id (文字列)", async () => {
+    const res = await SELF.fetch("https://example.com/api/reports/abc");
+    expect(res.status).toBe(400);
+  });
+
+  it("CORS ヘッダが付く", async () => {
+    const allowedOrigin = "https://tech-news-bot.rikeda71.workers.dev";
+    const id = await insertReport();
+
+    const res = await SELF.fetch(`https://example.com/api/reports/${id}`, {
+      headers: { origin: allowedOrigin },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("access-control-allow-origin")).toBe(allowedOrigin);
+  });
+});

--- a/apps/web/worker/api/reports-public.ts
+++ b/apps/web/worker/api/reports-public.ts
@@ -1,0 +1,40 @@
+import { Hono } from "hono";
+import type { Env } from "../types";
+import { getReport, listReports } from "../db/reports";
+import type { ReportKind } from "../db/reports";
+import type { AdminReportDetailResponse, AdminReportListResponse } from "./types";
+
+const app = new Hono<{ Bindings: Env }>();
+
+const VALID_KINDS = new Set<ReportKind>(["daily", "weekly", "monthly"]);
+
+app.get("/", async (c) => {
+  const kindParam = c.req.query("kind");
+  let kind: ReportKind | undefined;
+  if (kindParam !== undefined) {
+    if (!VALID_KINDS.has(kindParam as ReportKind)) {
+      return c.json({ error: "kind must be one of: daily | weekly | monthly" }, 400);
+    }
+    kind = kindParam as ReportKind;
+  }
+
+  const limitParam = Number(c.req.query("limit") ?? "20");
+  const limit = Number.isFinite(limitParam) ? Math.min(Math.max(limitParam, 1), 100) : 20;
+
+  const reports = await listReports(c.env.DB, { kind, limit });
+  return c.json<AdminReportListResponse>({ reports });
+});
+
+app.get("/:id", async (c) => {
+  const idParam = Number(c.req.param("id"));
+  if (!Number.isFinite(idParam) || idParam <= 0) {
+    return c.json({ error: "invalid id" }, 400);
+  }
+  const detail = await getReport(c.env.DB, idParam);
+  if (!detail) {
+    return c.json({ error: "report not found" }, 404);
+  }
+  return c.json<AdminReportDetailResponse>({ report: detail });
+});
+
+export default app;

--- a/apps/web/worker/api/router.ts
+++ b/apps/web/worker/api/router.ts
@@ -9,6 +9,7 @@ import health from "./health";
 import stats from "./stats";
 import admin from "./admin";
 import reports from "./reports";
+import publicReports from "./reports-public";
 import docs from "./docs";
 import { catalogHandler } from "./catalog";
 
@@ -26,7 +27,14 @@ function allowedOriginsCors(c: Context<{ Bindings: Env }>, next: Next) {
   return cors({ origin: origins })(c, next);
 }
 
-const PUBLIC_PATHS = ["/articles/*", "/categories/*", "/feeds/*", "/stats/*", "/health/*"] as const;
+const PUBLIC_PATHS = [
+  "/articles/*",
+  "/categories/*",
+  "/feeds/*",
+  "/stats/*",
+  "/health/*",
+  "/reports/*",
+] as const;
 for (const path of PUBLIC_PATHS) {
   api.use(path, allowedOriginsCors);
 }
@@ -43,6 +51,8 @@ api.route("/stats", stats);
 // Hono は path matching が前方一致でなく完全一致なので衝突しない。
 api.route("/admin/reports", reports);
 api.route("/admin", admin);
+// 公開 reports endpoint: 認証不要で一覧・詳細を提供する
+api.route("/reports", publicReports);
 api.route("/", docs);
 
 export default api;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,12 @@ importers:
       react-dom:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.14)(react@19.2.5)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.34.0
@@ -1250,11 +1256,26 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@24.12.2':
     resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
@@ -1267,11 +1288,20 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
   '@vitejs/plugin-react@6.0.1':
     resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
@@ -1459,11 +1489,32 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -1475,6 +1526,18 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -1482,6 +1545,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
@@ -1510,8 +1576,18 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fast-xml-builder@1.1.5:
     resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
@@ -1546,9 +1622,37 @@ packages:
     resolution: {integrity: sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==}
     engines: {node: '>=20.0.0'}
 
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   hono@4.12.15:
     resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
     engines: {node: '>=16.9.0'}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
@@ -1639,12 +1743,147 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   miniflare@4.20260426.0:
     resolution: {integrity: sha512-KM+v76d04qT+NsPfVKVQEgnnuLNE3uzCCl2QKMTJ5OXor5JbBm1vpkQwQ+l7o5ELCrZ74RnyKhJKLiJyUA39Tw==}
@@ -1654,6 +1893,9 @@ packages:
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -1681,6 +1923,9 @@ packages:
     peerDependenciesMeta:
       oxlint-tsgolint:
         optional: true
+
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
   path-expression-matcher@1.5.0:
     resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
@@ -1729,6 +1974,9 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
   react-dom@19.2.5:
     resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
     peerDependencies:
@@ -1737,9 +1985,27 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
+
   react@19.2.5:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   rollup@4.60.2:
     resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
@@ -1766,11 +2032,23 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   strnum@2.2.3:
     resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
+
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
@@ -1810,6 +2088,12 @@ packages:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -1827,6 +2111,30 @@ packages:
 
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
+
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite-plus@0.1.19:
     resolution: {integrity: sha512-QWuTqkO/a8Q7I3hHnYdvwlJa7mcc6hgh99/8CHoRb27pgo+z1ux+NGYYCZPJHKVtatAtVRaQQvy4cEQBHyB87A==}
@@ -1924,6 +2232,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -2631,9 +2942,27 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/deep-eql@4.0.2': {}
 
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.8
+
   '@types/estree@1.0.8': {}
+
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@24.12.2':
     dependencies:
@@ -2647,11 +2976,17 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
+
   '@types/whatwg-mimetype@3.0.2': {}
 
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 24.12.2
+
+  '@ungap/structured-clone@1.3.0': {}
 
   '@vitejs/plugin-react@6.0.1(@voidzero-dev/vite-plus-core@0.1.19(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(typescript@6.0.3))':
     dependencies:
@@ -2769,9 +3104,23 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  bail@2.0.2: {}
+
   blake3-wasm@2.1.5: {}
 
+  ccount@2.0.1: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
+
   cjs-module-lexer@1.4.3: {}
+
+  comma-separated-tokens@2.0.3: {}
 
   convert-source-map@2.0.0: {}
 
@@ -2779,9 +3128,21 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   dom-accessibility-api@0.5.16: {}
 
@@ -2854,7 +3215,13 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
 
+  escape-string-regexp@5.0.0: {}
+
+  estree-util-is-identifier-name@3.0.0: {}
+
   estree-walker@2.0.2: {}
+
+  extend@3.0.2: {}
 
   fast-xml-builder@1.1.5:
     dependencies:
@@ -2891,7 +3258,48 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   hono@4.12.15: {}
+
+  html-url-attributes@3.0.1: {}
+
+  inline-style-parser@0.2.7: {}
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
+  is-decimal@2.0.1: {}
+
+  is-hexadecimal@2.0.1: {}
+
+  is-plain-obj@4.1.0: {}
 
   jiti@2.6.1: {}
 
@@ -2952,11 +3360,359 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  longest-streak@3.1.0: {}
+
   lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  markdown-table@3.0.4: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   miniflare@4.20260426.0:
     dependencies:
@@ -2971,6 +3727,8 @@ snapshots:
       - utf-8-validate
 
   mrmime@2.0.1: {}
+
+  ms@2.1.3: {}
 
   nanoid@3.3.11: {}
 
@@ -3032,6 +3790,16 @@ snapshots:
       '@oxlint/binding-win32-x64-msvc': 1.60.0
       oxlint-tsgolint: 0.21.1
 
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   path-expression-matcher@1.5.0: {}
 
   path-to-regexp@6.3.0: {}
@@ -3070,6 +3838,8 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  property-information@7.1.0: {}
+
   react-dom@19.2.5(react@19.2.5):
     dependencies:
       react: 19.2.5
@@ -3077,7 +3847,59 @@ snapshots:
 
   react-is@17.0.2: {}
 
+  react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 19.2.14
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 19.2.5
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   react@19.2.5: {}
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   rollup@4.60.2:
     dependencies:
@@ -3153,9 +3975,24 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  space-separated-tokens@2.0.2: {}
+
   std-env@4.1.0: {}
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   strnum@2.2.3: {}
+
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
 
   supports-color@10.2.2: {}
 
@@ -3180,6 +4017,10 @@ snapshots:
 
   totalist@3.0.1: {}
 
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
+
   tslib@2.8.1:
     optional: true
 
@@ -3192,6 +4033,49 @@ snapshots:
   unenv@2.0.0-rc.24:
     dependencies:
       pathe: 2.0.3
+
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite-plus@0.1.19(@types/node@24.12.2)(esbuild@0.27.7)(happy-dom@20.9.0)(jiti@2.6.1)(typescript@6.0.3)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)):
     dependencies:
@@ -3299,3 +4183,5 @@ snapshots:
       youch-core: 0.3.3
 
   zod@3.25.76: {}
+
+  zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary

- 公開 GET endpoint `/api/reports` / `/api/reports/:id` を新設 (認証不要、CORS 付き)
- SPA に `/reports` 一覧ページと `/reports/:id` 詳細ページを追加
- markdown は `react-markdown` + `remark-gfm` でレンダリング、リンクは新タブ
- Header ナビに「レポート」タブを追加
- ブラウザの前後移動 (popstate) に対応

Closes #299

## 変更ファイル

**新規**
- `apps/web/worker/api/reports-public.ts` — 公開 endpoint
- `apps/web/client/hooks/useReports.ts` — データ取得フック
- `apps/web/client/components/ReportsList.tsx` — 一覧コンポーネント
- `apps/web/client/components/ReportDetail.tsx` — 詳細コンポーネント (markdown レンダリング)
- `apps/web/tests/worker/api/reports-public.test.ts` — worker テスト (10 ケース)
- `apps/web/tests/client/ReportsList.test.tsx` — クライアントテスト (5 ケース)
- `apps/web/tests/client/ReportDetail.test.tsx` — クライアントテスト (5 ケース)

**修正**
- `apps/web/worker/api/router.ts` — `/reports/*` CORS 追加、`publicReports` ルート登録
- `apps/web/client/App.tsx` — reports/report ビューのルーティング追加
- `apps/web/client/components/Header.tsx` — `AppView` 型と `NAV_TABS` に reports 追加
- `apps/web/client/lib/routing.ts` — `readReportIdFromPath()` と `readViewFromUrl()` 拡張
- `apps/web/client/types/api.ts` — `ReportListItem` / `ReportDetail` 型追加

## Test plan

- [x] `pnpm exec vp test run` — 543 tests passed
- [x] `pnpm -r typecheck` — エラーなし
- [x] `pnpm build` — ビルド成功
- [x] `pnpm exec vp fmt --write && vp check` — lint エラーなし
- [ ] CI 通過確認 (PR 作成後に監視)