### PR TITLE
test(client): add coverage for untested hooks

### DIFF
--- a/apps/web/tests/client/useArticlesCalendar.test.tsx
+++ b/apps/web/tests/client/useArticlesCalendar.test.tsx
@@ -1,0 +1,108 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import type { CalendarDay } from "../../client/types/api";
+
+const { useArticlesCalendar } = await import("../../client/hooks/useArticlesCalendar");
+
+function makeCalendarDay(date: string, count: number): CalendarDay {
+  return { date, count };
+}
+
+function makeResponse(items: CalendarDay[]) {
+  return {
+    ok: true,
+    json: () => Promise.resolve({ days: items.length, items }),
+  };
+}
+
+describe("useArticlesCalendar", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("fetch 成功時にカレンダーアイテムが返される", async () => {
+    const items = [makeCalendarDay("2026-04-28", 5), makeCalendarDay("2026-04-27", 3)];
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeResponse(items)));
+
+    const { result } = renderHook(() => useArticlesCalendar(30));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.items).toHaveLength(2);
+    expect(result.current.items[0]?.date).toBe("2026-04-28");
+    expect(result.current.items[0]?.count).toBe(5);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("fetch エラー時に error が設定されアイテムは空", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+
+    const { result } = renderHook(() => useArticlesCalendar(30));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toContain("500");
+    expect(result.current.items).toEqual([]);
+  });
+
+  it("空のレスポンスの場合 items が空配列", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ days: 90, items: [] }),
+      }),
+    );
+
+    const { result } = renderHook(() => useArticlesCalendar(90));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.items).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("days が変わると再 fetch が発火する", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(makeResponse([]));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const { rerender } = renderHook(({ days }) => useArticlesCalendar(days), {
+      initialProps: { days: 30 as 30 | 90 | 365 },
+    });
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    const firstCall = mockFetch.mock.calls[0] as [string, ...unknown[]];
+    expect(firstCall[0]).toContain("days=30");
+
+    rerender({ days: 90 as 30 | 90 | 365 });
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    const secondCall = mockFetch.mock.calls[1] as [string, ...unknown[]];
+    expect(secondCall[0]).toContain("days=90");
+  });
+
+  it("ネットワーク例外発生時に error が設定される", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("Network error")));
+
+    const { result } = renderHook(() => useArticlesCalendar(365));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBe("Network error");
+    expect(result.current.items).toEqual([]);
+  });
+});

--- a/apps/web/tests/client/useAuthorArticles.test.tsx
+++ b/apps/web/tests/client/useAuthorArticles.test.tsx
@@ -1,0 +1,130 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import type { Article } from "../../client/types/api";
+
+const { useAuthorArticles } = await import("../../client/hooks/useAuthorArticles");
+
+function makeArticle(id: number): Article {
+  return {
+    id,
+    guid: `guid-${id}`,
+    feed_id: "test-feed",
+    feed_name: "Test Feed",
+    title: `Article ${id}`,
+    url: `https://example.com/a/${id}`,
+    summary: null,
+    author: "Test Author",
+    published_at: "2026-04-28T10:00:00Z",
+    fetched_at: "2026-04-28T11:00:00Z",
+    category: "ai",
+    lang: "en",
+  };
+}
+
+function makeResponse(articles: Article[], nextCursor: string | null = null) {
+  return {
+    ok: true,
+    json: () => Promise.resolve({ articles, nextCursor }),
+  };
+}
+
+describe("useAuthorArticles", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("fetch 成功時に著者の記事一覧が返される", async () => {
+    const articles = [makeArticle(1), makeArticle(2)];
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeResponse(articles)));
+
+    const { result } = renderHook(() => useAuthorArticles("Test Author"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.articles).toHaveLength(2);
+    expect(result.current.error).toBeNull();
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it("fetch エラー時に error が設定され記事は空", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+
+    const { result } = renderHook(() => useAuthorArticles("Test Author"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toContain("500");
+    expect(result.current.articles).toEqual([]);
+  });
+
+  it("author が変わると再 fetch が発火する", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(makeResponse([makeArticle(1)]));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const { rerender } = renderHook(({ author }) => useAuthorArticles(author), {
+      initialProps: { author: "Author A" },
+    });
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    const firstCall = mockFetch.mock.calls[0] as [string, ...unknown[]];
+    expect(firstCall[0]).toContain(encodeURIComponent("Author A"));
+
+    rerender({ author: "Author B" });
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    const secondCall = mockFetch.mock.calls[1] as [string, ...unknown[]];
+    expect(secondCall[0]).toContain(encodeURIComponent("Author B"));
+  });
+
+  it("loadMore で次ページが追加される", async () => {
+    const page1 = [makeArticle(1), makeArticle(2)];
+    const page2 = [makeArticle(3)];
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(makeResponse(page1, "cursor-next"))
+      .mockResolvedValueOnce(makeResponse(page2, null));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const { result } = renderHook(() => useAuthorArticles("Test Author"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.articles).toHaveLength(2);
+    expect(result.current.hasMore).toBe(true);
+
+    await act(async () => {
+      await result.current.loadMore();
+    });
+
+    await waitFor(() => {
+      expect(result.current.articles).toHaveLength(3);
+    });
+
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it("author が空文字の場合は fetch が発火しない", async () => {
+    const mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+
+    const { result } = renderHook(() => useAuthorArticles(""));
+
+    // 短時間待って fetch が呼ばれていないことを確認
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result.current.articles).toEqual([]);
+  });
+});

--- a/apps/web/tests/client/useAuthorArticles.test.tsx
+++ b/apps/web/tests/client/useAuthorArticles.test.tsx
@@ -121,8 +121,7 @@ describe("useAuthorArticles", () => {
 
     const { result } = renderHook(() => useAuthorArticles(""));
 
-    // 短時間待って fetch が呼ばれていないことを確認
-    await new Promise((r) => setTimeout(r, 50));
+    await act(async () => {});
 
     expect(mockFetch).not.toHaveBeenCalled();
     expect(result.current.articles).toEqual([]);

--- a/apps/web/tests/client/useFeedDetail.test.tsx
+++ b/apps/web/tests/client/useFeedDetail.test.tsx
@@ -1,0 +1,129 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import type { Article, FeedDetail } from "../../client/types/api";
+
+const { useFeedDetail } = await import("../../client/hooks/useFeedDetail");
+
+function makeFeedDetail(id: string): FeedDetail {
+  return {
+    id,
+    name: `Feed ${id}`,
+    url: `https://example.com/feed/${id}`,
+    category: "ai",
+    lang: "en",
+    enabled: true,
+    articles_30d: 20,
+    last_published_at: "2026-04-28T00:00:00Z",
+  };
+}
+
+function makeArticle(num: number): Article {
+  return {
+    id: num,
+    guid: `guid-${num}`,
+    feed_id: "feed-1",
+    feed_name: "Feed 1",
+    title: `Article ${num}`,
+    url: `https://example.com/a/${num}`,
+    summary: null,
+    author: null,
+    published_at: "2026-04-28T10:00:00Z",
+    fetched_at: "2026-04-28T11:00:00Z",
+    category: "ai",
+    lang: "en",
+  };
+}
+
+describe("useFeedDetail", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("fetch 成功時にフィード詳細と記事一覧が返される", async () => {
+    const feed = makeFeedDetail("feed-1");
+    const articles = [makeArticle(1), makeArticle(2)];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ feed, recent_articles: articles }),
+      }),
+    );
+
+    const { result } = renderHook(() => useFeedDetail("feed-1"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.feed?.id).toBe("feed-1");
+    expect(result.current.articles).toHaveLength(2);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("404 エラー時に feed_not_found が設定される", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 404 }));
+
+    const { result } = renderHook(() => useFeedDetail("nonexistent"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBe("feed_not_found");
+    expect(result.current.feed).toBeNull();
+    expect(result.current.articles).toEqual([]);
+  });
+
+  it("500 エラー時に HTTP エラーメッセージが設定される", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+
+    const { result } = renderHook(() => useFeedDetail("feed-1"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBe("HTTP 500");
+    expect(result.current.feed).toBeNull();
+  });
+
+  it("feedId が変わると再 fetch が発火する", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ feed: makeFeedDetail("feed-2"), recent_articles: [] }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const { rerender } = renderHook(({ id }) => useFeedDetail(id), {
+      initialProps: { id: "feed-1" },
+    });
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    rerender({ id: "feed-2" });
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    const lastCall = mockFetch.mock.calls[1] as [string, ...unknown[]];
+    expect(lastCall[0]).toContain("feed-2");
+  });
+
+  it("ネットワーク例外発生時に error が設定される", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("Network failed")));
+
+    const { result } = renderHook(() => useFeedDetail("feed-1"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBe("Network failed");
+    expect(result.current.feed).toBeNull();
+    expect(result.current.articles).toEqual([]);
+  });
+});

--- a/apps/web/tests/client/useFeeds.test.tsx
+++ b/apps/web/tests/client/useFeeds.test.tsx
@@ -53,7 +53,7 @@ describe("useFeeds", () => {
       expect(result.current.loading).toBe(false);
     });
 
-    expect(result.current.error).toBeTruthy();
+    expect(result.current.error).toContain("500");
     expect(result.current.feeds).toEqual([]);
   });
 

--- a/apps/web/tests/client/useFeeds.test.tsx
+++ b/apps/web/tests/client/useFeeds.test.tsx
@@ -1,0 +1,102 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import type { FeedSummary } from "../../client/types/api";
+
+const { useFeeds } = await import("../../client/hooks/useFeeds");
+
+function makeFeed(id: string): FeedSummary {
+  return {
+    id,
+    name: `Feed ${id}`,
+    url: `https://example.com/feed/${id}`,
+    category: "ai",
+    lang: "en",
+    enabled: true,
+    articles_30d: 10,
+    last_published_at: "2026-04-28T00:00:00Z",
+  };
+}
+
+function makeResponse(feeds: FeedSummary[]) {
+  return {
+    ok: true,
+    json: () => Promise.resolve({ feeds }),
+  };
+}
+
+describe("useFeeds", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("fetch 成功時にフィード一覧が返される", async () => {
+    const feeds = [makeFeed("feed-1"), makeFeed("feed-2")];
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeResponse(feeds)));
+
+    const { result } = renderHook(() => useFeeds());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.feeds).toHaveLength(2);
+    expect(result.current.feeds[0]?.id).toBe("feed-1");
+    expect(result.current.error).toBeNull();
+  });
+
+  it("fetch エラー時に error が設定されフィードは空", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+
+    const { result } = renderHook(() => useFeeds());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBeTruthy();
+    expect(result.current.feeds).toEqual([]);
+  });
+
+  it("空のフィード一覧が返された場合、feeds は空配列", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeResponse([])));
+
+    const { result } = renderHook(() => useFeeds());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.feeds).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("fetch 中は loading が true", async () => {
+    let resolveFetch!: (v: unknown) => void;
+    const fetchPromise = new Promise((r) => {
+      resolveFetch = r;
+    });
+    vi.stubGlobal("fetch", vi.fn().mockReturnValue(fetchPromise));
+
+    const { result } = renderHook(() => useFeeds());
+
+    expect(result.current.loading).toBe(true);
+
+    resolveFetch(makeResponse([]));
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+  });
+
+  it("ネットワーク例外発生時に error が設定される", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("Network Error")));
+
+    const { result } = renderHook(() => useFeeds());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBe("Network Error");
+    expect(result.current.feeds).toEqual([]);
+  });
+});

--- a/apps/web/tests/client/useFilterHandlers.test.tsx
+++ b/apps/web/tests/client/useFilterHandlers.test.tsx
@@ -1,0 +1,244 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const { useFilterHandlers } = await import("../../client/hooks/useFilterHandlers");
+
+function makeState(overrides: Partial<Parameters<typeof useFilterHandlers>[0]> = {}) {
+  return {
+    category: "" as const,
+    lang: "" as const,
+    feedId: "",
+    q: "",
+    dateFrom: "",
+    dateTo: "",
+    unreadOnly: false,
+    starredOnly: false,
+    bookmarkedOnly: false,
+    ...overrides,
+  };
+}
+
+function makeSetters(overrides: Partial<Parameters<typeof useFilterHandlers>[1]> = {}) {
+  return {
+    setFeedId: vi.fn(),
+    setDateFrom: vi.fn(),
+    setDateTo: vi.fn(),
+    setUnreadOnly: vi.fn(),
+    setStarredOnly: vi.fn(),
+    setUrlFilters: vi.fn(),
+    setView: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("useFilterHandlers", () => {
+  beforeEach(() => {
+    // window.history.pushState と PopStateEvent のシミュレーション
+    vi.stubGlobal(
+      "history",
+      Object.assign(Object.create(window.history), {
+        pushState: vi.fn(),
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("handleCategoryChange が category を変更し feedId を維持する (category 非空の場合)", () => {
+    const setters = makeSetters();
+    const { result } = renderHook(() =>
+      useFilterHandlers(makeState({ feedId: "old-feed" }), setters),
+    );
+
+    act(() => {
+      result.current.handleCategoryChange("ai");
+    });
+
+    // v が truthy なので feedId はそのまま維持される
+    expect(setters.setFeedId).toHaveBeenCalledWith("old-feed");
+  });
+
+  it("handleCategoryChange が空文字に変更されたとき feedId をリセットする", () => {
+    const setters = makeSetters();
+    const { result } = renderHook(() =>
+      useFilterHandlers(makeState({ category: "ai", feedId: "old-feed" }), setters),
+    );
+
+    act(() => {
+      result.current.handleCategoryChange("");
+    });
+
+    // v が falsy なので feedId は空にリセットされる
+    expect(setters.setFeedId).toHaveBeenCalledWith("");
+  });
+
+  it("handleLangChange が lang を変更し feedId を維持する (lang 非空の場合)", () => {
+    const setters = makeSetters();
+    const { result } = renderHook(() =>
+      useFilterHandlers(makeState({ feedId: "some-feed" }), setters),
+    );
+
+    act(() => {
+      result.current.handleLangChange("ja");
+    });
+
+    // v が truthy なので feedId はそのまま維持される
+    expect(setters.setFeedId).toHaveBeenCalledWith("some-feed");
+  });
+
+  it("handleLangChange が空文字に変更されたとき feedId をリセットする", () => {
+    const setters = makeSetters();
+    const { result } = renderHook(() =>
+      useFilterHandlers(makeState({ lang: "en", feedId: "some-feed" }), setters),
+    );
+
+    act(() => {
+      result.current.handleLangChange("");
+    });
+
+    // v が falsy なので feedId は空にリセットされる
+    expect(setters.setFeedId).toHaveBeenCalledWith("");
+  });
+
+  it("handleFeedChange が setFeedId に feedId を渡して呼ぶ", () => {
+    const setters = makeSetters();
+    const { result } = renderHook(() => useFilterHandlers(makeState(), setters));
+
+    act(() => {
+      result.current.handleFeedChange("new-feed-id");
+    });
+
+    expect(setters.setFeedId).toHaveBeenCalledWith("new-feed-id");
+  });
+
+  it("handleQChange が setUrlFilters を q 付きで呼ぶ", () => {
+    const setters = makeSetters();
+    const { result } = renderHook(() => useFilterHandlers(makeState(), setters));
+
+    act(() => {
+      result.current.handleQChange("react hooks");
+    });
+
+    expect(setters.setUrlFilters).toHaveBeenCalledWith({ q: "react hooks" });
+  });
+
+  it("handleDateFromChange が setDateFrom を新しい値で呼ぶ", () => {
+    const setters = makeSetters();
+    const { result } = renderHook(() => useFilterHandlers(makeState(), setters));
+
+    act(() => {
+      result.current.handleDateFromChange("2026-04-01");
+    });
+
+    expect(setters.setDateFrom).toHaveBeenCalledWith("2026-04-01");
+  });
+
+  it("handleDateToChange が setDateTo を新しい値で呼ぶ", () => {
+    const setters = makeSetters();
+    const { result } = renderHook(() => useFilterHandlers(makeState(), setters));
+
+    act(() => {
+      result.current.handleDateToChange("2026-04-30");
+    });
+
+    expect(setters.setDateTo).toHaveBeenCalledWith("2026-04-30");
+  });
+
+  it("handleUnreadOnlyChange が setUnreadOnly を新しい値で呼ぶ", () => {
+    const setters = makeSetters();
+    const { result } = renderHook(() => useFilterHandlers(makeState(), setters));
+
+    act(() => {
+      result.current.handleUnreadOnlyChange(true);
+    });
+
+    expect(setters.setUnreadOnly).toHaveBeenCalledWith(true);
+  });
+
+  it("handleStarredOnlyChange が setStarredOnly を新しい値で呼ぶ", () => {
+    const setters = makeSetters();
+    const { result } = renderHook(() => useFilterHandlers(makeState(), setters));
+
+    act(() => {
+      result.current.handleStarredOnlyChange(true);
+    });
+
+    expect(setters.setStarredOnly).toHaveBeenCalledWith(true);
+  });
+
+  it("handleClear が全フィルタを空にしてリセットする", () => {
+    const setters = makeSetters();
+    const { result } = renderHook(() =>
+      useFilterHandlers(
+        makeState({
+          category: "ai",
+          lang: "en",
+          feedId: "some-feed",
+          q: "query",
+          dateFrom: "2026-01-01",
+          dateTo: "2026-04-30",
+          unreadOnly: true,
+          starredOnly: true,
+        }),
+        setters,
+      ),
+    );
+
+    act(() => {
+      result.current.handleClear();
+    });
+
+    expect(setters.setFeedId).toHaveBeenCalledWith("");
+    expect(setters.setDateFrom).toHaveBeenCalledWith("");
+    expect(setters.setDateTo).toHaveBeenCalledWith("");
+    expect(setters.setUnreadOnly).toHaveBeenCalledWith(false);
+    expect(setters.setStarredOnly).toHaveBeenCalledWith(false);
+  });
+
+  it("handleBookmarkedOnlyToggle が setUrlFilters で bookmarksOnly を反転させる", () => {
+    const setters = makeSetters();
+    const { result } = renderHook(() =>
+      useFilterHandlers(makeState({ bookmarkedOnly: false }), setters),
+    );
+
+    act(() => {
+      result.current.handleBookmarkedOnlyToggle();
+    });
+
+    expect(setters.setUrlFilters).toHaveBeenCalledWith({ bookmarksOnly: true });
+  });
+
+  it("handleSelectCategory が setView を呼ぶ", () => {
+    const setters = makeSetters();
+    const { result } = renderHook(() => useFilterHandlers(makeState(), setters));
+
+    act(() => {
+      result.current.handleSelectCategory("bigtech");
+    });
+
+    expect(setters.setView).toHaveBeenCalledWith("articles");
+  });
+
+  it("handleApplyPreset が指定したフィルタを適用する", () => {
+    const setters = makeSetters();
+    const { result } = renderHook(() => useFilterHandlers(makeState(), setters));
+
+    act(() => {
+      result.current.handleApplyPreset({
+        category: "ai",
+        lang: "ja",
+        feedId: "preset-feed",
+        q: "preset query",
+        unreadOnly: true,
+        starredOnly: false,
+      });
+    });
+
+    expect(setters.setFeedId).toHaveBeenCalledWith("preset-feed");
+    expect(setters.setUnreadOnly).toHaveBeenCalledWith(true);
+    expect(setters.setStarredOnly).toHaveBeenCalledWith(false);
+  });
+});

--- a/apps/web/tests/client/useReports.test.tsx
+++ b/apps/web/tests/client/useReports.test.tsx
@@ -1,0 +1,182 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import type { ReportDetail, ReportKind, ReportListItem } from "../../client/types/api";
+
+const { useReportsList, useReport } = await import("../../client/hooks/useReports");
+
+function makeReportListItem(id: number): ReportListItem {
+  return {
+    id,
+    kind: "daily",
+    period_start: "2026-04-28",
+    period_end: "2026-04-28",
+    category: "ai",
+    lang: "ja",
+    source_skill: "tech-news-digest",
+    generated_at: "2026-04-28T23:00:00Z",
+  };
+}
+
+function makeReportDetail(id: number): ReportDetail {
+  return {
+    ...makeReportListItem(id),
+    content: "# Daily Report\nContent here.",
+    meta_json: null,
+  };
+}
+
+describe("useReportsList", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("fetch 成功時にレポート一覧が返される", async () => {
+    const reports = [makeReportListItem(1), makeReportListItem(2)];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ reports }),
+      }),
+    );
+
+    const { result } = renderHook(() => useReportsList());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.data).toHaveLength(2);
+    expect(result.current.data[0]?.id).toBe(1);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("fetch エラー時に error が設定されデータは空", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+
+    const { result } = renderHook(() => useReportsList());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toContain("500");
+    expect(result.current.data).toEqual([]);
+  });
+
+  it("空のレポート一覧が返された場合、data は空配列", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ reports: [] }),
+      }),
+    );
+
+    const { result } = renderHook(() => useReportsList());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.data).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("kind が変わると再 fetch が発火する", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ reports: [] }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const { rerender } = renderHook(({ kind }: { kind: ReportKind }) => useReportsList(kind), {
+      initialProps: { kind: "daily" },
+    });
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    rerender({ kind: "weekly" });
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+});
+
+describe("useReport", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("fetch 成功時にレポート詳細が返される", async () => {
+    const report = makeReportDetail(5);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ report }),
+      }),
+    );
+
+    const { result } = renderHook(() => useReport(5));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.data?.id).toBe(5);
+    expect(result.current.data?.content).toBe("# Daily Report\nContent here.");
+    expect(result.current.error).toBeNull();
+  });
+
+  it("fetch エラー時に error が設定される", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 404 }));
+
+    const { result } = renderHook(() => useReport(99));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toContain("404");
+    expect(result.current.data).toBeNull();
+  });
+
+  it("id が変わると再 fetch が発火する", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ report: makeReportDetail(1) }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const { rerender } = renderHook(({ id }) => useReport(id), {
+      initialProps: { id: 1 },
+    });
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    rerender({ id: 2 });
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("ネットワーク例外発生時に error が設定される", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("Connection refused")));
+
+    const { result } = renderHook(() => useReport(1));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBe("Connection refused");
+    expect(result.current.data).toBeNull();
+  });
+});

--- a/apps/web/tests/client/useStats.test.tsx
+++ b/apps/web/tests/client/useStats.test.tsx
@@ -51,11 +51,10 @@ describe("useStats", () => {
     const { result } = renderHook(() => useStats());
 
     await waitFor(() => {
-      expect(result.current.error).toBeTruthy();
+      expect(result.current.error).toContain("503");
     });
 
     expect(result.current.stats).toBeNull();
-    expect(result.current.error).toContain("503");
   });
 
   it("ネットワーク例外発生時に error が設定される", async () => {

--- a/apps/web/tests/client/useStats.test.tsx
+++ b/apps/web/tests/client/useStats.test.tsx
@@ -1,0 +1,109 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import type { Stats } from "../../client/hooks/useStats";
+
+const { useStats } = await import("../../client/hooks/useStats");
+
+function makeStats(overrides: Partial<Stats> = {}): Stats {
+  return {
+    total: 100,
+    last_published_at: "2026-04-28T12:00:00Z",
+    last_fetched_at: "2026-04-28T13:00:00Z",
+    last24h: 5,
+    by_category: { ai: 50, bigtech: 30, jp: 15, zenn: 5 },
+    by_lang: { en: 70, ja: 30 },
+    stale_feeds: [],
+    category_trend_30d: [],
+    feed_activity: [],
+    ...overrides,
+  };
+}
+
+function makeResponse(stats: Stats) {
+  return {
+    ok: true,
+    json: () => Promise.resolve(stats),
+  };
+}
+
+describe("useStats", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("fetch 成功時に stats が返される", async () => {
+    const stats = makeStats({ total: 42 });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeResponse(stats)));
+
+    const { result } = renderHook(() => useStats());
+
+    await waitFor(() => {
+      expect(result.current.stats).not.toBeNull();
+    });
+
+    expect(result.current.stats?.total).toBe(42);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("fetch エラー時に error が設定される", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 503 }));
+
+    const { result } = renderHook(() => useStats());
+
+    await waitFor(() => {
+      expect(result.current.error).toBeTruthy();
+    });
+
+    expect(result.current.stats).toBeNull();
+    expect(result.current.error).toContain("503");
+  });
+
+  it("ネットワーク例外発生時に error が設定される", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("Network timeout")));
+
+    const { result } = renderHook(() => useStats());
+
+    await waitFor(() => {
+      expect(result.current.error).toBeTruthy();
+    });
+
+    expect(result.current.error).toBe("Network timeout");
+    expect(result.current.stats).toBeNull();
+  });
+
+  it("refreshSignal が変わると再 fetch が発火する", async () => {
+    const stats = makeStats();
+    const mockFetch = vi.fn().mockResolvedValue(makeResponse(stats));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const { result, rerender } = renderHook(({ signal }) => useStats(signal), {
+      initialProps: { signal: 0 },
+    });
+
+    await waitFor(() => {
+      expect(result.current.stats).not.toBeNull();
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    rerender({ signal: 1 });
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("stats の by_category が正しく反映される", async () => {
+    const stats = makeStats({ by_category: { ai: 99, bigtech: 1 } });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeResponse(stats)));
+
+    const { result } = renderHook(() => useStats());
+
+    await waitFor(() => {
+      expect(result.current.stats).not.toBeNull();
+    });
+
+    expect(result.current.stats?.by_category["ai"]).toBe(99);
+    expect(result.current.stats?.by_category["bigtech"]).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- apps/web/tests/client/ に 7 hook の新規テストファイルを追加
- 対象: useArticlesCalendar, useAuthorArticles, useFeedDetail, useFeeds, useFilterHandlers, useReports, useStats
- fetch 系 hook は vi.stubGlobal('fetch', ...) で境界 stub、afterEach で vi.unstubAllGlobals() を呼ぶ
- 古典派 (実物 hook impl を呼ぶ、hook を mock しない)

## テストファイルと件数

- useFeeds.test.tsx (5 ケース)
- useStats.test.tsx (5 ケース)
- useReports.test.tsx (8 ケース)
- useFeedDetail.test.tsx (5 ケース)
- useAuthorArticles.test.tsx (5 ケース)
- useArticlesCalendar.test.tsx (5 ケース)
- useFilterHandlers.test.tsx (13 ケース)

## Test plan

- pnpm test:client: 333 passed (before: 294 passed)
- pnpm check: 自分のファイルにエラーなし

Closes #323