### PR TITLE
test(worker): add coverage for catalog/xml/utils/feed-config

### DIFF
--- a/apps/web/tests/worker/api/catalog.test.ts
+++ b/apps/web/tests/worker/api/catalog.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vite-plus/test";
+import { SELF } from "cloudflare:test";
+
+// catalogHandler は /api/ (GET /) にマウントされている
+const CATALOG_URL = "https://example.com/api";
+
+describe("GET /api (catalog endpoint)", () => {
+  it("returns 200 with JSON body", async () => {
+    const res = await SELF.fetch(CATALOG_URL);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("application/json");
+  });
+
+  it("sets Cache-Control: public, max-age=3600", async () => {
+    const res = await SELF.fetch(CATALOG_URL);
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=3600");
+  });
+
+  it("response has name, version, description, endpoints, syndication, docs_url fields", async () => {
+    const res = await SELF.fetch(CATALOG_URL);
+    const body = await res.json<Record<string, unknown>>();
+    expect(typeof body["name"]).toBe("string");
+    expect(typeof body["version"]).toBe("string");
+    expect(typeof body["description"]).toBe("string");
+    expect(Array.isArray(body["endpoints"])).toBe(true);
+    expect(Array.isArray(body["syndication"])).toBe(true);
+    expect(typeof body["docs_url"]).toBe("string");
+  });
+
+  it("endpoints array contains entries with method, path, description, auth fields", async () => {
+    const res = await SELF.fetch(CATALOG_URL);
+    const body = await res.json<{
+      endpoints: { method: string; path: string; description: string; auth: string }[];
+    }>();
+    expect(body.endpoints.length).toBeGreaterThan(0);
+    for (const ep of body.endpoints) {
+      expect(typeof ep.method).toBe("string");
+      expect(typeof ep.path).toBe("string");
+      expect(typeof ep.description).toBe("string");
+      expect(["none", "admin"]).toContain(ep.auth);
+    }
+  });
+
+  it("syndication array contains entries with path and format fields", async () => {
+    const res = await SELF.fetch(CATALOG_URL);
+    const body = await res.json<{ syndication: { path: string; format: string }[] }>();
+    expect(body.syndication.length).toBeGreaterThan(0);
+    for (const s of body.syndication) {
+      expect(typeof s.path).toBe("string");
+      expect(typeof s.format).toBe("string");
+    }
+  });
+
+  it("contains /api/articles endpoint in the catalog", async () => {
+    const res = await SELF.fetch(CATALOG_URL);
+    const body = await res.json<{ endpoints: { path: string }[] }>();
+    const paths = body.endpoints.map((ep) => ep.path);
+    expect(paths).toContain("/api/articles");
+  });
+
+  it("admin endpoints have auth=admin", async () => {
+    const res = await SELF.fetch(CATALOG_URL);
+    const body = await res.json<{ endpoints: { path: string; auth: string }[] }>();
+    const adminEndpoints = body.endpoints.filter((ep) => ep.path.startsWith("/api/admin"));
+    expect(adminEndpoints.length).toBeGreaterThan(0);
+    for (const ep of adminEndpoints) {
+      expect(ep.auth).toBe("admin");
+    }
+  });
+
+  it("public endpoints have auth=none", async () => {
+    const res = await SELF.fetch(CATALOG_URL);
+    const body = await res.json<{ endpoints: { path: string; auth: string }[] }>();
+    const publicEndpoints = body.endpoints.filter((ep) => !ep.path.startsWith("/api/admin"));
+    expect(publicEndpoints.length).toBeGreaterThan(0);
+    for (const ep of publicEndpoints) {
+      expect(ep.auth).toBe("none");
+    }
+  });
+
+  it("syndication includes JSON Feed, RSS, Atom, and OPML formats", async () => {
+    const res = await SELF.fetch(CATALOG_URL);
+    const body = await res.json<{ syndication: { path: string; format: string }[] }>();
+    const formats = body.syndication.map((s) => s.format);
+    // 主要フォーマットが含まれること
+    const hasJsonFeed = formats.some((f) => f.includes("JSON Feed"));
+    const hasRss = formats.some((f) => f.includes("RSS"));
+    const hasAtom = formats.some((f) => f.includes("Atom"));
+    const hasOpml = formats.some((f) => f.includes("OPML"));
+    expect(hasJsonFeed).toBe(true);
+    expect(hasRss).toBe(true);
+    expect(hasAtom).toBe(true);
+    expect(hasOpml).toBe(true);
+  });
+
+  it("docs_url points to the GitHub repository", async () => {
+    const res = await SELF.fetch(CATALOG_URL);
+    const body = await res.json<{ docs_url: string }>();
+    expect(body.docs_url).toMatch(/^https?:\/\//);
+  });
+});

--- a/apps/web/tests/worker/feed-config.test.ts
+++ b/apps/web/tests/worker/feed-config.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vite-plus/test";
+import { loadAllFeeds, loadEnabledFeeds } from "../../worker/feed-config";
+
+describe("loadAllFeeds", () => {
+  it("returns an array", () => {
+    const feeds = loadAllFeeds();
+    expect(Array.isArray(feeds)).toBe(true);
+  });
+
+  it("returns at least one feed", () => {
+    const feeds = loadAllFeeds();
+    expect(feeds.length).toBeGreaterThan(0);
+  });
+
+  it("each feed has required fields: id, name, url, category, lang, enabled", () => {
+    const feeds = loadAllFeeds();
+    for (const feed of feeds) {
+      expect(typeof feed.id).toBe("string");
+      expect(feed.id.length).toBeGreaterThan(0);
+      expect(typeof feed.name).toBe("string");
+      expect(feed.name.length).toBeGreaterThan(0);
+      expect(typeof feed.url).toBe("string");
+      expect(feed.url).toMatch(/^https?:\/\//);
+      expect(["bigtech", "ai", "jp", "zenn"]).toContain(feed.category);
+      expect(["ja", "en"]).toContain(feed.lang);
+      expect(typeof feed.enabled).toBe("boolean");
+    }
+  });
+
+  it("all feed ids are unique", () => {
+    const feeds = loadAllFeeds();
+    const ids = feeds.map((f) => f.id);
+    const unique = new Set(ids);
+    expect(unique.size).toBe(ids.length);
+  });
+
+  it("includes feeds that are disabled", () => {
+    // loadAllFeeds はすべてのフィードを返す (enabled/disabled 問わず)
+    // YAML に enabled: false のエントリがある場合はそれも含む
+    const all = loadAllFeeds();
+    const enabled = loadEnabledFeeds();
+    // all は enabled 以上の件数になるはず (同数の場合は全件 enabled)
+    expect(all.length).toBeGreaterThanOrEqual(enabled.length);
+  });
+
+  it("includes well-known feeds (google-research, openai-blog, zenn-trending)", () => {
+    const feeds = loadAllFeeds();
+    const ids = feeds.map((f) => f.id);
+    expect(ids).toContain("google-research");
+    expect(ids).toContain("openai-blog");
+    expect(ids).toContain("zenn-trending");
+  });
+});
+
+describe("loadEnabledFeeds", () => {
+  it("returns an array", () => {
+    const feeds = loadEnabledFeeds();
+    expect(Array.isArray(feeds)).toBe(true);
+  });
+
+  it("returns at least one feed", () => {
+    const feeds = loadEnabledFeeds();
+    expect(feeds.length).toBeGreaterThan(0);
+  });
+
+  it("all returned feeds have enabled=true", () => {
+    const feeds = loadEnabledFeeds();
+    for (const feed of feeds) {
+      expect(feed.enabled).toBe(true);
+    }
+  });
+
+  it("is a subset of loadAllFeeds", () => {
+    const all = loadAllFeeds();
+    const enabled = loadEnabledFeeds();
+    const allIds = new Set(all.map((f) => f.id));
+    for (const feed of enabled) {
+      expect(allIds.has(feed.id)).toBe(true);
+    }
+  });
+
+  it("each feed has valid category (bigtech | ai | jp | zenn)", () => {
+    const feeds = loadEnabledFeeds();
+    for (const feed of feeds) {
+      expect(["bigtech", "ai", "jp", "zenn"]).toContain(feed.category);
+    }
+  });
+
+  it("each feed has valid lang (ja | en)", () => {
+    const feeds = loadEnabledFeeds();
+    for (const feed of feeds) {
+      expect(["ja", "en"]).toContain(feed.lang);
+    }
+  });
+
+  it("covers all 4 categories (bigtech, ai, jp, zenn)", () => {
+    const feeds = loadEnabledFeeds();
+    const categories = new Set(feeds.map((f) => f.category));
+    expect(categories.has("bigtech")).toBe(true);
+    expect(categories.has("ai")).toBe(true);
+    expect(categories.has("jp")).toBe(true);
+    expect(categories.has("zenn")).toBe(true);
+  });
+
+  it("covers both langs (ja and en)", () => {
+    const feeds = loadEnabledFeeds();
+    const langs = new Set(feeds.map((f) => f.lang));
+    expect(langs.has("ja")).toBe(true);
+    expect(langs.has("en")).toBe(true);
+  });
+});

--- a/apps/web/tests/worker/utils/types.test.ts
+++ b/apps/web/tests/worker/utils/types.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vite-plus/test";
+import { makeOneOf } from "../../../worker/utils/types";
+
+describe("makeOneOf", () => {
+  const VALUES = ["bigtech", "ai", "jp", "zenn"] as const;
+  const isCategory = makeOneOf<(typeof VALUES)[number]>(VALUES);
+
+  describe("returns true for values included in the list", () => {
+    it("returns true for 'bigtech'", () => {
+      expect(isCategory("bigtech")).toBe(true);
+    });
+
+    it("returns true for 'ai'", () => {
+      expect(isCategory("ai")).toBe(true);
+    });
+
+    it("returns true for 'jp'", () => {
+      expect(isCategory("jp")).toBe(true);
+    });
+
+    it("returns true for 'zenn'", () => {
+      expect(isCategory("zenn")).toBe(true);
+    });
+  });
+
+  describe("returns false for values not included in the list", () => {
+    it("returns false for a random string", () => {
+      expect(isCategory("unknown")).toBe(false);
+    });
+
+    it("returns false for empty string", () => {
+      expect(isCategory("")).toBe(false);
+    });
+
+    it("returns false for a string that partially matches", () => {
+      expect(isCategory("big")).toBe(false);
+    });
+
+    it("returns false for case-mismatched value", () => {
+      expect(isCategory("BigTech")).toBe(false);
+      expect(isCategory("AI")).toBe(false);
+    });
+  });
+
+  describe("returns false for undefined and null", () => {
+    it("returns false for undefined", () => {
+      expect(isCategory(undefined)).toBe(false);
+    });
+
+    it("returns false for null", () => {
+      expect(isCategory(null)).toBe(false);
+    });
+  });
+
+  describe("works with single-element list", () => {
+    const isSingle = makeOneOf(["only"] as const);
+
+    it("returns true for the single allowed value", () => {
+      expect(isSingle("only")).toBe(true);
+    });
+
+    it("returns false for any other string", () => {
+      expect(isSingle("other")).toBe(false);
+    });
+  });
+
+  describe("works with empty list", () => {
+    const isEmpty = makeOneOf([] as const);
+
+    it("returns false for any string", () => {
+      expect(isEmpty("anything")).toBe(false);
+    });
+
+    it("returns false for undefined", () => {
+      expect(isEmpty(undefined)).toBe(false);
+    });
+  });
+});

--- a/apps/web/tests/worker/utils/xml.test.ts
+++ b/apps/web/tests/worker/utils/xml.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "vite-plus/test";
+import { asArray, parseXml, pickText } from "../../../worker/utils/xml";
+
+// parseXml が返す型は unknown なので、テスト内では型アサーションで扱う
+type ParsedObj = Record<string, unknown>;
+
+const RSS_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test Feed</title>
+    <link>https://example.com</link>
+    <item>
+      <title>Post One</title>
+      <link>https://example.com/1</link>
+      <guid>guid-001</guid>
+      <pubDate>Mon, 01 Jan 2024 12:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>`;
+
+const ATOM_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Atom Feed</title>
+  <entry>
+    <title>Atom Entry</title>
+    <id>tag:example.com,2024:1</id>
+    <link rel="alternate" href="https://example.com/atom/1"/>
+    <updated>2024-01-01T00:00:00Z</updated>
+  </entry>
+</feed>`;
+
+const RDF_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns="http://purl.org/rss/1.0/">
+  <channel rdf:about="https://example.com">
+    <title>RDF Feed</title>
+    <link>https://example.com</link>
+  </channel>
+  <item rdf:about="https://example.com/rdf/1">
+    <title>RDF Item</title>
+    <link>https://example.com/rdf/1</link>
+  </item>
+</rdf:RDF>`;
+
+describe("parseXml", () => {
+  describe("RSS 2.0", () => {
+    it("parses RSS 2.0 and returns an object with rss root", () => {
+      const result = parseXml(RSS_XML) as ParsedObj;
+      expect(typeof result).toBe("object");
+      expect("rss" in result).toBe(true);
+    });
+
+    it("parses channel title from RSS", () => {
+      const result = parseXml(RSS_XML) as { rss: { channel: { title: string } } };
+      expect(result.rss.channel.title).toBe("Test Feed");
+    });
+
+    it("parses item title from RSS", () => {
+      const result = parseXml(RSS_XML) as {
+        rss: { channel: { item: { title: string; link: string; guid: string } } };
+      };
+      const item = result.rss.channel.item;
+      expect(item.title).toBe("Post One");
+      expect(item.link).toBe("https://example.com/1");
+      expect(item.guid).toBe("guid-001");
+    });
+  });
+
+  describe("Atom 1.0", () => {
+    it("parses Atom and returns an object with feed root", () => {
+      const result = parseXml(ATOM_XML) as ParsedObj;
+      expect(typeof result).toBe("object");
+      expect("feed" in result).toBe(true);
+    });
+
+    it("parses feed title from Atom", () => {
+      const result = parseXml(ATOM_XML) as { feed: { title: string } };
+      expect(result.feed.title).toBe("Atom Feed");
+    });
+
+    it("parses entry from Atom", () => {
+      const result = parseXml(ATOM_XML) as { feed: { entry: { title: string; id: string } } };
+      const entry = result.feed.entry;
+      expect(entry.title).toBe("Atom Entry");
+      expect(entry.id).toBe("tag:example.com,2024:1");
+    });
+  });
+
+  describe("RDF / RSS 1.0", () => {
+    it("parses RDF and returns an object (non-empty)", () => {
+      const result = parseXml(RDF_XML) as ParsedObj;
+      expect(typeof result).toBe("object");
+      const keys = Object.keys(result);
+      expect(keys.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("CDATA handling", () => {
+    it("preserves CDATA content", () => {
+      const xml = `<root><body><![CDATA[<p>Hello</p>]]></body></root>`;
+      const result = parseXml(xml) as { root: { body: { "#cdata": string } } };
+      expect(result.root.body["#cdata"]).toBe("<p>Hello</p>");
+    });
+  });
+
+  describe("attribute handling", () => {
+    it("captures attributes with @_ prefix", () => {
+      const xml = `<rss version="2.0"><channel><title>T</title></channel></rss>`;
+      const result = parseXml(xml) as { rss: { "@_version": string } };
+      expect(result.rss["@_version"]).toBe("2.0");
+    });
+  });
+
+  describe("invalid / malformed XML", () => {
+    it("does not throw on empty string (returns empty object or partial parse)", () => {
+      expect(() => parseXml("")).not.toThrow();
+    });
+
+    it("does not throw on plain text (non-XML)", () => {
+      expect(() => parseXml("just plain text no tags")).not.toThrow();
+    });
+  });
+});
+
+describe("pickText", () => {
+  it("returns null for null input", () => {
+    expect(pickText(null)).toBeNull();
+  });
+
+  it("returns null for undefined input", () => {
+    expect(pickText(undefined)).toBeNull();
+  });
+
+  it("returns the string itself when input is a string", () => {
+    expect(pickText("hello")).toBe("hello");
+  });
+
+  it("returns empty string unchanged when input is empty string", () => {
+    expect(pickText("")).toBe("");
+  });
+
+  it("converts number to string", () => {
+    expect(pickText(42)).toBe("42");
+  });
+
+  it("converts boolean to string", () => {
+    expect(pickText(true)).toBe("true");
+    expect(pickText(false)).toBe("false");
+  });
+
+  it("picks #text from object with #text property", () => {
+    expect(pickText({ "#text": "extracted" })).toBe("extracted");
+  });
+
+  it("picks #cdata from object with #cdata property when no #text", () => {
+    expect(pickText({ "#cdata": "cdata-content" })).toBe("cdata-content");
+  });
+
+  it("prefers #text over #cdata when both exist", () => {
+    expect(pickText({ "#text": "text-wins", "#cdata": "cdata-here" })).toBe("text-wins");
+  });
+
+  it("returns null for object without #text or #cdata", () => {
+    expect(pickText({ href: "https://example.com" })).toBeNull();
+  });
+
+  it("picks first non-null string from array", () => {
+    expect(pickText([null, undefined, "found", "second"])).toBe("found");
+  });
+
+  it("returns null for empty array", () => {
+    expect(pickText([])).toBeNull();
+  });
+
+  it("returns null for array of all nulls/undefineds", () => {
+    expect(pickText([null, undefined])).toBeNull();
+  });
+
+  it("picks string from nested object inside array", () => {
+    expect(pickText([{ "#text": "nested" }])).toBe("nested");
+  });
+});
+
+describe("asArray", () => {
+  it("returns empty array for undefined", () => {
+    expect(asArray(undefined)).toEqual([]);
+  });
+
+  it("returns empty array for null", () => {
+    expect(asArray(null)).toEqual([]);
+  });
+
+  it("wraps a single string value in an array", () => {
+    expect(asArray("single")).toEqual(["single"]);
+  });
+
+  it("wraps a single object value in an array", () => {
+    const obj = { title: "foo" };
+    expect(asArray(obj)).toEqual([obj]);
+  });
+
+  it("returns the array as-is when input is already an array", () => {
+    const arr = ["a", "b", "c"];
+    expect(asArray(arr)).toBe(arr);
+  });
+
+  it("returns empty array for empty array input", () => {
+    expect(asArray([])).toEqual([]);
+  });
+
+  it("preserves multi-element arrays", () => {
+    const arr = [{ id: 1 }, { id: 2 }];
+    expect(asArray(arr)).toEqual([{ id: 1 }, { id: 2 }]);
+  });
+
+  it("wraps number in an array", () => {
+    expect(asArray(0)).toEqual([0]);
+    expect(asArray(99)).toEqual([99]);
+  });
+});

--- a/apps/web/tests/worker/utils/xml.test.ts
+++ b/apps/web/tests/worker/utils/xml.test.ts
@@ -87,11 +87,9 @@ describe("parseXml", () => {
   });
 
   describe("RDF / RSS 1.0", () => {
-    it("parses RDF and returns an object (non-empty)", () => {
+    it("parses RDF and returns an object with rdf:RDF root", () => {
       const result = parseXml(RDF_XML) as ParsedObj;
-      expect(typeof result).toBe("object");
-      const keys = Object.keys(result);
-      expect(keys.length).toBeGreaterThan(0);
+      expect("rdf:RDF" in result).toBe(true);
     });
   });
 
@@ -166,6 +164,10 @@ describe("pickText", () => {
 
   it("picks first non-null string from array", () => {
     expect(pickText([null, undefined, "found", "second"])).toBe("found");
+  });
+
+  it("skips empty string in array and returns next non-empty value", () => {
+    expect(pickText(["", "found"])).toBe("found");
   });
 
   it("returns null for empty array", () => {


### PR DESCRIPTION
## Summary

- `apps/web/tests/worker/api/catalog.test.ts` (10 cases): `GET /api` の SELF.fetch 統合テスト。status/Content-Type/Cache-Control/payload shape/admin auth/syndication formats を網羅
- `apps/web/tests/worker/utils/xml.test.ts` (31 cases): `parseXml` (RSS 2.0/Atom/RDF/CDATA/属性)・`pickText` (string/number/boolean/object/#text/#cdata/array のエッジ)・`asArray` (undefined/null/scalar/array) の純関数テスト
- `apps/web/tests/worker/utils/types.test.ts` (14 cases): `makeOneOf` の包含/非包含/undefined/null/空リスト/単一要素リスト
- `apps/web/tests/worker/feed-config.test.ts` (16 cases): `loadAllFeeds`/`loadEnabledFeeds` の構造・一意性・サブセット関係・カテゴリ/lang 網羅性

## Test results

- Before: 31 files / 544 tests
- After: 35 files / 615 tests (+4 files, +71 tests)
- `pnpm test`: 35 passed / 615 passed
- `pnpm check`: 0 errors (既存 warnings のみ)

Closes #322