### PR TITLE
feat(reports): multi-category daily + AI for weekly/monthly + rich Slack post

### DIFF
--- a/.claude/skills/tech-news-digest/SKILL.md
+++ b/.claude/skills/tech-news-digest/SKILL.md
@@ -53,10 +53,39 @@ D1 (`articles` テーブル) から期間指定で記事メタデータを取得
 実行例:
 
 ```sh
+# 単一カテゴリ
 node tools/d1-client/recent.mjs --since=today --target=remote
 node tools/d1-client/recent.mjs --since=week --category=ai --target=remote
 node tools/d1-client/recent.mjs --since=week --category=jp --target=remote
 ```
+
+**複数カテゴリを対象にする場合 (例: bigtech + ai + jp)**:
+
+`recent.mjs` はカンマ区切り複数指定に非対応のため、カテゴリごとに呼んで URL で de-dup する:
+
+```sh
+# カテゴリごとに取得
+node tools/d1-client/recent.mjs --since=today --category=bigtech --target=remote > /tmp/arts_bigtech.json
+node tools/d1-client/recent.mjs --since=today --category=ai      --target=remote > /tmp/arts_ai.json
+node tools/d1-client/recent.mjs --since=today --category=jp      --target=remote > /tmp/arts_jp.json
+```
+
+取得後、3 つの `articles[]` を結合して URL de-dup する (古い `published_at` 優先):
+
+```js
+const seen = new Map();
+const merged = [];
+for (const a of [...bigtech, ...ai, ...jp].sort((x, y) =>
+  x.published_at.localeCompare(y.published_at),
+)) {
+  if (!seen.has(a.url)) {
+    seen.set(a.url, true);
+    merged.push(a);
+  }
+}
+```
+
+以降の Stage はマージ済み `merged` を `articles` として扱う。
 
 stdout に出る JSON 形式:
 
@@ -159,7 +188,9 @@ Markdown で次の構造で返す。`mode` に応じて該当しない節は省�
 
 期間: <ISO start> 〜 <ISO end> / 総件数 (de-dup 後): <deduped_total> / カテゴリ: bigtech=N, ai=N, jp=N
 
-## サマリ (重要記事 N 件) ← quick / deep のみ
+## Pick 記事リンク一覧 ← quick / deep のみ。必ず出力する。省略禁止
+
+Stage 2 で選定した重要記事のリンク集。
 
 - **[<タイトル>](url)** _(<feed_name>, <category>, <YYYY-MM-DD>)_ — <1〜2 文の日本語要約> <(summary based) があれば末尾に>
 - ...
@@ -193,6 +224,24 @@ Markdown で次の構造で返す。`mode` に応じて該当しない節は省�
 | bigtech  | N    |
 | ai       | N    |
 | jp       | N    |
+```
+
+**複数カテゴリ (例: bigtech / ai / jp) のレポートを生成する場合**は、`## カテゴリ別ハイライト` に代わり `## カテゴリ別動向` 節を設け、各カテゴリをサブセクションとして展開する:
+
+```md
+## カテゴリ別動向
+
+### bigtech
+
+<bigtech カテゴリの技術動向 2〜3 点。関連記事リンクを自然に埋め込む>
+
+### ai
+
+<ai カテゴリの技術動向 2〜3 点>
+
+### jp
+
+<jp カテゴリの技術動向 2〜3 点>
 ```
 
 ## ガードレール

--- a/.claude/skills/tech-news-weekly/SKILL.md
+++ b/.claude/skills/tech-news-weekly/SKILL.md
@@ -53,6 +53,35 @@ node tools/d1-client/recent.mjs --since=month --target=remote --limit=500
 node tools/d1-client/recent.mjs --since=week --category=ai --target=remote
 ```
 
+**複数カテゴリを対象にする場合 (例: bigtech + ai)**:
+
+`recent.mjs` はカンマ区切り複数指定に非対応のため、カテゴリごとに呼んで URL で de-dup する:
+
+```sh
+# 週次 (bigtech + ai の 2 カテゴリ)
+node tools/d1-client/recent.mjs --since=week --category=bigtech --target=remote > /tmp/arts_bigtech.json
+node tools/d1-client/recent.mjs --since=week --category=ai      --target=remote > /tmp/arts_ai.json
+
+# 月次 (bigtech + ai の 2 カテゴリ、上限拡張)
+node tools/d1-client/recent.mjs --since=month --category=bigtech --target=remote --limit=500 > /tmp/arts_bigtech.json
+node tools/d1-client/recent.mjs --since=month --category=ai      --target=remote --limit=500 > /tmp/arts_ai.json
+```
+
+取得後、2 つの `articles[]` を結合して URL de-dup する (古い `published_at` 優先):
+
+```js
+const seen = new Map();
+const merged = [];
+for (const a of [...bigtech, ...ai].sort((x, y) => x.published_at.localeCompare(y.published_at))) {
+  if (!seen.has(a.url)) {
+    seen.set(a.url, true);
+    merged.push(a);
+  }
+}
+```
+
+以降の Stage はマージ済み `merged` を `articles` として扱う。
+
 stdout の JSON 形式は `tech-news-digest` と同一 (`since`, `total`, `articles`, `by_category`, `by_feed`, `by_lang`)。
 
 **URL による de-dup**:
@@ -184,9 +213,9 @@ Stage 1 の全記事 (de-dup 後) と Stage 3 の本文要約を総合して、�
 - <ハイライト 1>
 - ...
 
-## 注目記事ピックアップ
+## 注目記事ピックアップ ← 必ず出力する。省略禁止
 
-- **[<タイトル>](url)** _(<feed_name>, <YYYY-MM-DD>)_: <1〜2 文の要約> <(summary based) があれば末尾に>
+- **[<タイトル>](url)** _(<feed_name>, <category>, <YYYY-MM-DD>)_: <1〜2 文の要約> <(summary based) があれば末尾に>
 - ...
 
 ## カテゴリ別件数
@@ -199,6 +228,8 @@ Stage 1 の全記事 (de-dup 後) と Stage 3 の本文要約を総合して、�
 ```
 
 各セクションを省略しない。記事 0 件のカテゴリは「記事なし」と記載する。
+
+**複数カテゴリ (例: bigtech + ai) のレポートを生成する場合**は、`## カテゴリ別ハイライト` の各サブセクションを対象カテゴリのみ展開し、`## 注目記事ピックアップ` の各エントリには `category` フィールドを必ず含める。
 
 ## ガードレール
 

--- a/.github/workflows/report-daily.yml
+++ b/.github/workflows/report-daily.yml
@@ -50,21 +50,30 @@ jobs:
             - since=today
             - mode=deep
             - target=remote
-            - category=bigtech
+            - zenn カテゴリは除外 (bigtech / ai / jp の 3 カテゴリを対象にする)
             - lang 指定なし
 
-            Stage 1 では `recent.mjs --category=bigtech --target=remote` を呼んでください。
+            Stage 1 では bigtech / ai / jp の 3 カテゴリをそれぞれ取得してマージしてください:
+              node tools/d1-client/recent.mjs --since=today --category=bigtech --target=remote
+              node tools/d1-client/recent.mjs --since=today --category=ai      --target=remote
+              node tools/d1-client/recent.mjs --since=today --category=jp      --target=remote
+            3 つの articles[] を結合し URL de-dup (古い published_at 優先) する。
+            以降の Stage はマージ済み articles を対象とする。
+
             Stage 1〜4 を完走したあと、最終的な markdown レポート全文を /tmp/report.md に
-            書き出してください。レポートには `## カテゴリ別ハイライト` 節を含めないでください
-            (bigtech 1 カテゴリのみのため不要)。
+            書き出してください。レポートには以下の節を必ず含めてください:
+            - `## Pick 記事リンク一覧` (必須・省略禁止): 各記事にタイトル/URL/feed_name/category/YYYY-MM-DD/1〜2文要約を含む
+            - `## カテゴリ別動向` (必須): bigtech / ai / jp の各サブセクション (###) でカテゴリごとの技術動向をサマる
+
             合わせて以下の JSON を /tmp/report-meta.json に書き出してください:
 
             {
               "kind": "daily",
               "period_start": "<since の ISO 8601>",
               "period_end":   "<実行時刻の ISO 8601>",
-              "category": "bigtech",
+              "category": null,
               "lang": null,
+              "included_categories": ["bigtech","ai","jp"],
               "source_skill": "tech-news-digest",
               "generated_at": "<実行時刻の ISO 8601>",
               "dedup_total": <number>,
@@ -79,9 +88,9 @@ jobs:
 
             加えて、Slack 投稿用のメッセージを /tmp/slack-message.md に書き出してください。
             - Slack mrkdwn 記法 (*bold*, _italic_, <URL|label>)
-            - 全体で 6000 文字以内
+            - 30000 文字以内 (上限。長くても構わない)
             - 冒頭にレポート概要を 1〜2 文
-            - その後に「主要トピック」「カテゴリ別ハイライト」「注目記事 (各記事は 1 行、リンク付き)」を Slack で読みやすく整形
+            - その後に「カテゴリ別ハイライト (bigtech / ai / jp)」「注目記事 (各記事は 1 行、リンク付き)」を Slack で読みやすく整形
             - 末尾に viewer URL は付けない (Actions 側で自動付与される)
 
       - name: Save report to D1 via admin API
@@ -110,7 +119,7 @@ jobs:
               source_skill: .source_skill,
               generated_at: .generated_at,
               content: $content,
-              meta: { dedup_total: .dedup_total, by_category: .by_category, by_feed: .by_feed }
+              meta: { dedup_total: .dedup_total, by_category: .by_category, by_feed: .by_feed, included_categories: .included_categories }
             }' /tmp/report-meta.json > /tmp/report-payload.json
 
           curl -fsS -X POST "$WORKER_URL/api/admin/reports" \
@@ -141,11 +150,54 @@ jobs:
             exit 0
           fi
           VIEWER_URL="$WORKER_URL/reports/$REPORT_ID"
-          {
-            cat /tmp/slack-message.md
-            printf '\n\n— <%s|レポート全文を Web で開く>\n' "$VIEWER_URL"
-          } > /tmp/slack-final.md
-          jq -Rs '{ text: . }' /tmp/slack-final.md > /tmp/slack-payload.json
+
+          # タイトル / 重要度を組み立て (daily: 🟢)
+          KIND=$(jq -r '.kind' /tmp/report-meta.json)
+          PERIOD_END=$(jq -r '.period_end' /tmp/report-meta.json | cut -c1-10)
+          TITLE="🟢 Daily Tech Report (${PERIOD_END})"
+          IMPORTANCE="重要度: 低"
+          GENERATED_AT=$(jq -r '.generated_at' /tmp/report-meta.json)
+
+          # slack-message.md を 2800 chars 単位の section block 群に変換
+          BLOCKS_JSON=$(node -e "
+            const fs = require('fs');
+            const text = fs.readFileSync('/tmp/slack-message.md', 'utf8');
+            const chunkSize = 2800;
+            const blocks = [];
+            for (let i = 0; i < text.length; i += chunkSize) {
+              blocks.push({ type: 'section', text: { type: 'mrkdwn', text: text.slice(i, i + chunkSize) } });
+            }
+            // 50 block 上限: header(1) + context(1) + divider(1) + chunks + divider(1) + footer(1) = 5 + chunks
+            const maxChunks = 44;
+            const trimmed = blocks.slice(0, maxChunks);
+            process.stdout.write(JSON.stringify(trimmed));
+          ")
+
+          TITLE_ESC=$(jq -Rn --arg v "$TITLE" '$v')
+          IMPORTANCE_ESC=$(jq -Rn --arg v "$IMPORTANCE | generated_at: $GENERATED_AT" '$v')
+          VIEWER_ESC=$(jq -Rn --arg v "— <${VIEWER_URL}|レポート全文を Web で開く>" '$v')
+
+          jq -n \
+            --argjson title "$TITLE_ESC" \
+            --argjson importance "$IMPORTANCE_ESC" \
+            --argjson chunks "$BLOCKS_JSON" \
+            --argjson viewer "$VIEWER_ESC" \
+            '{
+              text: $title,
+              blocks: (
+                [
+                  { type: "header", text: { type: "plain_text", text: $title } },
+                  { type: "context", elements: [{ type: "mrkdwn", text: $importance }] },
+                  { type: "divider" }
+                ]
+                + $chunks
+                + [
+                  { type: "divider" },
+                  { type: "section", text: { type: "mrkdwn", text: $viewer } }
+                ]
+              )
+            }' > /tmp/slack-payload.json
+
           curl -fsS -X POST "$SLACK_WEBHOOK_URL" \
             -H 'Content-Type: application/json' \
             --data-binary @/tmp/slack-payload.json

--- a/.github/workflows/report-monthly.yml
+++ b/.github/workflows/report-monthly.yml
@@ -48,21 +48,29 @@ jobs:
             - since=month
             - target=remote
             - limit=500
-            - category=bigtech
+            - bigtech と ai の 2 カテゴリを対象にする
             - lang 指定なし
 
-            Stage 1 では `recent.mjs --category=bigtech --target=remote --limit=500` を呼んでください。
+            Stage 1 では bigtech / ai の 2 カテゴリをそれぞれ取得してマージしてください:
+              node tools/d1-client/recent.mjs --since=month --category=bigtech --target=remote --limit=500
+              node tools/d1-client/recent.mjs --since=month --category=ai      --target=remote --limit=500
+            2 つの articles[] を結合し URL de-dup (古い published_at 優先) する。
+            以降の Stage はマージ済み articles を対象とする。
+
             Stage 1〜4 を完走したあと、最終的な markdown レポート全文を /tmp/report.md に
-            書き出してください。レポートには `## カテゴリ別ハイライト` 節を含めないでください
-            (bigtech 1 カテゴリのみのため不要)。
+            書き出してください。レポートには以下の節を必ず含めてください:
+            - `## 注目記事ピックアップ` (必須・省略禁止): 各記事にタイトル/URL/feed_name/category/YYYY-MM-DD/1〜2文要約を含む
+            - `## カテゴリ別ハイライト` (必須): bigtech / ai の各サブセクション (###) でカテゴリごとの動向をサマる
+
             合わせて以下の JSON を /tmp/report-meta.json に書き出してください:
 
             {
               "kind": "monthly",
               "period_start": "<実行時刻 -30 日 の ISO 8601>",
               "period_end":   "<実行時刻の ISO 8601>",
-              "category": "bigtech",
+              "category": null,
               "lang": null,
+              "included_categories": ["bigtech","ai"],
               "source_skill": "tech-news-weekly",
               "generated_at": "<実行時刻の ISO 8601>",
               "dedup_total": <number>,
@@ -77,9 +85,9 @@ jobs:
 
             加えて、Slack 投稿用のメッセージを /tmp/slack-message.md に書き出してください。
             - Slack mrkdwn 記法 (*bold*, _italic_, <URL|label>)
-            - 全体で 6000 文字以内
+            - 30000 文字以内 (上限。長くても構わない)
             - 冒頭にレポート概要を 1〜2 文
-            - その後に「主要トピック」「カテゴリ別ハイライト」「注目記事 (各記事は 1 行、リンク付き)」を Slack で読みやすく整形
+            - その後に「カテゴリ別ハイライト (bigtech / ai)」「注目記事 (各記事は 1 行、リンク付き)」を Slack で読みやすく整形
             - 末尾に viewer URL は付けない (Actions 側で自動付与される)
 
       - name: Save report to D1 via admin API
@@ -104,7 +112,7 @@ jobs:
               source_skill: .source_skill,
               generated_at: .generated_at,
               content: $content,
-              meta: { dedup_total: .dedup_total, by_category: .by_category, by_feed: .by_feed }
+              meta: { dedup_total: .dedup_total, by_category: .by_category, by_feed: .by_feed, included_categories: .included_categories }
             }' /tmp/report-meta.json > /tmp/report-payload.json
 
           curl -fsS -X POST "$WORKER_URL/api/admin/reports" \
@@ -135,11 +143,55 @@ jobs:
             exit 0
           fi
           VIEWER_URL="$WORKER_URL/reports/$REPORT_ID"
-          {
-            cat /tmp/slack-message.md
-            printf '\n\n— <%s|レポート全文を Web で開く>\n' "$VIEWER_URL"
-          } > /tmp/slack-final.md
-          jq -Rs '{ text: . }' /tmp/slack-final.md > /tmp/slack-payload.json
+
+          # タイトル / 重要度を組み立て (monthly: 🔴)
+          KIND=$(jq -r '.kind' /tmp/report-meta.json)
+          PERIOD_START=$(jq -r '.period_start' /tmp/report-meta.json | cut -c1-10)
+          PERIOD_END=$(jq -r '.period_end' /tmp/report-meta.json | cut -c1-10)
+          TITLE="🔴 Monthly Tech Report (${PERIOD_START} 〜 ${PERIOD_END})"
+          IMPORTANCE="重要度: 高"
+          GENERATED_AT=$(jq -r '.generated_at' /tmp/report-meta.json)
+
+          # slack-message.md を 2800 chars 単位の section block 群に変換
+          BLOCKS_JSON=$(node -e "
+            const fs = require('fs');
+            const text = fs.readFileSync('/tmp/slack-message.md', 'utf8');
+            const chunkSize = 2800;
+            const blocks = [];
+            for (let i = 0; i < text.length; i += chunkSize) {
+              blocks.push({ type: 'section', text: { type: 'mrkdwn', text: text.slice(i, i + chunkSize) } });
+            }
+            // 50 block 上限: header(1) + context(1) + divider(1) + chunks + divider(1) + footer(1) = 5 + chunks
+            const maxChunks = 44;
+            const trimmed = blocks.slice(0, maxChunks);
+            process.stdout.write(JSON.stringify(trimmed));
+          ")
+
+          TITLE_ESC=$(jq -Rn --arg v "$TITLE" '$v')
+          IMPORTANCE_ESC=$(jq -Rn --arg v "$IMPORTANCE | generated_at: $GENERATED_AT" '$v')
+          VIEWER_ESC=$(jq -Rn --arg v "— <${VIEWER_URL}|レポート全文を Web で開く>" '$v')
+
+          jq -n \
+            --argjson title "$TITLE_ESC" \
+            --argjson importance "$IMPORTANCE_ESC" \
+            --argjson chunks "$BLOCKS_JSON" \
+            --argjson viewer "$VIEWER_ESC" \
+            '{
+              text: $title,
+              blocks: (
+                [
+                  { type: "header", text: { type: "plain_text", text: $title } },
+                  { type: "context", elements: [{ type: "mrkdwn", text: $importance }] },
+                  { type: "divider" }
+                ]
+                + $chunks
+                + [
+                  { type: "divider" },
+                  { type: "section", text: { type: "mrkdwn", text: $viewer } }
+                ]
+              )
+            }' > /tmp/slack-payload.json
+
           curl -fsS -X POST "$SLACK_WEBHOOK_URL" \
             -H 'Content-Type: application/json' \
             --data-binary @/tmp/slack-payload.json

--- a/.github/workflows/report-weekly.yml
+++ b/.github/workflows/report-weekly.yml
@@ -46,21 +46,29 @@ jobs:
             tech-news-weekly skill を以下の引数で起動してください:
             - since=week
             - target=remote
-            - category=bigtech
+            - bigtech と ai の 2 カテゴリを対象にする
             - lang 指定なし
 
-            Stage 1 では `recent.mjs --category=bigtech --target=remote` を呼んでください。
+            Stage 1 では bigtech / ai の 2 カテゴリをそれぞれ取得してマージしてください:
+              node tools/d1-client/recent.mjs --since=week --category=bigtech --target=remote
+              node tools/d1-client/recent.mjs --since=week --category=ai      --target=remote
+            2 つの articles[] を結合し URL de-dup (古い published_at 優先) する。
+            以降の Stage はマージ済み articles を対象とする。
+
             Stage 1〜4 を完走したあと、最終的な markdown レポート全文を /tmp/report.md に
-            書き出してください。レポートには `## カテゴリ別ハイライト` 節を含めないでください
-            (bigtech 1 カテゴリのみのため不要)。
+            書き出してください。レポートには以下の節を必ず含めてください:
+            - `## 注目記事ピックアップ` (必須・省略禁止): 各記事にタイトル/URL/feed_name/category/YYYY-MM-DD/1〜2文要約を含む
+            - `## カテゴリ別ハイライト` (必須): bigtech / ai の各サブセクション (###) でカテゴリごとの動向をサマる
+
             合わせて以下の JSON を /tmp/report-meta.json に書き出してください:
 
             {
               "kind": "weekly",
               "period_start": "<実行時刻 -7 日 の ISO 8601>",
               "period_end":   "<実行時刻の ISO 8601>",
-              "category": "bigtech",
+              "category": null,
               "lang": null,
+              "included_categories": ["bigtech","ai"],
               "source_skill": "tech-news-weekly",
               "generated_at": "<実行時刻の ISO 8601>",
               "dedup_total": <number>,
@@ -75,9 +83,9 @@ jobs:
 
             加えて、Slack 投稿用のメッセージを /tmp/slack-message.md に書き出してください。
             - Slack mrkdwn 記法 (*bold*, _italic_, <URL|label>)
-            - 全体で 6000 文字以内
+            - 30000 文字以内 (上限。長くても構わない)
             - 冒頭にレポート概要を 1〜2 文
-            - その後に「主要トピック」「カテゴリ別ハイライト」「注目記事 (各記事は 1 行、リンク付き)」を Slack で読みやすく整形
+            - その後に「カテゴリ別ハイライト (bigtech / ai)」「注目記事 (各記事は 1 行、リンク付き)」を Slack で読みやすく整形
             - 末尾に viewer URL は付けない (Actions 側で自動付与される)
 
       - name: Save report to D1 via admin API
@@ -102,7 +110,7 @@ jobs:
               source_skill: .source_skill,
               generated_at: .generated_at,
               content: $content,
-              meta: { dedup_total: .dedup_total, by_category: .by_category, by_feed: .by_feed }
+              meta: { dedup_total: .dedup_total, by_category: .by_category, by_feed: .by_feed, included_categories: .included_categories }
             }' /tmp/report-meta.json > /tmp/report-payload.json
 
           curl -fsS -X POST "$WORKER_URL/api/admin/reports" \
@@ -133,11 +141,55 @@ jobs:
             exit 0
           fi
           VIEWER_URL="$WORKER_URL/reports/$REPORT_ID"
-          {
-            cat /tmp/slack-message.md
-            printf '\n\n— <%s|レポート全文を Web で開く>\n' "$VIEWER_URL"
-          } > /tmp/slack-final.md
-          jq -Rs '{ text: . }' /tmp/slack-final.md > /tmp/slack-payload.json
+
+          # タイトル / 重要度を組み立て (weekly: 🟡)
+          KIND=$(jq -r '.kind' /tmp/report-meta.json)
+          PERIOD_START=$(jq -r '.period_start' /tmp/report-meta.json | cut -c1-10)
+          PERIOD_END=$(jq -r '.period_end' /tmp/report-meta.json | cut -c1-10)
+          TITLE="🟡 Weekly Tech Report (${PERIOD_START} 〜 ${PERIOD_END})"
+          IMPORTANCE="重要度: 中"
+          GENERATED_AT=$(jq -r '.generated_at' /tmp/report-meta.json)
+
+          # slack-message.md を 2800 chars 単位の section block 群に変換
+          BLOCKS_JSON=$(node -e "
+            const fs = require('fs');
+            const text = fs.readFileSync('/tmp/slack-message.md', 'utf8');
+            const chunkSize = 2800;
+            const blocks = [];
+            for (let i = 0; i < text.length; i += chunkSize) {
+              blocks.push({ type: 'section', text: { type: 'mrkdwn', text: text.slice(i, i + chunkSize) } });
+            }
+            // 50 block 上限: header(1) + context(1) + divider(1) + chunks + divider(1) + footer(1) = 5 + chunks
+            const maxChunks = 44;
+            const trimmed = blocks.slice(0, maxChunks);
+            process.stdout.write(JSON.stringify(trimmed));
+          ")
+
+          TITLE_ESC=$(jq -Rn --arg v "$TITLE" '$v')
+          IMPORTANCE_ESC=$(jq -Rn --arg v "$IMPORTANCE | generated_at: $GENERATED_AT" '$v')
+          VIEWER_ESC=$(jq -Rn --arg v "— <${VIEWER_URL}|レポート全文を Web で開く>" '$v')
+
+          jq -n \
+            --argjson title "$TITLE_ESC" \
+            --argjson importance "$IMPORTANCE_ESC" \
+            --argjson chunks "$BLOCKS_JSON" \
+            --argjson viewer "$VIEWER_ESC" \
+            '{
+              text: $title,
+              blocks: (
+                [
+                  { type: "header", text: { type: "plain_text", text: $title } },
+                  { type: "context", elements: [{ type: "mrkdwn", text: $importance }] },
+                  { type: "divider" }
+                ]
+                + $chunks
+                + [
+                  { type: "divider" },
+                  { type: "section", text: { type: "mrkdwn", text: $viewer } }
+                ]
+              )
+            }' > /tmp/slack-payload.json
+
           curl -fsS -X POST "$SLACK_WEBHOOK_URL" \
             -H 'Content-Type: application/json' \
             --data-binary @/tmp/slack-payload.json

--- a/docs/reports-pipeline.md
+++ b/docs/reports-pipeline.md
@@ -124,11 +124,11 @@ CORS は付けず、Bearer `ADMIN_TOKEN` (rotation 中は `ADMIN_TOKEN_NEXT` も
 
 各 workflow は `.github/workflows/` 配下に置く。
 
-| File                 | スケジュール (UTC) | スケジュール (JST) | 起動する skill     | skill 引数                                 |
-| -------------------- | ------------------ | ------------------ | ------------------ | ------------------------------------------ |
-| `report-daily.yml`   | `0 22 * * *`       | 毎日 07:00         | `tech-news-digest` | `since=today, deep, category=bigtech`      |
-| `report-weekly.yml`  | `0 22 * * 0`       | 毎週月曜 07:00     | `tech-news-weekly` | `since=week, category=bigtech`             |
-| `report-monthly.yml` | `0 22 1 * *`       | 毎月 2 日 07:00    | `tech-news-weekly` | `since=month, limit=500, category=bigtech` |
+| File                 | スケジュール (UTC) | スケジュール (JST) | 起動する skill     | skill 引数                                                          |
+| -------------------- | ------------------ | ------------------ | ------------------ | ------------------------------------------------------------------- |
+| `report-daily.yml`   | `0 22 * * *`       | 毎日 07:00         | `tech-news-digest` | `since=today, deep, categories=bigtech+ai+jp (3 回呼び), zenn 除外` |
+| `report-weekly.yml`  | `0 22 * * 0`       | 毎週月曜 07:00     | `tech-news-weekly` | `since=week, categories=bigtech+ai (2 回呼び)`                      |
+| `report-monthly.yml` | `0 22 1 * *`       | 毎月 2 日 07:00    | `tech-news-weekly` | `since=month, limit=500, categories=bigtech+ai (2 回呼び)`          |
 
 > monthly は GitHub Actions cron が `L` (月末) を非対応のため、「翌月 2 日 JST 07:00 に
 > 過去 30 日を集計」として暦月とほぼ等価のレポートを作る。`since=month` は skill 仕様で
@@ -137,29 +137,23 @@ CORS は付けず、Bearer `ADMIN_TOKEN` (rotation 中は `ADMIN_TOKEN_NEXT` も
 ### Workflow の構造 (共通)
 
 1. `actions/checkout` + `pnpm/action-setup` + `actions/setup-node` + `pnpm install`
-2. `anthropics/claude-code-base-action@v1`
+2. `anthropics/claude-code-base-action@beta`
    - `claude_code_oauth_token`: subscription 経由で発行された OAuth token
    - `allowed_tools`: `"Bash,Read,Write,WebFetch,Skill"`
    - env: `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID` (recent.mjs が wrangler 経由で D1 にアクセスする際に必要)
-   - prompt: skill 起動 + `/tmp/report.md` / `/tmp/report-meta.json` への書き出しを指示
-3. `jq` で markdown と meta JSON を 1 つの payload にまとめ、`curl POST /api/admin/reports` で Worker に投入
+   - prompt: skill 起動 + `/tmp/report.md` / `/tmp/report-meta.json` / `/tmp/slack-message.md` への書き出しを指示
+3. `jq` で markdown と meta JSON を 1 つの payload にまとめ、`curl POST /api/admin/reports` で Worker に投入 (レスポンスを `/tmp/post-resp.json` に保存)
+4. `Post to Slack` ステップで blocks payload を組み立て incoming webhook に投稿
 
-prompt の本体例 (`report-daily.yml`):
+**カテゴリ複数取得パターン**: `recent.mjs` はカンマ区切り複数指定に非対応のため、カテゴリごとに呼んで URL で de-dup する:
 
 ```
-tech-news-digest skill を以下の引数で起動してください:
-- since=today
-- mode=deep
-- target=remote
-- category=bigtech
-- lang 指定なし
-
-Stage 1 では `recent.mjs --category=bigtech --target=remote` を呼んでください。
-Stage 1〜4 を完走したあと、最終的な markdown レポート全文を /tmp/report.md に
-書き出してください。レポートには `## カテゴリ別ハイライト` 節を含めないでください
-(bigtech 1 カテゴリのみのため不要)。
-合わせて meta JSON を /tmp/report-meta.json に書き出してください: { kind, period_start, ..., category: "bigtech" }
+daily   : --category=bigtech, --category=ai, --category=jp を各 1 回 → 3 結果をマージ → URL de-dup
+weekly  : --category=bigtech, --category=ai を各 1 回 → 2 結果をマージ → URL de-dup
+monthly : --category=bigtech --limit=500, --category=ai --limit=500 を各 1 回 → 2 結果をマージ → URL de-dup
 ```
+
+meta_json の `included_categories` にカバーしたカテゴリ配列を記録する (Worker 側 schema 変更なし、`meta_json` 任意 JSON)。
 
 ### concurrency
 
@@ -241,12 +235,34 @@ Slack への投稿は Worker ではなく GitHub Actions 側で行う。
 
 フロー:
 
-1. Skill (Claude Code) が `/tmp/slack-message.md` を生成 (Slack mrkdwn 形式、6000 文字以内)
+1. Skill (Claude Code) が `/tmp/slack-message.md` を生成 (Slack mrkdwn 形式、30000 文字以内)
 2. `Save report to D1` ステップで POST レスポンス (`{ ok, id }`) を `/tmp/post-resp.json` に保存
-3. `Post to Slack` ステップが `id` から viewer URL を組み立て、`/tmp/slack-message.md` の末尾に付与して Slack incoming webhook に投稿
+3. `Post to Slack` ステップが blocks payload を組み立てて Slack incoming webhook に投稿
+
+### Blocks payload 構造
+
+```
+header block   : 🟢/🟡/🔴 + 種別 + 期間
+context block  : 重要度テキスト + generated_at
+divider
+section block × N : slack-message.md を 2800 chars 単位でチャンク分割
+divider
+section block  : レポート全文を Web で開く (viewer URL)
+```
+
+重要度と絵文字:
+
+| kind    | 絵文字 | タイトル例                                          | 重要度テキスト |
+| ------- | ------ | --------------------------------------------------- | -------------- |
+| daily   | 🟢     | `🟢 Daily Tech Report (2026-04-29)`                 | 重要度: 低     |
+| weekly  | 🟡     | `🟡 Weekly Tech Report (2026-04-22 〜 2026-04-29)`  | 重要度: 中     |
+| monthly | 🔴     | `🔴 Monthly Tech Report (2026-03-30 〜 2026-04-29)` | 重要度: 高     |
 
 特性:
 
+- 6000 文字制限は撤廃。30000 文字以内を推奨上限とし、blocks 分割で長文に対応
+- blocks 総数は最大 50 (Slack 制約)。チャンク数は上限 44 に制限し、固定ブロック 5 個と合わせて 49 以下に収まる
+- スレッド投稿は incoming webhook の仕様で不可 (`thread_ts` 非対応)。将来必要になれば bot token (`xoxb-`) + `chat.postMessage` に移行する
 - `SLACK_WEBHOOK_URL` が未設定の場合は no-op でスキップ (投稿しないだけで workflow は正常終了)
 - `continue-on-error: true` を付けているため、Slack 投稿が失敗 (non-2xx / timeout) しても workflow 全体が fail しない
 - webhook URL リテラルをコードに埋め込まない。`${{ secrets.SLACK_WEBHOOK_URL }}` 経由でのみ参照する


### PR DESCRIPTION
## Summary

- daily レポートを bigtech / ai / jp 3 カテゴリに拡張し、カテゴリ別動向セクションを必須化
- weekly / monthly レポートを bigtech + ai の 2 カテゴリに拡張
- Slack 投稿を blocks 構造化 + 重要度 emoji (🟢/🟡/🔴) + 長文 chunks 分割に刷新

## 背景

- **#308**: daily は zenn 以外の全カテゴリ (bigtech/ai/jp) を対象に、weekly/monthly は bigtech+ai の 2 カテゴリに拡張したい。`recent.mjs` はカンマ区切り複数指定非対応のため、カテゴリごとに複数回呼んで URL de-dup する案 A を採用
- **#309**: Slack 投稿にタイトル・重要度・長文対応を導入。incoming webhook で thread_ts は不可と結論し、blocks で構造化した 1 メッセージに収める
- **#310**: D1 保存 markdown に Pick 記事リンク一覧を必須セクションとして含める

## 変更点

### #310: SKILL.md pick 記事リンク一覧

- `tech-news-digest/SKILL.md`: `## サマリ` を `## Pick 記事リンク一覧` に改称し quick/deep で **必須・省略禁止** に変更。各エントリにタイトル/URL/feed_name/category/published_at/要約を必須化
- `tech-news-weekly/SKILL.md`: `## 注目記事ピックアップ` を **必須・省略禁止** に変更し `category` フィールドを追加

### #308: 複数カテゴリ対応

- `report-daily.yml` prompt: bigtech/ai/jp を各 1 回 recent.mjs で取得して URL de-dup。`## カテゴリ別動向` 節 (3 サブセクション) を必須化。meta に `included_categories: ["bigtech","ai","jp"]` を追加
- `report-weekly.yml` prompt: bigtech+ai の 2 カテゴリに拡張。`## カテゴリ別ハイライト` 節 (2 サブセクション) を必須化。meta に `included_categories: ["bigtech","ai"]` を追加
- `report-monthly.yml` prompt: weekly と同様 (--limit=500 付き)
- `tech-news-digest/SKILL.md` + `tech-news-weekly/SKILL.md`: Stage 1 に複数カテゴリ呼び出し + URL de-dup パターンを追記

### #309: Slack rich blocks

- 3 workflow の `Post to Slack` ステップを blocks payload に刷新:
  - header block: 🟢/🟡/🔴 + 種別 + 期間
  - context block: 重要度テキスト + generated_at
  - section block × N: slack-message.md を 2800 chars/chunk で分割 (上限 44 chunk = blocks 49 以下)
  - footer section: viewer URL リンク
- slack-message.md の 6000 文字制限を撤廃し 30000 文字以内に変更
- `docs/reports-pipeline.md`: Slack 通知節を新仕様に更新 (重要度 emoji / blocks 分割 / スレッド不可の説明)

## Test plan

- [x] `pnpm build` pass
- [x] `pnpm typecheck` pass
- [x] `pnpm lint` pass (既存 warning のみ)
- [x] `pnpm test` pass (543 tests)
- [x] YAML 構文チェック 3 workflow OK
- [x] Slack payload ローカル動作確認 (blocks 7, max mrkdwn 2800 chars)
- [ ] merge 後に `gh workflow run report-daily.yml` を手動 dispatch し Slack の実際の見た目 (🟢 タイトル / 重要度 低 / カテゴリ別動向 bigtech/ai/jp) を確認
- [ ] 同様に `gh workflow run report-weekly.yml` (🟡 / 重要度 中 / bigtech+ai)
- [ ] 同様に `gh workflow run report-monthly.yml` (🔴 / 重要度 高 / bigtech+ai)

Closes #308
Closes #309
Closes #310