### PR TITLE
refactor(db): consolidate cursor pagination in articles.ts

### DIFF
--- a/apps/web/worker/db/articles.ts
+++ b/apps/web/worker/db/articles.ts
@@ -1,5 +1,51 @@
 import type { Article, FeedCategory, FeedLang } from "../types";
 
+// ---------------------------------------------------------------------------
+// 共通定数 / ヘルパー (内部使用のみ)
+// ---------------------------------------------------------------------------
+
+/** cursor ページネーションで使う SELECT カラム一覧 */
+const ARTICLES_SELECT_FIELDS = `a.id, a.guid, a.feed_id, f.name AS feed_name, a.title, a.url, a.summary,
+           a.author, a.published_at, a.fetched_at, a.category, a.lang`;
+
+/** articles + feeds の FROM / JOIN 句 */
+const ARTICLES_FROM_JOIN = `FROM articles a
+    LEFT JOIN feeds f ON f.id = a.feed_id`;
+
+type Cursor = { publishedAt: string; id: number };
+
+/**
+ * cursor 条件を conds / binds に追記する。
+ * cursor がない場合は何もしない。
+ */
+function appendCursorCondition(
+  conds: string[],
+  binds: unknown[],
+  cursor: Cursor | null | undefined,
+): void {
+  if (!cursor) return;
+  conds.push(
+    `(a.published_at < ?${binds.length + 1} OR (a.published_at = ?${binds.length + 1} AND a.id < ?${binds.length + 2}))`,
+  );
+  binds.push(cursor.publishedAt, cursor.id);
+}
+
+/**
+ * DB から取得した rows を limit と比較して { articles, nextCursor } に変換する。
+ * DB には limit+1 件をリクエストしており、超えていればカーソルを生成して slice する。
+ */
+function extractWithCursor(
+  rows: Article[],
+  limit: number,
+): { articles: Article[]; nextCursor: Cursor | null } {
+  if (rows.length <= limit) {
+    return { articles: rows, nextCursor: null };
+  }
+  const articles = rows.slice(0, limit);
+  const last = articles[articles.length - 1];
+  return { articles, nextCursor: { publishedAt: last.published_at, id: last.id } };
+}
+
 export interface InsertableArticle {
   guid: string;
   feed_id: string;
@@ -98,14 +144,7 @@ export async function listArticles(
     conds.push(`a.published_at <= ?${binds.length + 1}`);
     binds.push(params.dateTo);
   }
-  if (params.cursor) {
-    conds.push(
-      `(a.published_at < ?${binds.length + 1} OR (a.published_at = ?${binds.length + 1} AND a.id < ?${binds.length + 2}))`,
-    );
-    binds.push(params.cursor.publishedAt, params.cursor.id);
-  }
-
-  let sql: string;
+  appendCursorCondition(conds, binds, params.cursor);
   if (params.q && params.q.trim()) {
     conds.push(
       `a.id IN (SELECT rowid FROM articles_fts WHERE articles_fts MATCH ?${binds.length + 1})`,
@@ -114,11 +153,9 @@ export async function listArticles(
   }
 
   const where = conds.length > 0 ? `WHERE ${conds.join(" AND ")}` : "";
-  sql = `
-    SELECT a.id, a.guid, a.feed_id, f.name AS feed_name, a.title, a.url, a.summary,
-           a.author, a.published_at, a.fetched_at, a.category, a.lang
-    FROM articles a
-    LEFT JOIN feeds f ON f.id = a.feed_id
+  const sql = `
+    SELECT ${ARTICLES_SELECT_FIELDS}
+    ${ARTICLES_FROM_JOIN}
     ${where}
     ORDER BY a.published_at DESC, a.id DESC
     LIMIT ?${binds.length + 1}
@@ -129,16 +166,7 @@ export async function listArticles(
     .prepare(sql)
     .bind(...binds)
     .all<Article>();
-
-  const rows = result.results ?? [];
-  let nextCursor: { publishedAt: string; id: number } | null = null;
-  let articles = rows;
-  if (rows.length > limit) {
-    articles = rows.slice(0, limit);
-    const last = articles[articles.length - 1];
-    nextCursor = { publishedAt: last.published_at, id: last.id };
-  }
-  return { articles, nextCursor };
+  return extractWithCursor(result.results ?? [], limit);
 }
 
 export interface GetRandomArticlesParams {
@@ -170,10 +198,8 @@ export async function getRandomArticles(
 
   const where = conds.length > 0 ? `WHERE ${conds.join(" AND ")}` : "";
   const sql = `
-    SELECT a.id, a.guid, a.feed_id, f.name AS feed_name, a.title, a.url, a.summary,
-           a.author, a.published_at, a.fetched_at, a.category, a.lang
-    FROM articles a
-    LEFT JOIN feeds f ON f.id = a.feed_id
+    SELECT ${ARTICLES_SELECT_FIELDS}
+    ${ARTICLES_FROM_JOIN}
     ${where}
     ORDER BY RANDOM()
     LIMIT ?${binds.length + 1}
@@ -184,17 +210,14 @@ export async function getRandomArticles(
     .prepare(sql)
     .bind(...binds)
     .all<Article>();
-
   return result.results ?? [];
 }
 
 export async function getArticleById(db: D1Database, id: number): Promise<Article | null> {
   const result = await db
     .prepare(
-      `SELECT a.id, a.guid, a.feed_id, f.name AS feed_name, a.title, a.url, a.summary,
-              a.author, a.published_at, a.fetched_at, a.category, a.lang
-       FROM articles a
-       LEFT JOIN feeds f ON f.id = a.feed_id
+      `SELECT ${ARTICLES_SELECT_FIELDS}
+       ${ARTICLES_FROM_JOIN}
        WHERE a.id = ?1
        LIMIT 1`,
     )
@@ -206,10 +229,8 @@ export async function getArticleById(db: D1Database, id: number): Promise<Articl
 export async function findArticleByGuid(db: D1Database, guid: string): Promise<Article | null> {
   const result = await db
     .prepare(
-      `SELECT a.id, a.guid, a.feed_id, f.name AS feed_name, a.title, a.url, a.summary,
-              a.author, a.published_at, a.fetched_at, a.category, a.lang
-       FROM articles a
-       LEFT JOIN feeds f ON f.id = a.feed_id
+      `SELECT ${ARTICLES_SELECT_FIELDS}
+       ${ARTICLES_FROM_JOIN}
        WHERE a.guid = ?1
        LIMIT 1`,
     )
@@ -234,10 +255,8 @@ export async function getRelatedArticles(
   // 同じ feed_id の記事を published_at 降順で n 件取得 (対象自身除外)
   const sameFeedRows = await db
     .prepare(
-      `SELECT a.id, a.guid, a.feed_id, f.name AS feed_name, a.title, a.url, a.summary,
-              a.author, a.published_at, a.fetched_at, a.category, a.lang
-       FROM articles a
-       LEFT JOIN feeds f ON f.id = a.feed_id
+      `SELECT ${ARTICLES_SELECT_FIELDS}
+       ${ARTICLES_FROM_JOIN}
        WHERE a.feed_id = ?1 AND a.guid != ?2
        ORDER BY a.published_at DESC
        LIMIT ?3`,
@@ -256,10 +275,8 @@ export async function getRelatedArticles(
   const placeholders = excludeGuids.map((_, i) => `?${i + 3}`).join(",");
   const sameCategoryRows = await db
     .prepare(
-      `SELECT a.id, a.guid, a.feed_id, f.name AS feed_name, a.title, a.url, a.summary,
-              a.author, a.published_at, a.fetched_at, a.category, a.lang
-       FROM articles a
-       LEFT JOIN feeds f ON f.id = a.feed_id
+      `SELECT ${ARTICLES_SELECT_FIELDS}
+       ${ARTICLES_FROM_JOIN}
        WHERE a.category = ?1 AND a.feed_id != ?2 AND a.guid NOT IN (${placeholders})
        ORDER BY a.published_at DESC
        LIMIT ?${excludeGuids.length + 3}`,
@@ -289,10 +306,8 @@ export async function getNeighbors(db: D1Database, guid: string): Promise<Neighb
   const [prevResult, nextResult] = await Promise.all([
     db
       .prepare(
-        `SELECT a.id, a.guid, a.feed_id, f.name AS feed_name, a.title, a.url, a.summary,
-                a.author, a.published_at, a.fetched_at, a.category, a.lang
-         FROM articles a
-         LEFT JOIN feeds f ON f.id = a.feed_id
+        `SELECT ${ARTICLES_SELECT_FIELDS}
+         ${ARTICLES_FROM_JOIN}
          WHERE a.feed_id = ?1
            AND (a.published_at < ?2 OR (a.published_at = ?2 AND a.guid < ?3))
          ORDER BY a.published_at DESC, a.guid DESC
@@ -302,10 +317,8 @@ export async function getNeighbors(db: D1Database, guid: string): Promise<Neighb
       .first<Article>(),
     db
       .prepare(
-        `SELECT a.id, a.guid, a.feed_id, f.name AS feed_name, a.title, a.url, a.summary,
-                a.author, a.published_at, a.fetched_at, a.category, a.lang
-         FROM articles a
-         LEFT JOIN feeds f ON f.id = a.feed_id
+        `SELECT ${ARTICLES_SELECT_FIELDS}
+         ${ARTICLES_FROM_JOIN}
          WHERE a.feed_id = ?1
            AND (a.published_at > ?2 OR (a.published_at = ?2 AND a.guid > ?3))
          ORDER BY a.published_at ASC, a.guid ASC
@@ -492,10 +505,8 @@ export async function getArticlesByMonth(
 
   const where = `WHERE ${conds.join(" AND ")}`;
   const sql = `
-    SELECT a.id, a.guid, a.feed_id, f.name AS feed_name, a.title, a.url, a.summary,
-           a.author, a.published_at, a.fetched_at, a.category, a.lang
-    FROM articles a
-    LEFT JOIN feeds f ON f.id = a.feed_id
+    SELECT ${ARTICLES_SELECT_FIELDS}
+    ${ARTICLES_FROM_JOIN}
     ${where}
     ORDER BY a.published_at DESC, a.id DESC
     LIMIT ?${binds.length + 1}
@@ -506,7 +517,6 @@ export async function getArticlesByMonth(
     .prepare(sql)
     .bind(...binds)
     .all<Article>();
-
   return result.results ?? [];
 }
 
@@ -562,19 +572,12 @@ export async function getArticlesByFeed(
   const conds: string[] = [`a.feed_id = ?1`];
   const binds: unknown[] = [feedId];
 
-  if (cursor) {
-    conds.push(
-      `(a.published_at < ?${binds.length + 1} OR (a.published_at = ?${binds.length + 1} AND a.id < ?${binds.length + 2}))`,
-    );
-    binds.push(cursor.publishedAt, cursor.id);
-  }
+  appendCursorCondition(conds, binds, cursor);
 
   const where = `WHERE ${conds.join(" AND ")}`;
   const sql = `
-    SELECT a.id, a.guid, a.feed_id, f.name AS feed_name, a.title, a.url, a.summary,
-           a.author, a.published_at, a.fetched_at, a.category, a.lang
-    FROM articles a
-    LEFT JOIN feeds f ON f.id = a.feed_id
+    SELECT ${ARTICLES_SELECT_FIELDS}
+    ${ARTICLES_FROM_JOIN}
     ${where}
     ORDER BY a.published_at DESC, a.id DESC
     LIMIT ?${binds.length + 1}
@@ -585,16 +588,7 @@ export async function getArticlesByFeed(
     .prepare(sql)
     .bind(...binds)
     .all<Article>();
-
-  const rows = result.results ?? [];
-  let nextCursor: { publishedAt: string; id: number } | null = null;
-  let articles = rows;
-  if (rows.length > limit) {
-    articles = rows.slice(0, limit);
-    const last = articles[articles.length - 1];
-    nextCursor = { publishedAt: last.published_at, id: last.id };
-  }
-  return { articles, nextCursor };
+  return extractWithCursor(result.results ?? [], limit);
 }
 
 export interface GetArticlesByAuthorResult {
@@ -612,19 +606,12 @@ export async function getArticlesByAuthor(
   const conds: string[] = [`a.author = ?1`];
   const binds: unknown[] = [author];
 
-  if (cursor) {
-    conds.push(
-      `(a.published_at < ?${binds.length + 1} OR (a.published_at = ?${binds.length + 1} AND a.id < ?${binds.length + 2}))`,
-    );
-    binds.push(cursor.publishedAt, cursor.id);
-  }
+  appendCursorCondition(conds, binds, cursor);
 
   const where = `WHERE ${conds.join(" AND ")}`;
   const sql = `
-    SELECT a.id, a.guid, a.feed_id, f.name AS feed_name, a.title, a.url, a.summary,
-           a.author, a.published_at, a.fetched_at, a.category, a.lang
-    FROM articles a
-    LEFT JOIN feeds f ON f.id = a.feed_id
+    SELECT ${ARTICLES_SELECT_FIELDS}
+    ${ARTICLES_FROM_JOIN}
     ${where}
     ORDER BY a.published_at DESC, a.id DESC
     LIMIT ?${binds.length + 1}
@@ -635,16 +622,7 @@ export async function getArticlesByAuthor(
     .prepare(sql)
     .bind(...binds)
     .all<Article>();
-
-  const rows = result.results ?? [];
-  let nextCursor: { publishedAt: string; id: number } | null = null;
-  let articles = rows;
-  if (rows.length > limit) {
-    articles = rows.slice(0, limit);
-    const last = articles[articles.length - 1];
-    nextCursor = { publishedAt: last.published_at, id: last.id };
-  }
-  return { articles, nextCursor };
+  return extractWithCursor(result.results ?? [], limit);
 }
 
 export interface CalendarItem {
@@ -703,19 +681,12 @@ export async function getArticlesByCategory(
   const conds: string[] = [`a.category = ?1`];
   const binds: unknown[] = [category];
 
-  if (cursor) {
-    conds.push(
-      `(a.published_at < ?${binds.length + 1} OR (a.published_at = ?${binds.length + 1} AND a.id < ?${binds.length + 2}))`,
-    );
-    binds.push(cursor.publishedAt, cursor.id);
-  }
+  appendCursorCondition(conds, binds, cursor);
 
   const where = `WHERE ${conds.join(" AND ")}`;
   const sql = `
-    SELECT a.id, a.guid, a.feed_id, f.name AS feed_name, a.title, a.url, a.summary,
-           a.author, a.published_at, a.fetched_at, a.category, a.lang
-    FROM articles a
-    LEFT JOIN feeds f ON f.id = a.feed_id
+    SELECT ${ARTICLES_SELECT_FIELDS}
+    ${ARTICLES_FROM_JOIN}
     ${where}
     ORDER BY a.published_at DESC, a.id DESC
     LIMIT ?${binds.length + 1}
@@ -726,16 +697,7 @@ export async function getArticlesByCategory(
     .prepare(sql)
     .bind(...binds)
     .all<Article>();
-
-  const rows = result.results ?? [];
-  let nextCursor: { publishedAt: string; id: number } | null = null;
-  let articles = rows;
-  if (rows.length > limit) {
-    articles = rows.slice(0, limit);
-    const last = articles[articles.length - 1];
-    nextCursor = { publishedAt: last.published_at, id: last.id };
-  }
-  return { articles, nextCursor };
+  return extractWithCursor(result.results ?? [], limit);
 }
 
 export interface GetArticlesByDayResult {
@@ -754,19 +716,12 @@ export async function getArticlesByDay(
   const conds: string[] = [`a.published_at >= ?1`, `a.published_at < ?2`];
   const binds: unknown[] = [startIso, endIso];
 
-  if (cursor) {
-    conds.push(
-      `(a.published_at < ?${binds.length + 1} OR (a.published_at = ?${binds.length + 1} AND a.id < ?${binds.length + 2}))`,
-    );
-    binds.push(cursor.publishedAt, cursor.id);
-  }
+  appendCursorCondition(conds, binds, cursor);
 
   const where = `WHERE ${conds.join(" AND ")}`;
   const sql = `
-    SELECT a.id, a.guid, a.feed_id, f.name AS feed_name, a.title, a.url, a.summary,
-           a.author, a.published_at, a.fetched_at, a.category, a.lang
-    FROM articles a
-    LEFT JOIN feeds f ON f.id = a.feed_id
+    SELECT ${ARTICLES_SELECT_FIELDS}
+    ${ARTICLES_FROM_JOIN}
     ${where}
     ORDER BY a.published_at DESC, a.id DESC
     LIMIT ?${binds.length + 1}
@@ -777,16 +732,7 @@ export async function getArticlesByDay(
     .prepare(sql)
     .bind(...binds)
     .all<Article>();
-
-  const rows = result.results ?? [];
-  let nextCursor: { publishedAt: string; id: number } | null = null;
-  let articles = rows;
-  if (rows.length > limit) {
-    articles = rows.slice(0, limit);
-    const last = articles[articles.length - 1];
-    nextCursor = { publishedAt: last.published_at, id: last.id };
-  }
-  return { articles, nextCursor };
+  return extractWithCursor(result.results ?? [], limit);
 }
 
 /** 指定日 (UTC) の総記事数を返す */
@@ -830,19 +776,12 @@ export async function searchArticles(
     binds.push(`%${escaped}%`);
   }
 
-  if (cursor) {
-    conds.push(
-      `(a.published_at < ?${binds.length + 1} OR (a.published_at = ?${binds.length + 1} AND a.id < ?${binds.length + 2}))`,
-    );
-    binds.push(cursor.publishedAt, cursor.id);
-  }
+  appendCursorCondition(conds, binds, cursor);
 
   const where = conds.length > 0 ? `WHERE ${conds.join(" AND ")}` : "";
   const sql = `
-    SELECT a.id, a.guid, a.feed_id, f.name AS feed_name, a.title, a.url, a.summary,
-           a.author, a.published_at, a.fetched_at, a.category, a.lang
-    FROM articles a
-    LEFT JOIN feeds f ON f.id = a.feed_id
+    SELECT ${ARTICLES_SELECT_FIELDS}
+    ${ARTICLES_FROM_JOIN}
     ${where}
     ORDER BY a.published_at DESC, a.id DESC
     LIMIT ?${binds.length + 1}
@@ -853,16 +792,7 @@ export async function searchArticles(
     .prepare(sql)
     .bind(...binds)
     .all<Article>();
-
-  const rows = result.results ?? [];
-  let nextCursor: { publishedAt: string; id: number } | null = null;
-  let articles = rows;
-  if (rows.length > limit) {
-    articles = rows.slice(0, limit);
-    const last = articles[articles.length - 1];
-    nextCursor = { publishedAt: last.published_at, id: last.id };
-  }
-  return { articles, nextCursor };
+  return extractWithCursor(result.results ?? [], limit);
 }
 
 function escapeFtsQuery(input: string): string {

--- a/apps/web/worker/db/articles.ts
+++ b/apps/web/worker/db/articles.ts
@@ -9,10 +9,9 @@ const ARTICLES_SELECT_FIELDS = `a.id, a.guid, a.feed_id, f.name AS feed_name, a.
            a.author, a.published_at, a.fetched_at, a.category, a.lang`;
 
 /** articles + feeds の FROM / JOIN 句 */
-const ARTICLES_FROM_JOIN = `FROM articles a
-    LEFT JOIN feeds f ON f.id = a.feed_id`;
+const ARTICLES_FROM_JOIN = "FROM articles a LEFT JOIN feeds f ON f.id = a.feed_id";
 
-type Cursor = { publishedAt: string; id: number };
+export type Cursor = { publishedAt: string; id: number };
 
 /**
  * cursor 条件を conds / binds に追記する。
@@ -108,12 +107,12 @@ export interface ListArticlesParams {
   dateFrom?: string;
   dateTo?: string;
   limit: number;
-  cursor?: { publishedAt: string; id: number } | null;
+  cursor?: Cursor | null;
 }
 
 export interface ListArticlesResult {
   articles: Article[];
-  nextCursor: { publishedAt: string; id: number } | null;
+  nextCursor: Cursor | null;
 }
 
 export async function listArticles(
@@ -559,7 +558,7 @@ export async function countArticlesByMonth(
 
 export interface GetArticlesByFeedResult {
   articles: Article[];
-  nextCursor: { publishedAt: string; id: number } | null;
+  nextCursor: Cursor | null;
 }
 
 /** feed_id で記事を published_at DESC で取得。cursor は listArticles / getArticlesByAuthor と同形式 */
@@ -567,7 +566,7 @@ export async function getArticlesByFeed(
   db: D1Database,
   feedId: string,
   limit: number,
-  cursor: { publishedAt: string; id: number } | null,
+  cursor: Cursor | null,
 ): Promise<GetArticlesByFeedResult> {
   const conds: string[] = [`a.feed_id = ?1`];
   const binds: unknown[] = [feedId];
@@ -593,7 +592,7 @@ export async function getArticlesByFeed(
 
 export interface GetArticlesByAuthorResult {
   articles: Article[];
-  nextCursor: { publishedAt: string; id: number } | null;
+  nextCursor: Cursor | null;
 }
 
 /** 著者名で記事を published_at DESC で取得。cursor は listArticles と同形式 */
@@ -601,7 +600,7 @@ export async function getArticlesByAuthor(
   db: D1Database,
   author: string,
   limit: number,
-  cursor: { publishedAt: string; id: number } | null,
+  cursor: Cursor | null,
 ): Promise<GetArticlesByAuthorResult> {
   const conds: string[] = [`a.author = ?1`];
   const binds: unknown[] = [author];
@@ -668,7 +667,7 @@ export async function getArticlesCalendar(
 
 export interface GetArticlesByCategoryResult {
   articles: Article[];
-  nextCursor: { publishedAt: string; id: number } | null;
+  nextCursor: Cursor | null;
 }
 
 /** category で記事を published_at DESC で取得。cursor は getArticlesByFeed / getArticlesByAuthor と同形式 */
@@ -676,7 +675,7 @@ export async function getArticlesByCategory(
   db: D1Database,
   category: FeedCategory,
   limit: number,
-  cursor: { publishedAt: string; id: number } | null,
+  cursor: Cursor | null,
 ): Promise<GetArticlesByCategoryResult> {
   const conds: string[] = [`a.category = ?1`];
   const binds: unknown[] = [category];
@@ -702,7 +701,7 @@ export async function getArticlesByCategory(
 
 export interface GetArticlesByDayResult {
   articles: Article[];
-  nextCursor: { publishedAt: string; id: number } | null;
+  nextCursor: Cursor | null;
 }
 
 /** 指定日 (UTC 00:00:00 〜 翌日 00:00:00) の記事を published_at DESC で取得。cursor は既存と同形式 */
@@ -711,7 +710,7 @@ export async function getArticlesByDay(
   startIso: string,
   endIso: string,
   limit: number,
-  cursor: { publishedAt: string; id: number } | null,
+  cursor: Cursor | null,
 ): Promise<GetArticlesByDayResult> {
   const conds: string[] = [`a.published_at >= ?1`, `a.published_at < ?2`];
   const binds: unknown[] = [startIso, endIso];
@@ -750,7 +749,7 @@ export async function countArticlesByDay(
 
 export interface SearchArticlesResult {
   articles: Article[];
-  nextCursor: { publishedAt: string; id: number } | null;
+  nextCursor: Cursor | null;
 }
 
 /**
@@ -762,7 +761,7 @@ export async function searchArticles(
   db: D1Database,
   tokens: string[],
   limit: number,
-  cursor: { publishedAt: string; id: number } | null,
+  cursor: Cursor | null,
 ): Promise<SearchArticlesResult> {
   const conds: string[] = [];
   const binds: unknown[] = [];


### PR DESCRIPTION
## Summary

- `apps/web/worker/db/articles.ts` で 7 関数が重複していた SELECT カラム / FROM JOIN 句 / cursor WHERE 条件 / nextCursor 抽出ロジックを共通ヘルパーに抽出
- 抽出したヘルパー: `ARTICLES_SELECT_FIELDS`、`ARTICLES_FROM_JOIN`、`appendCursorCondition()`、`extractWithCursor()`
- 公開 API (関数シグネチャ / 戻り値型) は完全に維持
- 877 行 → 807 行 (-70 行)

## Test plan

- [x] `pnpm check` pass (エラー 0 件)
- [x] `pnpm build` pass
- [x] `pnpm test` pass (31 files / 544 tests)
- [ ] テストファイルは一切変更していない

Closes #317