### PR TITLE
fix(reports): accept ISO 8601 without milliseconds

### DIFF
--- a/apps/web/tests/worker/api/reports.test.ts
+++ b/apps/web/tests/worker/api/reports.test.ts
@@ -129,6 +129,22 @@ describe("POST /api/admin/reports", () => {
     expect(res.status).toBe(400);
   });
 
+  // LLM はミリ秒抜きの ISO 8601 (`...:00Z`) を生成しがちなので受け入れる
+  it("200: accepts ISO 8601 without milliseconds", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(
+        buildPayload({
+          period_start: "2026-04-27T00:00:00Z",
+          period_end: "2026-04-28T00:00:00Z",
+          generated_at: "2026-04-28T00:01:00Z",
+        }),
+      ),
+    });
+    expect(res.status).toBe(200);
+  });
+
   it("400: rejects empty content", async () => {
     const res = await SELF.fetch("https://example.com/api/admin/reports", {
       method: "POST",

--- a/apps/web/worker/api/reports.ts
+++ b/apps/web/worker/api/reports.ts
@@ -52,10 +52,15 @@ function authGuard(c: Context<{ Bindings: Env }>): Response | null {
   return null;
 }
 
+// Date.toISOString() の strict round-trip だと "2026-04-29T00:00:00Z" のような
+// ms 抜きの ISO 8601 (LLM が頻繁に出力する形式) が弾かれる。
+// 形を正規表現で軽く gate しつつ Date.parse() で意味的妥当性を確認する。
+const ISO8601_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})$/;
 function isISO8601(s: unknown): s is string {
   if (typeof s !== "string" || s.length === 0) return false;
+  if (!ISO8601_RE.test(s)) return false;
   const d = new Date(s);
-  return !Number.isNaN(d.getTime()) && d.toISOString() === s;
+  return !Number.isNaN(d.getTime());
 }
 
 interface PostBody {


### PR DESCRIPTION
## Summary

Skill が生成する meta JSON は `2026-04-29T00:00:00Z` のような ms 抜き ISO 8601 を出すことが多く、`/api/admin/reports` POST の strict round-trip validation で 400 を返していた。形を regex で gate しつつ Date.parse() で意味的妥当性を確認する方式に変更し、ms あり/なし両形式を受け入れる。

## 背景

PR #313 merge 後の workflow_dispatch で daily/weekly が Save report to D1 ステップで 400 → Slack 投稿が skip された。

## 変更点

- `apps/web/worker/api/reports.ts`: `isISO8601` を regex + Date.parse() のハイブリッドに変更
- `apps/web/tests/worker/api/reports.test.ts`: ms 抜き形式の受け入れケースを追加 (既存の "yesterday" を弾くケースは regex で引き続き reject)

## Test plan

- [x] `pnpm --filter @tnb/web run typecheck`
- [x] `pnpm --filter @tnb/web run test` 544 tests pass
- [ ] CI green
- [ ] merge 後 Report Daily/Weekly/Monthly 再 dispatch で 200 確認

Closes #314