### PR TITLE
feat(reports): post Slack as threaded message (Bot Token)

### DIFF
--- a/.github/workflows/report-daily.yml
+++ b/.github/workflows/report-daily.yml
@@ -128,76 +128,128 @@ jobs:
             -o /tmp/post-resp.json \
             --data-binary @/tmp/report-payload.json
 
-      - name: Post to Slack
+      - name: Post to Slack (threaded)
         if: ${{ success() }}
         continue-on-error: true
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           WORKER_URL: https://tech-news-bot.rikeda71.workers.dev
         run: |
           set -euo pipefail
-          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
-            echo "SLACK_WEBHOOK_URL not set – skipping Slack notification"
+
+          # required secrets / files の存在チェック (skip 条件)
+          if [ -z "${SLACK_BOT_TOKEN:-}" ] || [ -z "${SLACK_CHANNEL_ID:-}" ]; then
+            echo "SLACK_BOT_TOKEN or SLACK_CHANNEL_ID not set – skipping Slack thread post"
             exit 0
           fi
-          if [ ! -f /tmp/slack-message.md ] || [ ! -f /tmp/post-resp.json ]; then
-            echo "Slack message or post response missing – skipping Slack notification"
+          if [ ! -f /tmp/slack-message.md ] || [ ! -f /tmp/post-resp.json ] || [ ! -f /tmp/report-meta.json ]; then
+            echo "Required files missing – skipping Slack thread post"
             exit 0
           fi
+
           REPORT_ID=$(jq -r '.id' /tmp/post-resp.json)
           if [ -z "$REPORT_ID" ] || [ "$REPORT_ID" = "null" ]; then
-            echo "Could not determine report id – skipping Slack notification"
+            echo "report id missing – skipping"
             exit 0
           fi
           VIEWER_URL="$WORKER_URL/reports/$REPORT_ID"
 
-          # タイトル / 重要度を組み立て (daily: 🟢)
           KIND=$(jq -r '.kind' /tmp/report-meta.json)
-          PERIOD_END=$(jq -r '.period_end' /tmp/report-meta.json | cut -c1-10)
-          TITLE="🟢 Daily Tech Report (${PERIOD_END})"
-          IMPORTANCE="重要度: 低"
+          PERIOD_START=$(jq -r '.period_start' /tmp/report-meta.json)
+          PERIOD_END=$(jq -r '.period_end' /tmp/report-meta.json)
           GENERATED_AT=$(jq -r '.generated_at' /tmp/report-meta.json)
 
-          # slack-message.md を 2800 chars 単位の section block 群に変換
-          BLOCKS_JSON=$(node -e "
-            const fs = require('fs');
-            const text = fs.readFileSync('/tmp/slack-message.md', 'utf8');
-            const chunkSize = 2800;
-            const blocks = [];
-            for (let i = 0; i < text.length; i += chunkSize) {
-              blocks.push({ type: 'section', text: { type: 'mrkdwn', text: text.slice(i, i + chunkSize) } });
-            }
-            // 50 block 上限: header(1) + context(1) + divider(1) + chunks + divider(1) + footer(1) = 5 + chunks
-            const maxChunks = 44;
-            const trimmed = blocks.slice(0, maxChunks);
-            process.stdout.write(JSON.stringify(trimmed));
-          ")
+          # Build title (emoji + label + period)
+          case "$KIND" in
+            daily)
+              EMOJI="🟢"; SEVERITY="重要度: 低"; LABEL="Daily"
+              DATE_LABEL=$(echo "$PERIOD_END" | cut -c1-10)
+              TITLE="$EMOJI $LABEL Tech Report ($DATE_LABEL)"
+              ;;
+            weekly)
+              EMOJI="🟡"; SEVERITY="重要度: 中"; LABEL="Weekly"
+              START=$(echo "$PERIOD_START" | cut -c1-10); END=$(echo "$PERIOD_END" | cut -c1-10)
+              TITLE="$EMOJI $LABEL Tech Report ($START 〜 $END)"
+              ;;
+            monthly)
+              EMOJI="🔴"; SEVERITY="重要度: 高"; LABEL="Monthly"
+              START=$(echo "$PERIOD_START" | cut -c1-10); END=$(echo "$PERIOD_END" | cut -c1-10)
+              TITLE="$EMOJI $LABEL Tech Report ($START 〜 $END)"
+              ;;
+            *)
+              echo "Unknown kind $KIND – skipping"; exit 0 ;;
+          esac
 
-          TITLE_ESC=$(jq -Rn --arg v "$TITLE" '$v')
-          IMPORTANCE_ESC=$(jq -Rn --arg v "$IMPORTANCE | generated_at: $GENERATED_AT" '$v')
-          VIEWER_ESC=$(jq -Rn --arg v "— <${VIEWER_URL}|レポート全文を Web で開く>" '$v')
-
-          jq -n \
-            --argjson title "$TITLE_ESC" \
-            --argjson importance "$IMPORTANCE_ESC" \
-            --argjson chunks "$BLOCKS_JSON" \
-            --argjson viewer "$VIEWER_ESC" \
+          # ===== Step A: post parent (title + severity) =====
+          PARENT_PAYLOAD=$(jq -n \
+            --arg ch "$SLACK_CHANNEL_ID" \
+            --arg t "$TITLE" \
+            --arg s "$SEVERITY · generated_at: $GENERATED_AT" \
             '{
-              text: $title,
-              blocks: (
-                [
-                  { type: "header", text: { type: "plain_text", text: $title } },
-                  { type: "context", elements: [{ type: "mrkdwn", text: $importance }] },
-                  { type: "divider" }
-                ]
-                + $chunks
-                + [
-                  { type: "divider" },
-                  { type: "section", text: { type: "mrkdwn", text: $viewer } }
-                ]
-              )
-            }' > /tmp/slack-payload.json
+              channel: $ch,
+              text: $t,
+              blocks: [
+                { type: "header", text: { type: "plain_text", text: $t, emoji: true } },
+                { type: "context", elements: [ { type: "mrkdwn", text: $s } ] }
+              ]
+            }')
 
-          curl -fsS -X POST "$SLACK_WEBHOOK_URL" \
-            -H 'Content-Type: application/json' \
-            --data-binary @/tmp/slack-payload.json
+          PARENT_RESP=$(curl -fsS -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            --data "$PARENT_PAYLOAD")
+
+          PARENT_OK=$(echo "$PARENT_RESP" | jq -r '.ok')
+          if [ "$PARENT_OK" != "true" ]; then
+            ERR=$(echo "$PARENT_RESP" | jq -r '.error // "unknown"')
+            echo "Parent post failed: $ERR"
+            exit 0
+          fi
+          THREAD_TS=$(echo "$PARENT_RESP" | jq -r '.ts')
+          if [ -z "$THREAD_TS" ] || [ "$THREAD_TS" = "null" ]; then
+            echo "Parent ts missing – skipping child post"; exit 0
+          fi
+
+          # ===== Step B: post child (chunked body in thread) =====
+          # python で安全に chunk 分割。runner 標準で python3 が入っている。
+          CHILD_PAYLOAD=$(VIEWER_URL="$VIEWER_URL" SLACK_CHANNEL_ID="$SLACK_CHANNEL_ID" THREAD_TS="$THREAD_TS" python3 - <<'PYEOF'
+          import json, os
+          with open('/tmp/slack-message.md', encoding='utf-8') as f:
+              msg = f.read().rstrip()
+          CHUNK = 2800       # Slack mrkdwn block limit 3000 chars 安全側
+          MAX_BLOCKS = 48    # divider + section (viewer link) のために 2 枠残す
+          chunks = [msg[i:i+CHUNK] for i in range(0, len(msg), CHUNK)]
+          truncated = False
+          if len(chunks) > MAX_BLOCKS:
+              chunks = chunks[:MAX_BLOCKS]
+              truncated = True
+          blocks = [{"type": "section", "text": {"type": "mrkdwn", "text": c}} for c in chunks]
+          if truncated:
+              blocks.append({"type": "context", "elements": [{"type": "mrkdwn",
+                  "text": "_…本文が長すぎたため一部省略されました。続きは Web viewer で_"}]})
+          blocks.append({"type": "divider"})
+          blocks.append({"type": "section", "text": {"type": "mrkdwn",
+              "text": f"<{os.environ['VIEWER_URL']}|レポート全文を Web で開く>"}})
+          payload = {
+              "channel": os.environ['SLACK_CHANNEL_ID'],
+              "thread_ts": os.environ['THREAD_TS'],
+              "text": "レポート本文",
+              "blocks": blocks,
+          }
+          print(json.dumps(payload, ensure_ascii=False))
+          PYEOF
+          )
+
+          CHILD_RESP=$(curl -fsS -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            --data "$CHILD_PAYLOAD")
+
+          CHILD_OK=$(echo "$CHILD_RESP" | jq -r '.ok')
+          if [ "$CHILD_OK" != "true" ]; then
+            ERR=$(echo "$CHILD_RESP" | jq -r '.error // "unknown"')
+            echo "Child post failed: $ERR"
+            exit 0
+          fi
+          echo "Posted parent + thread successfully (ts=$THREAD_TS)"

--- a/.github/workflows/report-monthly.yml
+++ b/.github/workflows/report-monthly.yml
@@ -121,77 +121,128 @@ jobs:
             -o /tmp/post-resp.json \
             --data-binary @/tmp/report-payload.json
 
-      - name: Post to Slack
+      - name: Post to Slack (threaded)
         if: ${{ success() }}
         continue-on-error: true
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           WORKER_URL: https://tech-news-bot.rikeda71.workers.dev
         run: |
           set -euo pipefail
-          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
-            echo "SLACK_WEBHOOK_URL not set – skipping Slack notification"
+
+          # required secrets / files の存在チェック (skip 条件)
+          if [ -z "${SLACK_BOT_TOKEN:-}" ] || [ -z "${SLACK_CHANNEL_ID:-}" ]; then
+            echo "SLACK_BOT_TOKEN or SLACK_CHANNEL_ID not set – skipping Slack thread post"
             exit 0
           fi
-          if [ ! -f /tmp/slack-message.md ] || [ ! -f /tmp/post-resp.json ]; then
-            echo "Slack message or post response missing – skipping Slack notification"
+          if [ ! -f /tmp/slack-message.md ] || [ ! -f /tmp/post-resp.json ] || [ ! -f /tmp/report-meta.json ]; then
+            echo "Required files missing – skipping Slack thread post"
             exit 0
           fi
+
           REPORT_ID=$(jq -r '.id' /tmp/post-resp.json)
           if [ -z "$REPORT_ID" ] || [ "$REPORT_ID" = "null" ]; then
-            echo "Could not determine report id – skipping Slack notification"
+            echo "report id missing – skipping"
             exit 0
           fi
           VIEWER_URL="$WORKER_URL/reports/$REPORT_ID"
 
-          # タイトル / 重要度を組み立て (monthly: 🔴)
           KIND=$(jq -r '.kind' /tmp/report-meta.json)
-          PERIOD_START=$(jq -r '.period_start' /tmp/report-meta.json | cut -c1-10)
-          PERIOD_END=$(jq -r '.period_end' /tmp/report-meta.json | cut -c1-10)
-          TITLE="🔴 Monthly Tech Report (${PERIOD_START} 〜 ${PERIOD_END})"
-          IMPORTANCE="重要度: 高"
+          PERIOD_START=$(jq -r '.period_start' /tmp/report-meta.json)
+          PERIOD_END=$(jq -r '.period_end' /tmp/report-meta.json)
           GENERATED_AT=$(jq -r '.generated_at' /tmp/report-meta.json)
 
-          # slack-message.md を 2800 chars 単位の section block 群に変換
-          BLOCKS_JSON=$(node -e "
-            const fs = require('fs');
-            const text = fs.readFileSync('/tmp/slack-message.md', 'utf8');
-            const chunkSize = 2800;
-            const blocks = [];
-            for (let i = 0; i < text.length; i += chunkSize) {
-              blocks.push({ type: 'section', text: { type: 'mrkdwn', text: text.slice(i, i + chunkSize) } });
-            }
-            // 50 block 上限: header(1) + context(1) + divider(1) + chunks + divider(1) + footer(1) = 5 + chunks
-            const maxChunks = 44;
-            const trimmed = blocks.slice(0, maxChunks);
-            process.stdout.write(JSON.stringify(trimmed));
-          ")
+          # Build title (emoji + label + period)
+          case "$KIND" in
+            daily)
+              EMOJI="🟢"; SEVERITY="重要度: 低"; LABEL="Daily"
+              DATE_LABEL=$(echo "$PERIOD_END" | cut -c1-10)
+              TITLE="$EMOJI $LABEL Tech Report ($DATE_LABEL)"
+              ;;
+            weekly)
+              EMOJI="🟡"; SEVERITY="重要度: 中"; LABEL="Weekly"
+              START=$(echo "$PERIOD_START" | cut -c1-10); END=$(echo "$PERIOD_END" | cut -c1-10)
+              TITLE="$EMOJI $LABEL Tech Report ($START 〜 $END)"
+              ;;
+            monthly)
+              EMOJI="🔴"; SEVERITY="重要度: 高"; LABEL="Monthly"
+              START=$(echo "$PERIOD_START" | cut -c1-10); END=$(echo "$PERIOD_END" | cut -c1-10)
+              TITLE="$EMOJI $LABEL Tech Report ($START 〜 $END)"
+              ;;
+            *)
+              echo "Unknown kind $KIND – skipping"; exit 0 ;;
+          esac
 
-          TITLE_ESC=$(jq -Rn --arg v "$TITLE" '$v')
-          IMPORTANCE_ESC=$(jq -Rn --arg v "$IMPORTANCE | generated_at: $GENERATED_AT" '$v')
-          VIEWER_ESC=$(jq -Rn --arg v "— <${VIEWER_URL}|レポート全文を Web で開く>" '$v')
-
-          jq -n \
-            --argjson title "$TITLE_ESC" \
-            --argjson importance "$IMPORTANCE_ESC" \
-            --argjson chunks "$BLOCKS_JSON" \
-            --argjson viewer "$VIEWER_ESC" \
+          # ===== Step A: post parent (title + severity) =====
+          PARENT_PAYLOAD=$(jq -n \
+            --arg ch "$SLACK_CHANNEL_ID" \
+            --arg t "$TITLE" \
+            --arg s "$SEVERITY · generated_at: $GENERATED_AT" \
             '{
-              text: $title,
-              blocks: (
-                [
-                  { type: "header", text: { type: "plain_text", text: $title } },
-                  { type: "context", elements: [{ type: "mrkdwn", text: $importance }] },
-                  { type: "divider" }
-                ]
-                + $chunks
-                + [
-                  { type: "divider" },
-                  { type: "section", text: { type: "mrkdwn", text: $viewer } }
-                ]
-              )
-            }' > /tmp/slack-payload.json
+              channel: $ch,
+              text: $t,
+              blocks: [
+                { type: "header", text: { type: "plain_text", text: $t, emoji: true } },
+                { type: "context", elements: [ { type: "mrkdwn", text: $s } ] }
+              ]
+            }')
 
-          curl -fsS -X POST "$SLACK_WEBHOOK_URL" \
-            -H 'Content-Type: application/json' \
-            --data-binary @/tmp/slack-payload.json
+          PARENT_RESP=$(curl -fsS -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            --data "$PARENT_PAYLOAD")
+
+          PARENT_OK=$(echo "$PARENT_RESP" | jq -r '.ok')
+          if [ "$PARENT_OK" != "true" ]; then
+            ERR=$(echo "$PARENT_RESP" | jq -r '.error // "unknown"')
+            echo "Parent post failed: $ERR"
+            exit 0
+          fi
+          THREAD_TS=$(echo "$PARENT_RESP" | jq -r '.ts')
+          if [ -z "$THREAD_TS" ] || [ "$THREAD_TS" = "null" ]; then
+            echo "Parent ts missing – skipping child post"; exit 0
+          fi
+
+          # ===== Step B: post child (chunked body in thread) =====
+          # python で安全に chunk 分割。runner 標準で python3 が入っている。
+          CHILD_PAYLOAD=$(VIEWER_URL="$VIEWER_URL" SLACK_CHANNEL_ID="$SLACK_CHANNEL_ID" THREAD_TS="$THREAD_TS" python3 - <<'PYEOF'
+          import json, os
+          with open('/tmp/slack-message.md', encoding='utf-8') as f:
+              msg = f.read().rstrip()
+          CHUNK = 2800       # Slack mrkdwn block limit 3000 chars 安全側
+          MAX_BLOCKS = 48    # divider + section (viewer link) のために 2 枠残す
+          chunks = [msg[i:i+CHUNK] for i in range(0, len(msg), CHUNK)]
+          truncated = False
+          if len(chunks) > MAX_BLOCKS:
+              chunks = chunks[:MAX_BLOCKS]
+              truncated = True
+          blocks = [{"type": "section", "text": {"type": "mrkdwn", "text": c}} for c in chunks]
+          if truncated:
+              blocks.append({"type": "context", "elements": [{"type": "mrkdwn",
+                  "text": "_…本文が長すぎたため一部省略されました。続きは Web viewer で_"}]})
+          blocks.append({"type": "divider"})
+          blocks.append({"type": "section", "text": {"type": "mrkdwn",
+              "text": f"<{os.environ['VIEWER_URL']}|レポート全文を Web で開く>"}})
+          payload = {
+              "channel": os.environ['SLACK_CHANNEL_ID'],
+              "thread_ts": os.environ['THREAD_TS'],
+              "text": "レポート本文",
+              "blocks": blocks,
+          }
+          print(json.dumps(payload, ensure_ascii=False))
+          PYEOF
+          )
+
+          CHILD_RESP=$(curl -fsS -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            --data "$CHILD_PAYLOAD")
+
+          CHILD_OK=$(echo "$CHILD_RESP" | jq -r '.ok')
+          if [ "$CHILD_OK" != "true" ]; then
+            ERR=$(echo "$CHILD_RESP" | jq -r '.error // "unknown"')
+            echo "Child post failed: $ERR"
+            exit 0
+          fi
+          echo "Posted parent + thread successfully (ts=$THREAD_TS)"

--- a/.github/workflows/report-weekly.yml
+++ b/.github/workflows/report-weekly.yml
@@ -119,77 +119,128 @@ jobs:
             -o /tmp/post-resp.json \
             --data-binary @/tmp/report-payload.json
 
-      - name: Post to Slack
+      - name: Post to Slack (threaded)
         if: ${{ success() }}
         continue-on-error: true
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           WORKER_URL: https://tech-news-bot.rikeda71.workers.dev
         run: |
           set -euo pipefail
-          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
-            echo "SLACK_WEBHOOK_URL not set – skipping Slack notification"
+
+          # required secrets / files の存在チェック (skip 条件)
+          if [ -z "${SLACK_BOT_TOKEN:-}" ] || [ -z "${SLACK_CHANNEL_ID:-}" ]; then
+            echo "SLACK_BOT_TOKEN or SLACK_CHANNEL_ID not set – skipping Slack thread post"
             exit 0
           fi
-          if [ ! -f /tmp/slack-message.md ] || [ ! -f /tmp/post-resp.json ]; then
-            echo "Slack message or post response missing – skipping Slack notification"
+          if [ ! -f /tmp/slack-message.md ] || [ ! -f /tmp/post-resp.json ] || [ ! -f /tmp/report-meta.json ]; then
+            echo "Required files missing – skipping Slack thread post"
             exit 0
           fi
+
           REPORT_ID=$(jq -r '.id' /tmp/post-resp.json)
           if [ -z "$REPORT_ID" ] || [ "$REPORT_ID" = "null" ]; then
-            echo "Could not determine report id – skipping Slack notification"
+            echo "report id missing – skipping"
             exit 0
           fi
           VIEWER_URL="$WORKER_URL/reports/$REPORT_ID"
 
-          # タイトル / 重要度を組み立て (weekly: 🟡)
           KIND=$(jq -r '.kind' /tmp/report-meta.json)
-          PERIOD_START=$(jq -r '.period_start' /tmp/report-meta.json | cut -c1-10)
-          PERIOD_END=$(jq -r '.period_end' /tmp/report-meta.json | cut -c1-10)
-          TITLE="🟡 Weekly Tech Report (${PERIOD_START} 〜 ${PERIOD_END})"
-          IMPORTANCE="重要度: 中"
+          PERIOD_START=$(jq -r '.period_start' /tmp/report-meta.json)
+          PERIOD_END=$(jq -r '.period_end' /tmp/report-meta.json)
           GENERATED_AT=$(jq -r '.generated_at' /tmp/report-meta.json)
 
-          # slack-message.md を 2800 chars 単位の section block 群に変換
-          BLOCKS_JSON=$(node -e "
-            const fs = require('fs');
-            const text = fs.readFileSync('/tmp/slack-message.md', 'utf8');
-            const chunkSize = 2800;
-            const blocks = [];
-            for (let i = 0; i < text.length; i += chunkSize) {
-              blocks.push({ type: 'section', text: { type: 'mrkdwn', text: text.slice(i, i + chunkSize) } });
-            }
-            // 50 block 上限: header(1) + context(1) + divider(1) + chunks + divider(1) + footer(1) = 5 + chunks
-            const maxChunks = 44;
-            const trimmed = blocks.slice(0, maxChunks);
-            process.stdout.write(JSON.stringify(trimmed));
-          ")
+          # Build title (emoji + label + period)
+          case "$KIND" in
+            daily)
+              EMOJI="🟢"; SEVERITY="重要度: 低"; LABEL="Daily"
+              DATE_LABEL=$(echo "$PERIOD_END" | cut -c1-10)
+              TITLE="$EMOJI $LABEL Tech Report ($DATE_LABEL)"
+              ;;
+            weekly)
+              EMOJI="🟡"; SEVERITY="重要度: 中"; LABEL="Weekly"
+              START=$(echo "$PERIOD_START" | cut -c1-10); END=$(echo "$PERIOD_END" | cut -c1-10)
+              TITLE="$EMOJI $LABEL Tech Report ($START 〜 $END)"
+              ;;
+            monthly)
+              EMOJI="🔴"; SEVERITY="重要度: 高"; LABEL="Monthly"
+              START=$(echo "$PERIOD_START" | cut -c1-10); END=$(echo "$PERIOD_END" | cut -c1-10)
+              TITLE="$EMOJI $LABEL Tech Report ($START 〜 $END)"
+              ;;
+            *)
+              echo "Unknown kind $KIND – skipping"; exit 0 ;;
+          esac
 
-          TITLE_ESC=$(jq -Rn --arg v "$TITLE" '$v')
-          IMPORTANCE_ESC=$(jq -Rn --arg v "$IMPORTANCE | generated_at: $GENERATED_AT" '$v')
-          VIEWER_ESC=$(jq -Rn --arg v "— <${VIEWER_URL}|レポート全文を Web で開く>" '$v')
-
-          jq -n \
-            --argjson title "$TITLE_ESC" \
-            --argjson importance "$IMPORTANCE_ESC" \
-            --argjson chunks "$BLOCKS_JSON" \
-            --argjson viewer "$VIEWER_ESC" \
+          # ===== Step A: post parent (title + severity) =====
+          PARENT_PAYLOAD=$(jq -n \
+            --arg ch "$SLACK_CHANNEL_ID" \
+            --arg t "$TITLE" \
+            --arg s "$SEVERITY · generated_at: $GENERATED_AT" \
             '{
-              text: $title,
-              blocks: (
-                [
-                  { type: "header", text: { type: "plain_text", text: $title } },
-                  { type: "context", elements: [{ type: "mrkdwn", text: $importance }] },
-                  { type: "divider" }
-                ]
-                + $chunks
-                + [
-                  { type: "divider" },
-                  { type: "section", text: { type: "mrkdwn", text: $viewer } }
-                ]
-              )
-            }' > /tmp/slack-payload.json
+              channel: $ch,
+              text: $t,
+              blocks: [
+                { type: "header", text: { type: "plain_text", text: $t, emoji: true } },
+                { type: "context", elements: [ { type: "mrkdwn", text: $s } ] }
+              ]
+            }')
 
-          curl -fsS -X POST "$SLACK_WEBHOOK_URL" \
-            -H 'Content-Type: application/json' \
-            --data-binary @/tmp/slack-payload.json
+          PARENT_RESP=$(curl -fsS -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            --data "$PARENT_PAYLOAD")
+
+          PARENT_OK=$(echo "$PARENT_RESP" | jq -r '.ok')
+          if [ "$PARENT_OK" != "true" ]; then
+            ERR=$(echo "$PARENT_RESP" | jq -r '.error // "unknown"')
+            echo "Parent post failed: $ERR"
+            exit 0
+          fi
+          THREAD_TS=$(echo "$PARENT_RESP" | jq -r '.ts')
+          if [ -z "$THREAD_TS" ] || [ "$THREAD_TS" = "null" ]; then
+            echo "Parent ts missing – skipping child post"; exit 0
+          fi
+
+          # ===== Step B: post child (chunked body in thread) =====
+          # python で安全に chunk 分割。runner 標準で python3 が入っている。
+          CHILD_PAYLOAD=$(VIEWER_URL="$VIEWER_URL" SLACK_CHANNEL_ID="$SLACK_CHANNEL_ID" THREAD_TS="$THREAD_TS" python3 - <<'PYEOF'
+          import json, os
+          with open('/tmp/slack-message.md', encoding='utf-8') as f:
+              msg = f.read().rstrip()
+          CHUNK = 2800       # Slack mrkdwn block limit 3000 chars 安全側
+          MAX_BLOCKS = 48    # divider + section (viewer link) のために 2 枠残す
+          chunks = [msg[i:i+CHUNK] for i in range(0, len(msg), CHUNK)]
+          truncated = False
+          if len(chunks) > MAX_BLOCKS:
+              chunks = chunks[:MAX_BLOCKS]
+              truncated = True
+          blocks = [{"type": "section", "text": {"type": "mrkdwn", "text": c}} for c in chunks]
+          if truncated:
+              blocks.append({"type": "context", "elements": [{"type": "mrkdwn",
+                  "text": "_…本文が長すぎたため一部省略されました。続きは Web viewer で_"}]})
+          blocks.append({"type": "divider"})
+          blocks.append({"type": "section", "text": {"type": "mrkdwn",
+              "text": f"<{os.environ['VIEWER_URL']}|レポート全文を Web で開く>"}})
+          payload = {
+              "channel": os.environ['SLACK_CHANNEL_ID'],
+              "thread_ts": os.environ['THREAD_TS'],
+              "text": "レポート本文",
+              "blocks": blocks,
+          }
+          print(json.dumps(payload, ensure_ascii=False))
+          PYEOF
+          )
+
+          CHILD_RESP=$(curl -fsS -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            --data "$CHILD_PAYLOAD")
+
+          CHILD_OK=$(echo "$CHILD_RESP" | jq -r '.ok')
+          if [ "$CHILD_OK" != "true" ]; then
+            ERR=$(echo "$CHILD_RESP" | jq -r '.error // "unknown"')
+            echo "Child post failed: $ERR"
+            exit 0
+          fi
+          echo "Posted parent + thread successfully (ts=$THREAD_TS)"

--- a/docs/reports-pipeline.md
+++ b/docs/reports-pipeline.md
@@ -20,7 +20,7 @@ D1 (本番) ── articles
 Worker (Hono)
    ↓ 5. upsertReport → レスポンス { ok, id } を /tmp/post-resp.json に保存
 D1 (本番) ── reports
-   ↓ 6. GH Actions → Slack (LLM が生成した /tmp/slack-message.md に viewer URL を付与して webhook に投稿)
+   ↓ 6. GH Actions → Slack (Bot Token + chat.postMessage API でスレッド投稿: 親=タイトル+重要度 / 子=本文)
 Slack
 ```
 
@@ -143,7 +143,7 @@ CORS は付けず、Bearer `ADMIN_TOKEN` (rotation 中は `ADMIN_TOKEN_NEXT` も
    - env: `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID` (recent.mjs が wrangler 経由で D1 にアクセスする際に必要)
    - prompt: skill 起動 + `/tmp/report.md` / `/tmp/report-meta.json` / `/tmp/slack-message.md` への書き出しを指示
 3. `jq` で markdown と meta JSON を 1 つの payload にまとめ、`curl POST /api/admin/reports` で Worker に投入 (レスポンスを `/tmp/post-resp.json` に保存)
-4. `Post to Slack` ステップで blocks payload を組み立て incoming webhook に投稿
+4. `Post to Slack (threaded)` ステップで Slack Bot Token + `chat.postMessage` API を使い、親メッセージ (タイトル + 重要度) を投稿後、`thread_ts` を取得して本文を thread にぶら下げる
 
 **カテゴリ複数取得パターン**: `recent.mjs` はカンマ区切り複数指定に非対応のため、カテゴリごとに呼んで URL で de-dup する:
 
@@ -166,13 +166,15 @@ meta_json の `included_categories` にカバーしたカテゴリ配列を記�
 
 repository secrets に以下を登録する。
 
-| Secret                    | 用途                                                 | 取得元                                          |
-| ------------------------- | ---------------------------------------------------- | ----------------------------------------------- |
-| `CLAUDE_CODE_OAUTH_TOKEN` | `claude-code-base-action` の認証 (subscription 経由) | `claude /install-github-app` で発行             |
-| `WORKER_ADMIN_TOKEN`      | `/api/admin/reports` の Bearer 認証                  | `openssl rand -hex 32` などで生成 (GH 側で管理) |
-| `CLOUDFLARE_API_TOKEN`    | `wrangler d1 execute --remote` を打つために必要      | Cloudflare dashboard → API Tokens               |
-| `CLOUDFLARE_ACCOUNT_ID`   | wrangler の account 自動選択                         | Cloudflare dashboard                            |
-| `SLACK_WEBHOOK_URL`       | Slack 投稿 (incoming webhook)                        | Slack ワークスペースで incoming webhook を作成  |
+| Secret                    | 用途                                                                 | 取得元                                                             |
+| ------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `CLAUDE_CODE_OAUTH_TOKEN` | `claude-code-base-action` の認証 (subscription 経由)                 | `claude /install-github-app` で発行                                |
+| `WORKER_ADMIN_TOKEN`      | `/api/admin/reports` の Bearer 認証                                  | `openssl rand -hex 32` などで生成 (GH 側で管理)                    |
+| `CLOUDFLARE_API_TOKEN`    | `wrangler d1 execute --remote` を打つために必要                      | Cloudflare dashboard → API Tokens                                  |
+| `CLOUDFLARE_ACCOUNT_ID`   | wrangler の account 自動選択                                         | Cloudflare dashboard                                               |
+| `SLACK_BOT_TOKEN`         | report workflow の Slack スレッド投稿 (`chat.postMessage` API)       | Slack App 管理画面 → OAuth & Permissions → Bot Token (`xoxb-...`)  |
+| `SLACK_CHANNEL_ID`        | report workflow の投稿先 channel ID (= `CTPQ8SP98`)                  | Slack channel の URL または右クリック → Copy link から取得         |
+| `SLACK_WEBHOOK_URL`       | collector 日次ダイジェスト用 (apps/web/worker/notify/slack-daily.ts) | Slack ワークスペースで incoming webhook を作成 (report では未使用) |
 
 `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` は既に deploy workflow で使っている
 ものを流用できる。
@@ -232,20 +234,30 @@ UNIQUE index が `(kind, period, category)` で張られているため、catego
 ## Slack 通知
 
 Slack への投稿は Worker ではなく GitHub Actions 側で行う。
+Slack Bot Token + `chat.postMessage` API を使い、**スレッド化した 2 段構成**で投稿する。
 
 フロー:
 
 1. Skill (Claude Code) が `/tmp/slack-message.md` を生成 (Slack mrkdwn 形式、30000 文字以内)
 2. `Save report to D1` ステップで POST レスポンス (`{ ok, id }`) を `/tmp/post-resp.json` に保存
-3. `Post to Slack` ステップが blocks payload を組み立てて Slack incoming webhook に投稿
+3. `Post to Slack (threaded)` ステップが 2 段階の `chat.postMessage` を実行:
+   - **Step A (親メッセージ)**: タイトル + 重要度を header/context block で投稿。レスポンスの `.ts` を取得
+   - **Step B (子メッセージ)**: 取得した `ts` を `thread_ts` に指定し、`slack-message.md` を chunks に分割して thread にぶら下げる
 
 ### Blocks payload 構造
 
+**親メッセージ** (`chat.postMessage`):
+
 ```
 header block   : 🟢/🟡/🔴 + 種別 + 期間
-context block  : 重要度テキスト + generated_at
-divider
-section block × N : slack-message.md を 2800 chars 単位でチャンク分割
+context block  : 重要度テキスト · generated_at
+```
+
+**子メッセージ** (thread_ts 付き `chat.postMessage`):
+
+```
+section block × N : slack-message.md を 2800 chars 単位でチャンク分割 (最大 48 チャンク)
+[context block    : 省略された場合の注記 (超過時のみ)]
 divider
 section block  : レポート全文を Web で開く (viewer URL)
 ```
@@ -260,18 +272,30 @@ section block  : レポート全文を Web で開く (viewer URL)
 
 特性:
 
-- 6000 文字制限は撤廃。30000 文字以内を推奨上限とし、blocks 分割で長文に対応
-- blocks 総数は最大 50 (Slack 制約)。チャンク数は上限 44 に制限し、固定ブロック 5 個と合わせて 49 以下に収まる
-- スレッド投稿は incoming webhook の仕様で不可 (`thread_ts` 非対応)。将来必要になれば bot token (`xoxb-`) + `chat.postMessage` に移行する
-- `SLACK_WEBHOOK_URL` が未設定の場合は no-op でスキップ (投稿しないだけで workflow は正常終了)
-- `continue-on-error: true` を付けているため、Slack 投稿が失敗 (non-2xx / timeout) しても workflow 全体が fail しない
-- webhook URL リテラルをコードに埋め込まない。`${{ secrets.SLACK_WEBHOOK_URL }}` 経由でのみ参照する
+- 30000 文字以内を推奨上限とし、blocks 分割で長文に対応
+- 子メッセージの blocks 総数は最大 50 (Slack 制約)。チャンク数は上限 48 に制限し、divider + viewer link の 2 枠を確保
+- `SLACK_BOT_TOKEN` または `SLACK_CHANNEL_ID` が未設定の場合は no-op でスキップ (投稿しないだけで workflow は正常終了)
+- `continue-on-error: true` を付けているため、Slack 投稿が失敗しても workflow 全体が fail しない
+- bot token リテラルをコードに埋め込まない。`${{ secrets.SLACK_BOT_TOKEN }}` 経由でのみ参照する
+- **bot を channel に invite する必要がある**: Slack ワークスペースで `/invite @<bot名>` を channel (CTPQ8SP98) で実行しないと `not_in_channel` エラーになる
+
+> **注**: `apps/web/worker/notify/slack-daily.ts` (collector の日次ダイジェスト) は引き続き
+> `SLACK_WEBHOOK_URL` (incoming webhook) を使用する。この webhook は削除しないこと。
 
 ### 設定方法
 
 ```bash
-gh secret set SLACK_WEBHOOK_URL
-# プロンプトに Slack incoming webhook URL を入力
+# Slack App を作成して Bot Token (xoxb-...) を取得し登録する
+gh secret set SLACK_BOT_TOKEN
+# プロンプトに xoxb-... トークンを入力
+
+# SLACK_CHANNEL_ID は登録済み (CTPQ8SP98)
+# 未登録の場合:
+gh secret set SLACK_CHANNEL_ID
+# プロンプトに CTPQ8SP98 を入力
+
+# Slack App に chat:write スコープを付与し、bot を channel に invite:
+# Slack ワークスペース内で /invite @<bot名> を CTPQ8SP98 channel で実行
 ```
 
 ---


### PR DESCRIPTION
## Summary

- `report-{daily,weekly,monthly}.yml` の `Post to Slack` ステップを `chat.postMessage` API を使ったスレッド化投稿に切り替え
- `SLACK_WEBHOOK_URL` (collector 日次ダイジェスト用) は削除せず維持
- `docs/reports-pipeline.md` の Slack 通知節と GitHub Secrets 表を更新

## 背景

incoming webhook では `thread_ts` に非対応で、レスポンスから `ts` を取得できないためスレッド投稿が不可能。
Slack Bot Token + `chat.postMessage` API に切り替えることで、親メッセージ (タイトル + 重要度) → 子メッセージ (本文) のスレッド構成を実現する。

## 変更点

- `.github/workflows/report-daily.yml`: `Post to Slack` → `Post to Slack (threaded)` に置き換え
- `.github/workflows/report-weekly.yml`: 同上
- `.github/workflows/report-monthly.yml`: 同上
- `docs/reports-pipeline.md`: Slack 通知節・全体像フロー・GitHub Secrets 表を更新

各 workflow の新ステップは以下の構造:
1. `SLACK_BOT_TOKEN` / `SLACK_CHANNEL_ID` 未設定時は no-op でスキップ
2. **Step A**: `chat.postMessage` で親メッセージ (header block + context block) を投稿。`.ts` を取得
3. **Step B**: python3 で `slack-message.md` を 2800 chars 単位に chunk 分割し、`thread_ts` 付きで子メッセージとして投稿。末尾に viewer URL リンク

## Test plan

- [x] `pnpm build` pass
- [x] `pnpm typecheck` pass
- [x] `pnpm lint` pass (warning 5 件は既存)
- [x] `pnpm format` pass
- [x] `pnpm test` pass (544 tests)
- [x] YAML 構文チェック 3 ファイルすべて OK (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] ローカル payload smoke test:
  - PARENT_PAYLOAD: `{"channel":"CTPQ8SP98","text":"🟢 Daily Tech Report (2026-04-29)","blocks":[{"type":"header",...},{"type":"context",...}]}`
  - CHILD_PAYLOAD: blocks 数 4 (2 chunks + divider + viewer link)、最大 mrkdwn 長 2800 chars 以内
  - daily / weekly / monthly 全種で TITLE / EMOJI / SEVERITY が正しいことを確認
- [ ] merge 後に `SLACK_BOT_TOKEN` を GH secret 登録 → Slack App に `chat:write` スコープ付与 → bot を CTPQ8SP98 channel に `/invite` → `workflow_dispatch` で動作確認

Closes #321

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Enhancements**
  * Slack notifications for daily, weekly, and monthly reports now use threaded messages for improved message organization and readability
  * Enhanced error handling and validation for Slack notification delivery

* **Documentation**
  * Updated pipeline documentation to reflect new Slack Bot API configuration requirements and threaded message behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->