### PR TITLE
fix(claude): drop invalid fork-bomb deny entry, move guard to hook

### DIFF
--- a/.claude/hooks/block-dangerous.sh
+++ b/.claude/hooks/block-dangerous.sh
@@ -76,4 +76,11 @@ if echo "$CMD" | grep -Eq 'curl[[:space:]]+[^|]*\|[[:space:]]*(sh|bash|zsh)([[:s
   block "piping curl into a shell is forbidden"
 fi
 
+# 7) fork bomb (関数定義 + 自己再帰 pipe & background の典型形)
+#    例: `:(){:|:&};:` `bomb(){bomb|bomb&};bomb` など
+#    permissions.deny は `(`/`)` を含むパターンを表現できないので、こちらで拾う。
+if echo "$CMD" | grep -Eq '[a-zA-Z_:][a-zA-Z0-9_:]*[[:space:]]*\(\)[[:space:]]*\{[^}]*\|[^}]*&[^}]*\}[[:space:]]*;'; then
+  block "fork bomb-like recursive function is forbidden"
+fi
+
 exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -131,7 +131,6 @@
       "Bash(rm -rf $HOME)",
       "Bash(rm -rf $HOME/*)",
       "Bash(rm -rf ..:*)",
-      "Bash(:(){:|:&};:)",
       "Bash(sudo:*)",
       "Bash(git push --force origin main:*)",
       "Bash(git push -f origin main:*)",


### PR DESCRIPTION
## Summary

- `.claude/settings.json` の `permissions.deny` にあったエントリは Claude Code 起動時に schema 拒否され、毎セッション settings warning を出していた。括弧や特殊文字を含む fork-bomb literal は permission rule の構文では表現できない
- 該当エントリを deny から削除し、同等の防御を `.claude/hooks/block-dangerous.sh` の正規表現ガード (項目 7) に移動。古典的な `:` 形式と任意名形式の両方を捕捉、通常の関数定義 (`foo() { echo hi; }; foo` のような単純な body のもの) は誤検出しない
- hook には JSON 入力経由で動作確認済み: fork-bomb → block (exit 2), benign → pass (exit 0)

## Test plan

- [x] `bash -n .claude/hooks/block-dangerous.sh` で構文 OK
- [x] `jq empty .claude/settings.json` で JSON 整形 OK
- [x] hook を JSON 入力経由で動作確認 (fork-bomb → block, benign → pass)
- [ ] merge 後、新セッションで settings warning が消えることを確認
