### PR TITLE
chore(rules): forbid utils overuse, recommend soft assertions

### DIFF
--- a/.claude/rules/01-typescript.md
+++ b/.claude/rules/01-typescript.md
@@ -42,6 +42,26 @@ type CollectResult =
 - 早期 return を優先しネストを浅く保つ
 - 1 ファイルに複数 export しても良いが、責務が違うものは分ける (例: `articles-query.ts` と `articles-write.ts`)
 
+## ヘルパーの配置 (utils/ の濫用禁止)
+
+ヘルパー関数を **反射的に `utils/` に置かない**。`utils/` は「**実際に複数ファイルから import されている、責務が独立した関数**」のための置き場であって、「いつか共通化されるかも」のバッファではない。
+
+| 状況                               | 置く場所                                                                             |
+| ---------------------------------- | ------------------------------------------------------------------------------------ |
+| 1 ファイルでしか使わない           | **そのファイル内** (export せずローカル関数 / 同ファイルの top-level 関数)           |
+| 1 ディレクトリ内の 2-3 ファイル    | そのディレクトリ内に `helpers.ts` や `<domain>.ts` を作る (例: `collector/parse.ts`) |
+| 2 つ以上の独立ドメインから使われる | `worker/utils/<name>.ts` または `client/utils/<name>.ts`                             |
+| 型だけの定義                       | 単一ファイルなら使う場所、複数なら `worker/types.ts` / `client/types/api.ts` に集約  |
+
+判断ルール:
+
+- **新規 helper を `utils/` に置きたくなったら、まず "import 元が現在 2 ファイル以上あるか" を確認**。1 つしかないなら呼び出し側に inline する
+- **dead code は速やかに削除**。「将来使うかも」の helper を置かない (YAGNI)。型エイリアス (`NonEmptyArray<T>` 等) も使われていないなら削除
+- **既存の `utils/` を増やすな**。ファイル名が抽象的 (`utils.ts`, `helpers.ts`) になりがちで責務が膨らむ。代わりに具体的なドメイン名 (`xml.ts`, `etag.ts`) で切る
+- **テストヘルパーも同じ**。`tests/fixtures/` は seed データ専用。テストロジックの共通化は `tests/<area>/_helpers.ts` のような具体名で
+
+例: `worker/api/articles.ts` の list endpoint で limit/cursor を parse する `parseListQuery(c)` は **articles.ts 内のローカル関数で OK**。他の API ファイルから使うようになって初めて `worker/api/_helpers.ts` などに昇格させる。
+
 ## コメント
 
 - 「**なぜ**」を書く。「何を」はコードで読めるので書かない

--- a/.claude/rules/20-testing-overview.md
+++ b/.claude/rules/20-testing-overview.md
@@ -82,6 +82,24 @@ CI では `vp check` (lint+format+typecheck) → `pnpm build` → `pnpm test` �
 
 - **新機能 / バグ修正は基本テストを追加してから PR を出す**。テスト追加が困難なケース (UI のごく些細な視覚変更等) は PR description にその旨を明記
 - **assertion は具体的に**。`expect(result).toBeTruthy()` でなく `expect(result).toEqual({ status: "ok", saved: 3 })`
+- **複数の独立した観点を検証する場合は soft assertion (`expect.soft(...)`) を使う**。1 つ目の失敗で fail-fast せず、すべての観点の失敗を 1 回の実行で集約できる:
+
+  ```ts
+  it("GET /api/articles returns paginated list", async () => {
+    const res = await SELF.fetch("https://x.test/api/articles?limit=2");
+    const body = await res.json<ArticlesResponse>();
+
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Cache-Control")).toContain("max-age");
+    expect.soft(body.articles).toHaveLength(2);
+    expect.soft(body.next_cursor).toBeTypeOf("string");
+  });
+  ```
+
+  - 「同じ対象の **独立した側面** (status / header / body の各キー)」を 1 テストでまとめて見る場合に有効
+  - 一方、後続の assert が前の assert の前提に依存する (例: `body.articles[0]` を見るには `articles.length > 0` 必須) ケースは通常の `expect` を使い fail-fast させる
+  - **assert を 5 件以上書くなら 1 テストとして肥大化していないか見直す**。観点が独立しすぎているなら `it` を分ける方が良い
+
 - **テストの独立性**: 1 テストが他のテストに依存しない。順序を変えても通ること
 - **flaky なテストは即修正**。retry でごまかさない (Playwright の `retries: 2` は CI 限定の保険)
 - **import 規約**:


### PR DESCRIPTION
## Summary
- `01-typescript.md`: `utils/` に helper を反射的に置かない方針を明文化。1 ファイルでしか使わないものは呼び出し側に inline、複数ファイルでも近接ディレクトリの `helpers.ts` から始める
- `20-testing-overview.md`: 独立した複数観点を 1 テストで検証する場合 `expect.soft(...)` を使う方針を追加

## Background
レビューで指摘される「dead helper が utils に残る」「fail-fast assert が複数の独立観点をまとめてしまい、1 つ通すだけで他がスキップされる」問題への予防策。

## Test plan
- [x] vp check 不要 (markdown のみ)
- [ ] 後続 issue で実装側を遡及対応 (utils audit / soft assertion 採用)