### PR TITLE
feat(reports): notify Slack on POST /api/admin/reports

### DIFF
--- a/apps/web/tests/worker/api/reports.test.ts
+++ b/apps/web/tests/worker/api/reports.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vite-plus/test";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { SELF } from "cloudflare:test";
 import type {
   AdminReportDetailResponse,
@@ -36,6 +36,10 @@ function buildPayload(overrides: Partial<ReportPayload> = {}): ReportPayload {
     ...overrides,
   };
 }
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("POST /api/admin/reports", () => {
   it("401: rejects unauthenticated request", async () => {
@@ -251,5 +255,32 @@ describe("GET /api/admin/reports/:id", () => {
     const body = (await res.json()) as AdminReportDetailResponse;
     expect(body.report.content).toBe("with meta");
     expect(body.report.meta_json).toContain("dedup_total");
+  });
+});
+
+describe("POST /api/admin/reports — Slack notification", () => {
+  it("200: POST succeeds (and does not throw) when SLACK_WEBHOOK_URL is not set", async () => {
+    // テスト環境では SLACK_WEBHOOK_URL が未定義のため、no-op になり POST 自体は 200
+    const res = await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(buildPayload()),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as AdminReportSaveResponse;
+    expect(body.ok).toBe(true);
+  });
+
+  it("200: POST succeeds even when Slack webhook returns non-2xx (Slack failure does not affect D1 save)", async () => {
+    // fetch を spy して Slack webhook 呼び出しが 500 を返しても POST 自体は 200
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(null, { status: 500 }));
+    const res = await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(buildPayload({ period_start: "2026-04-27T00:00:00.000Z" })),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as AdminReportSaveResponse;
+    expect(body.ok).toBe(true);
   });
 });

--- a/apps/web/tests/worker/notify/slack-report.test.ts
+++ b/apps/web/tests/worker/notify/slack-report.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import {
+  buildPayload,
+  postReportNotification,
+  type ReportNotifyParams,
+} from "../../../worker/notify/slack-report";
+
+const WEBHOOK_URL = "https://hooks.slack.com/services/test/webhook";
+
+function makeParams(overrides: Partial<ReportNotifyParams> = {}): ReportNotifyParams {
+  return {
+    kind: "daily",
+    period_start: "2026-04-28T00:00:00.000Z",
+    period_end: "2026-04-29T00:00:00.000Z",
+    category: null,
+    lang: null,
+    source_skill: "tech-news-digest",
+    generated_at: "2026-04-29T00:01:00.000Z",
+    content_bytes: 1024,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("buildPayload", () => {
+  it("header contains kind and period_end date", () => {
+    const { blocks } = buildPayload(makeParams());
+    const header = (blocks as { type: string; text: { text: string } }[]).find(
+      (b) => b.type === "header",
+    );
+    expect(header?.text.text).toContain("daily");
+    expect(header?.text.text).toContain("2026-04-29");
+  });
+
+  it("text field contains kind and content_bytes as fallback", () => {
+    const { text } = buildPayload(makeParams({ content_bytes: 2048 }));
+    expect(text).toContain("daily");
+    expect(text).toContain("2048");
+  });
+
+  it("shows '全体' when category is null", () => {
+    const { blocks } = buildPayload(makeParams({ category: null }));
+    const sections = (blocks as { type: string; text?: { text: string } }[]).filter(
+      (b) => b.type === "section",
+    );
+    expect(sections.some((s) => s.text?.text.includes("全体"))).toBe(true);
+  });
+
+  it("shows '全言語' when lang is null", () => {
+    const { blocks } = buildPayload(makeParams({ lang: null }));
+    const sections = (blocks as { type: string; text?: { text: string } }[]).filter(
+      (b) => b.type === "section",
+    );
+    expect(sections.some((s) => s.text?.text.includes("全言語"))).toBe(true);
+  });
+
+  it("shows category name when category is specified", () => {
+    const { blocks } = buildPayload(makeParams({ category: "bigtech" }));
+    const sections = (blocks as { type: string; text?: { text: string } }[]).filter(
+      (b) => b.type === "section",
+    );
+    expect(sections.some((s) => s.text?.text.includes("bigtech"))).toBe(true);
+  });
+
+  it("does not include viewer_url block when viewer_url is undefined", () => {
+    const { blocks } = buildPayload(makeParams({ viewer_url: undefined }));
+    const sections = (blocks as { type: string; text?: { text: string } }[]).filter(
+      (b) => b.type === "section",
+    );
+    // viewer_url がない場合は「レポートを開く」リンクが含まれない
+    expect(sections.every((s) => !s.text?.text.includes("レポートを開く"))).toBe(true);
+  });
+
+  it("includes viewer_url link when viewer_url is provided", () => {
+    const url = "https://example.com/reports/1";
+    const { blocks } = buildPayload(makeParams({ viewer_url: url }));
+    const sections = (blocks as { type: string; text?: { text: string } }[]).filter(
+      (b) => b.type === "section",
+    );
+    expect(sections.some((s) => s.text?.text.includes(url))).toBe(true);
+    expect(sections.some((s) => s.text?.text.includes("レポートを開く"))).toBe(true);
+  });
+
+  it("shows source_skill in section", () => {
+    const { blocks } = buildPayload(makeParams({ source_skill: "tech-news-weekly" }));
+    const sections = (blocks as { type: string; text?: { text: string } }[]).filter(
+      (b) => b.type === "section",
+    );
+    expect(sections.some((s) => s.text?.text.includes("tech-news-weekly"))).toBe(true);
+  });
+
+  it("shows generated_at in section", () => {
+    const { blocks } = buildPayload(makeParams({ generated_at: "2026-04-29T00:01:00.000Z" }));
+    const sections = (blocks as { type: string; text?: { text: string } }[]).filter(
+      (b) => b.type === "section",
+    );
+    expect(sections.some((s) => s.text?.text.includes("2026-04-29T00:01:00.000Z"))).toBe(true);
+  });
+});
+
+describe("postReportNotification", () => {
+  it("returns posted=false and does not call fetch when webhookUrl is undefined", async () => {
+    const spy = vi.spyOn(globalThis, "fetch");
+    const result = await postReportNotification(undefined, makeParams());
+    expect(result.posted).toBe(false);
+    expect(result.error).toBeUndefined();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("returns posted=true when webhook returns 200", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(null, { status: 200 }));
+    const result = await postReportNotification(WEBHOOK_URL, makeParams());
+    expect(result.posted).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("calls fetch with POST method and correct URL", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+    await postReportNotification(WEBHOOK_URL, makeParams());
+    expect(spy).toHaveBeenCalledTimes(1);
+    const [url, init] = spy.mock.calls[0];
+    expect(url).toBe(WEBHOOK_URL);
+    expect(init?.method).toBe("POST");
+  });
+
+  it("returns posted=false with error when webhook returns non-2xx (500)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(null, { status: 500 }));
+    const result = await postReportNotification(WEBHOOK_URL, makeParams());
+    expect(result.posted).toBe(false);
+    expect(result.error).toBe("status 500");
+  });
+
+  it("returns posted=false with error when fetch throws (AbortError timeout)", async () => {
+    const abortError = new DOMException("The operation was aborted.", "AbortError");
+    vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(abortError);
+    const result = await postReportNotification(WEBHOOK_URL, makeParams());
+    expect(result.posted).toBe(false);
+    expect(result.error).toBe("The operation was aborted.");
+  });
+
+  it("returns posted=false with error when fetch throws generic error", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(new TypeError("Failed to fetch"));
+    const result = await postReportNotification(WEBHOOK_URL, makeParams());
+    expect(result.posted).toBe(false);
+    expect(result.error).toBe("Failed to fetch");
+  });
+
+  it("payload body contains kind and content_bytes", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+    await postReportNotification(WEBHOOK_URL, makeParams({ kind: "weekly", content_bytes: 512 }));
+    const body = JSON.parse(spy.mock.calls[0][1]?.body as string) as {
+      text: string;
+      blocks: unknown[];
+    };
+    expect(body.text).toContain("weekly");
+    expect(body.text).toContain("512");
+    expect(Array.isArray(body.blocks)).toBe(true);
+  });
+});

--- a/apps/web/worker/api/reports.ts
+++ b/apps/web/worker/api/reports.ts
@@ -3,6 +3,7 @@ import type { Context } from "hono";
 import type { Env } from "../types";
 import { getReport, listReports, upsertReport } from "../db/reports";
 import type { ReportInput, ReportKind } from "../db/reports";
+import { postReportNotification } from "../notify/slack-report";
 import type {
   AdminReportDetailResponse,
   AdminReportListResponse,
@@ -163,6 +164,21 @@ app.post("/", async (c) => {
   }
 
   const { id } = await upsertReport(c.env.DB, validated.input);
+
+  // Slack 通知: waitUntil でレスポンスをブロックせずに投げる。失敗しても D1 への保存は成功済みなので無視。
+  const notifyPromise = postReportNotification(c.env.SLACK_WEBHOOK_URL, {
+    kind: validated.input.kind,
+    period_start: validated.input.period_start,
+    period_end: validated.input.period_end,
+    category: validated.input.category,
+    lang: validated.input.lang,
+    source_skill: validated.input.source_skill,
+    generated_at: validated.input.generated_at,
+    content_bytes: validated.input.content.length,
+    viewer_url: undefined,
+  });
+  c.executionCtx?.waitUntil(notifyPromise);
+
   return c.json<AdminReportSaveResponse>({ ok: true, id });
 });
 

--- a/apps/web/worker/notify/slack-report.ts
+++ b/apps/web/worker/notify/slack-report.ts
@@ -1,0 +1,109 @@
+import type { ReportKind } from "../db/reports";
+
+export interface ReportNotifyParams {
+  kind: ReportKind;
+  period_start: string;
+  period_end: string;
+  category: string | null;
+  lang: string | null;
+  source_skill: string;
+  generated_at: string;
+  content_bytes: number;
+  viewer_url?: string;
+}
+
+export interface ReportNotifyResult {
+  posted: boolean;
+  error?: string;
+}
+
+/** Slack blocks payload を組み立てる */
+export function buildPayload(params: ReportNotifyParams): { text: string; blocks: unknown[] } {
+  const {
+    kind,
+    period_end,
+    category,
+    lang,
+    source_skill,
+    generated_at,
+    content_bytes,
+    viewer_url,
+  } = params;
+
+  const dateLabel = period_end.slice(0, 10);
+  const categoryLabel = category ?? "全体";
+  const langLabel = lang ?? "全言語";
+
+  const headerText = `📝 Report Saved — ${kind} ${dateLabel}`;
+  const summaryText = `*${source_skill}* — category=${categoryLabel} / lang=${langLabel} / ${content_bytes} bytes`;
+  const generatedText = `生成日時 ${generated_at}`;
+  const fallbackText = `${headerText} (${source_skill} / ${content_bytes} bytes)`;
+
+  const blocks: unknown[] = [
+    {
+      type: "header",
+      text: { type: "plain_text", text: headerText },
+    },
+    {
+      type: "section",
+      text: { type: "mrkdwn", text: summaryText },
+    },
+    {
+      type: "section",
+      text: { type: "mrkdwn", text: generatedText },
+    },
+  ];
+
+  if (viewer_url) {
+    blocks.push({
+      type: "section",
+      text: { type: "mrkdwn", text: `<${viewer_url}|レポートを開く>` },
+    });
+  }
+
+  return {
+    text: fallbackText,
+    blocks,
+  };
+}
+
+/**
+ * Slack incoming webhook にレポート保存通知を投稿する。
+ * webhookUrl が未設定なら no-op。fetch 失敗 / non-2xx は posted=false で返す (throw しない)。
+ * Discord は blocks を無視して text フィールドをメッセージとして表示する。
+ */
+export async function postReportNotification(
+  webhookUrl: string | undefined,
+  params: ReportNotifyParams,
+): Promise<ReportNotifyResult> {
+  if (!webhookUrl) {
+    console.log("[slack-report] SLACK_WEBHOOK_URL not set – skipping report notification");
+    return { posted: false };
+  }
+
+  const payload = buildPayload(params);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 5000);
+
+  try {
+    const res = await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      const error = `status ${res.status}`;
+      console.error(`[slack-report] webhook returned non-2xx: ${res.status} ${res.statusText}`);
+      return { posted: false, error };
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`[slack-report] failed to post: ${message}`);
+    return { posted: false, error: message };
+  } finally {
+    clearTimeout(timer);
+  }
+
+  return { posted: true };
+}

--- a/docs/reports-pipeline.md
+++ b/docs/reports-pipeline.md
@@ -230,6 +230,24 @@ UNIQUE index が `(kind, period, category)` で張られているため、catego
 
 ---
 
+## Slack 通知
+
+`POST /api/admin/reports` で upsert が成功すると、`SLACK_WEBHOOK_URL` に設定した incoming webhook へ通知が飛ぶ。
+通知には保存されたレポートの kind / period / category / lang / source_skill / content サイズが含まれる。
+
+- リクエスト遅延を避けるため `c.executionCtx.waitUntil(...)` で非同期送信する
+- Slack 投稿が失敗 (non-2xx / timeout 5s) しても POST 自体の応答は 200 のまま (D1 への保存は成功済み)
+- `SLACK_WEBHOOK_URL` が未設定の場合は no-op (通知なし)
+
+### 設定方法
+
+```bash
+wrangler secret put SLACK_WEBHOOK_URL
+# プロンプトに Slack incoming webhook URL を入力
+```
+
+---
+
 ## 関連ファイル
 
 - `migrations/0010_reports.sql` — テーブル / index 定義


### PR DESCRIPTION
Closes #298

## Summary

- worker/notify/slack-report.ts を新設し buildPayload / postReportNotification を実装。Slack Block Kit 形式でレポート通知を構成する
- POST /api/admin/reports ハンドラから c.executionCtx?.waitUntil 経由で非同期に Slack 通知を送信。Slack 失敗が D1 保存の成否に影響しない設計
- slack-report.test.ts (unit) と reports.test.ts (integration) に Slack 通知関連のテストケースを追加

## Test plan

- [x] vp check pass (lint/fmt/typecheck)
- [x] vp test run pass (551 tests)
- [ ] merge 後に SLACK_WEBHOOK_URL secret を登録し、POST /api/admin/reports を実行して Slack チャンネルへの投稿を確認する