### PR TITLE
feat(d1-client): support comma-separated --category in recent.mjs

### DIFF
--- a/tools/d1-client/README.md
+++ b/tools/d1-client/README.md
@@ -18,12 +18,12 @@ D1 からデータを抽出する Node.js CLI スクリプト群。Claude skills
 node tools/d1-client/recent.mjs --since=<today|week|month|N> [options]
 ```
 
-| オプション   | デフォルト | 説明                                                                                 |
-| ------------ | ---------- | ------------------------------------------------------------------------------------ |
-| `--since`    | (必須)     | `today` / `week` / `month` / `N`                                                     |
-| `--target`   | `local`    | `local` または `remote`                                                              |
-| `--category` | なし       | `bigtech` / `ai` / `jp` / `zenn`。カンマ区切りで複数指定可 (例: `bigtech,ai,jp`)    |
-| `--lang`     | なし       | `ja` または `en`                                                                     |
+| オプション   | デフォルト | 説明                                                                              |
+| ------------ | ---------- | --------------------------------------------------------------------------------- |
+| `--since`    | (必須)     | `today` / `week` / `month` / `N`                                                  |
+| `--target`   | `local`    | `local` または `remote`                                                           |
+| `--category` | なし       | `bigtech` / `ai` / `jp` / `zenn`。カンマ区切りで複数指定可 (例: `bigtech,ai,jp`) |
+| `--lang`     | なし       | `ja` または `en`                                                                  |
 | `--limit`    | `200`      | 最大取得件数 (上限 1000 — D1 の 1 invocation あたり 50 queries 制限に基づく実装上限) |
 
 例:

--- a/tools/d1-client/README.md
+++ b/tools/d1-client/README.md
@@ -22,7 +22,7 @@ node tools/d1-client/recent.mjs --since=<today|week|month|N> [options]
 | ------------ | ---------- | ------------------------------------------------------------------------------------ |
 | `--since`    | (必須)     | `today` / `week` / `month` / `N`                                                     |
 | `--target`   | `local`    | `local` または `remote`                                                              |
-| `--category` | なし       | `bigtech` / `ai` / `jp` / `zenn`                                                     |
+| `--category` | なし       | `bigtech` / `ai` / `jp` / `zenn`。カンマ区切りで複数指定可 (例: `bigtech,ai,jp`)    |
 | `--lang`     | なし       | `ja` または `en`                                                                     |
 | `--limit`    | `200`      | 最大取得件数 (上限 1000 — D1 の 1 invocation あたり 50 queries 制限に基づく実装上限) |
 
@@ -31,6 +31,7 @@ node tools/d1-client/recent.mjs --since=<today|week|month|N> [options]
 ```sh
 node tools/d1-client/recent.mjs --since=today --target=remote
 node tools/d1-client/recent.mjs --since=week --category=ai --target=remote
+node tools/d1-client/recent.mjs --since=today --category=bigtech,ai,jp --target=remote
 ```
 
 出力 JSON:

--- a/tools/d1-client/README.md
+++ b/tools/d1-client/README.md
@@ -18,12 +18,12 @@ D1 からデータを抽出する Node.js CLI スクリプト群。Claude skills
 node tools/d1-client/recent.mjs --since=<today|week|month|N> [options]
 ```
 
-| オプション   | デフォルト | 説明                                                                              |
-| ------------ | ---------- | --------------------------------------------------------------------------------- |
-| `--since`    | (必須)     | `today` / `week` / `month` / `N`                                                  |
-| `--target`   | `local`    | `local` または `remote`                                                           |
-| `--category` | なし       | `bigtech` / `ai` / `jp` / `zenn`。カンマ区切りで複数指定可 (例: `bigtech,ai,jp`) |
-| `--lang`     | なし       | `ja` または `en`                                                                  |
+| オプション   | デフォルト | 説明                                                                                 |
+| ------------ | ---------- | ------------------------------------------------------------------------------------ |
+| `--since`    | (必須)     | `today` / `week` / `month` / `N`                                                     |
+| `--target`   | `local`    | `local` または `remote`                                                              |
+| `--category` | なし       | `bigtech` / `ai` / `jp` / `zenn`。カンマ区切りで複数指定可 (例: `bigtech,ai,jp`)     |
+| `--lang`     | なし       | `ja` または `en`                                                                     |
 | `--limit`    | `200`      | 最大取得件数 (上限 1000 — D1 の 1 invocation あたり 50 queries 制限に基づく実装上限) |
 
 例:

--- a/tools/d1-client/recent.mjs
+++ b/tools/d1-client/recent.mjs
@@ -59,10 +59,15 @@ const VALID_LANGS = ["ja", "en"];
 function buildSQL({ since, category, lang, limit }) {
   const where = [`a.published_at > '${since.replace(/'/g, "''")}'`];
   if (category) {
-    const cats = category.split(",").map((c) => c.trim()).filter(Boolean);
+    const cats = category
+      .split(",")
+      .map((c) => c.trim())
+      .filter(Boolean);
     const invalid = cats.filter((c) => !VALID_CATEGORIES.includes(c));
     if (invalid.length > 0) {
-      process.stderr.write(`Invalid --category value(s): ${invalid.join(", ")}. Allowed: ${VALID_CATEGORIES.join(", ")}\n`);
+      process.stderr.write(
+        `Invalid --category value(s): ${invalid.join(", ")}. Allowed: ${VALID_CATEGORIES.join(", ")}\n`,
+      );
       process.exit(2);
     }
     const placeholders = cats.map((c) => `'${c.replace(/'/g, "''")}'`).join(", ");

--- a/tools/d1-client/recent.mjs
+++ b/tools/d1-client/recent.mjs
@@ -4,7 +4,7 @@
 //
 // Usage:
 //   node tools/d1-client/recent.mjs --since=today [--target=local|remote]
-//                                   [--category=ai|bigtech|jp|zenn] [--lang=ja|en]
+//                                   [--category=ai|bigtech|jp|zenn[,ai,...]] [--lang=ja|en]
 //                                   [--limit=200]
 //
 // Output (stdout): JSON object as documented in SKILL.md
@@ -53,10 +53,28 @@ function sinceToISO(spec) {
   return new Date(now.getTime() - ms).toISOString();
 }
 
+const VALID_CATEGORIES = ["bigtech", "ai", "jp", "zenn"];
+const VALID_LANGS = ["ja", "en"];
+
 function buildSQL({ since, category, lang, limit }) {
   const where = [`a.published_at > '${since.replace(/'/g, "''")}'`];
-  if (category) where.push(`a.category = '${category.replace(/'/g, "''")}'`);
-  if (lang) where.push(`a.lang = '${lang.replace(/'/g, "''")}'`);
+  if (category) {
+    const cats = category.split(",").map((c) => c.trim()).filter(Boolean);
+    const invalid = cats.filter((c) => !VALID_CATEGORIES.includes(c));
+    if (invalid.length > 0) {
+      process.stderr.write(`Invalid --category value(s): ${invalid.join(", ")}. Allowed: ${VALID_CATEGORIES.join(", ")}\n`);
+      process.exit(2);
+    }
+    const placeholders = cats.map((c) => `'${c.replace(/'/g, "''")}'`).join(", ");
+    where.push(`a.category IN (${placeholders})`);
+  }
+  if (lang) {
+    if (!VALID_LANGS.includes(lang)) {
+      process.stderr.write(`Invalid --lang value: ${lang}. Allowed: ${VALID_LANGS.join(", ")}\n`);
+      process.exit(2);
+    }
+    where.push(`a.lang = '${lang.replace(/'/g, "''")}'`);
+  }
   return `
 SELECT a.id, a.guid, a.feed_id, f.name AS feed_name,
        a.title, a.url, a.summary, a.author,


### PR DESCRIPTION
## Summary
- `recent.mjs` の `--category` をカンマ区切り複数指定 (`--category=bigtech,ai,jp`) に対応
- `IN (...)` で SQL を組み立てる。単一指定も完全に後方互換
- 値が無効カテゴリの場合は exit 2 で停止 (新規ホワイトリスト検証)
- `--lang` にも同等のホワイトリスト検証を追加

## Closes
- Closes #311

## Test plan
- [ ] `node tools/d1-client/recent.mjs --since=today --target=local --category=bigtech` (単一: 後方互換)
- [ ] `node tools/d1-client/recent.mjs --since=today --target=local --category=bigtech,ai,jp` (複数)
- [ ] `node tools/d1-client/recent.mjs --since=today --target=local --category=invalid` → exit 2 / エラー出力
- [ ] CI green