### PR TITLE
fix(d1-client): sanitize FTS5 query and validate category/lang in search.mjs

### DIFF
--- a/tools/d1-client/README.md
+++ b/tools/d1-client/README.md
@@ -56,7 +56,7 @@ node tools/d1-client/search.mjs --q=<keyword> [options]
 
 | オプション   | デフォルト | 説明                             |
 | ------------ | ---------- | -------------------------------- |
-| `--q`        | (必須)     | 検索キーワード                   |
+| `--q`        | (必須)     | 検索キーワード (FTS5 特殊文字は除去される) |
 | `--since`    | `month`    | `today` / `week` / `month` / `N` |
 | `--target`   | `local`    | `local` または `remote`          |
 | `--category` | なし       | `bigtech` / `ai` / `jp` / `zenn` |

--- a/tools/d1-client/README.md
+++ b/tools/d1-client/README.md
@@ -54,14 +54,14 @@ FTS5 (trigram tokenizer, `migration/0003_fts5_trigram.sql` で設定) を使っ�
 node tools/d1-client/search.mjs --q=<keyword> [options]
 ```
 
-| オプション   | デフォルト | 説明                             |
-| ------------ | ---------- | -------------------------------- |
+| オプション   | デフォルト | 説明                                       |
+| ------------ | ---------- | ------------------------------------------ |
 | `--q`        | (必須)     | 検索キーワード (FTS5 特殊文字は除去される) |
-| `--since`    | `month`    | `today` / `week` / `month` / `N` |
-| `--target`   | `local`    | `local` または `remote`          |
-| `--category` | なし       | `bigtech` / `ai` / `jp` / `zenn` |
-| `--lang`     | なし       | `ja` または `en`                 |
-| `--limit`    | `100`      | 最大取得件数 (上限 1000)         |
+| `--since`    | `month`    | `today` / `week` / `month` / `N`           |
+| `--target`   | `local`    | `local` または `remote`                    |
+| `--category` | なし       | `bigtech` / `ai` / `jp` / `zenn`           |
+| `--lang`     | なし       | `ja` または `en`                           |
+| `--limit`    | `100`      | 最大取得件数 (上限 1000)                   |
 
 例:
 

--- a/tools/d1-client/search.mjs
+++ b/tools/d1-client/search.mjs
@@ -28,9 +28,7 @@ const VALID_LANGS = new Set(["ja", "en"]);
  */
 function sanitizeFtsQuery(q) {
   // ダブルクォートを除去し、FTS5 特殊文字 (* ^ ( ) : - ;) をスペースに置換
-  const cleaned = q
-    .replace(/"/g, "")
-    .replace(/[*^();:-]/g, " ");
+  const cleaned = q.replace(/"/g, "").replace(/[*^();:-]/g, " ");
   // スペースで分割し空トークンを除去、FTS5 予約語 (AND/OR/NOT) を除去
   const tokens = cleaned
     .split(/\s+/)
@@ -147,9 +145,7 @@ function main() {
     process.exit(2);
   }
   if (opts.lang !== null && !VALID_LANGS.has(opts.lang)) {
-    process.stderr.write(
-      `Invalid --lang=${opts.lang}. Allowed: ${[...VALID_LANGS].join("|")}\n`,
-    );
+    process.stderr.write(`Invalid --lang=${opts.lang}. Allowed: ${[...VALID_LANGS].join("|")}\n`);
     process.exit(2);
   }
   const sinceISO = sinceToISO(opts.since);

--- a/tools/d1-client/search.mjs
+++ b/tools/d1-client/search.mjs
@@ -19,6 +19,28 @@ const REPO_ROOT = path.resolve(path.dirname(__filename), "..", "..");
 const WRANGLER_DIR = path.join(REPO_ROOT, "apps", "web");
 const DB_NAME = "tech-news-bot-db";
 
+const VALID_CATEGORIES = new Set(["bigtech", "ai", "jp", "zenn"]);
+const VALID_LANGS = new Set(["ja", "en"]);
+
+/**
+ * FTS5 オペレータ汚染を防ぐため入力をサニタイズする。
+ * ダブルクォートと FTS5 特殊文字を除去し、各トークンを quoted phrase として再構築する。
+ */
+function sanitizeFtsQuery(q) {
+  // ダブルクォートを除去し、FTS5 特殊文字 (* ^ ( ) : - ;) をスペースに置換
+  const cleaned = q
+    .replace(/"/g, "")
+    .replace(/[*^();:-]/g, " ");
+  // スペースで分割し空トークンを除去、FTS5 予約語 (AND/OR/NOT) を除去
+  const tokens = cleaned
+    .split(/\s+/)
+    .filter(Boolean)
+    .filter((t) => !["AND", "OR", "NOT"].includes(t.toUpperCase()));
+  if (tokens.length === 0) return '""';
+  // 各トークンを quoted phrase として連結（部分一致精度を保ちつつオペレータ汚染を防ぐ）
+  return tokens.map((t) => `"${t}"`).join(" ");
+}
+
 function parseArgs(argv) {
   const out = { q: null, since: "month", target: "local", category: null, lang: null, limit: 100 };
   for (const arg of argv.slice(2)) {
@@ -50,10 +72,8 @@ function sinceToISO(spec) {
 }
 
 function buildSQL({ q, since, category, lang, limit }) {
-  // trigram tokenizer は quoted phrase でもスペース区切り単語でも動作するが、
-  // quoted で渡すと部分一致の精度が上がる場面がある。
-  const escapedQ = q.replace(/"/g, '""');
-  const quotedQ = `"${escapedQ}"`;
+  // sanitizeFtsQuery で特殊文字を除去済みの quoted phrase を MATCH に渡す。
+  const matchExpr = sanitizeFtsQuery(q);
   const sinceEscaped = since.replace(/'/g, "''");
 
   const extraWhere = [];
@@ -68,7 +88,7 @@ SELECT a.id, a.guid, a.feed_id, f.name AS feed_name,
 FROM articles a
 JOIN articles_fts fts ON fts.rowid = a.id
 LEFT JOIN feeds f ON f.id = a.feed_id
-WHERE articles_fts MATCH '${quotedQ}'
+WHERE articles_fts MATCH '${matchExpr}'
   AND a.published_at > '${sinceEscaped}'
   ${extraClause}
 ORDER BY rank, a.published_at DESC
@@ -118,6 +138,18 @@ function main() {
   const opts = parseArgs(process.argv);
   if (!opts.q) {
     process.stderr.write("Missing --q=<keyword>\n");
+    process.exit(2);
+  }
+  if (opts.category !== null && !VALID_CATEGORIES.has(opts.category)) {
+    process.stderr.write(
+      `Invalid --category=${opts.category}. Allowed: ${[...VALID_CATEGORIES].join("|")}\n`,
+    );
+    process.exit(2);
+  }
+  if (opts.lang !== null && !VALID_LANGS.has(opts.lang)) {
+    process.stderr.write(
+      `Invalid --lang=${opts.lang}. Allowed: ${[...VALID_LANGS].join("|")}\n`,
+    );
     process.exit(2);
   }
   const sinceISO = sinceToISO(opts.since);

--- a/tools/d1-client/search.mjs
+++ b/tools/d1-client/search.mjs
@@ -139,13 +139,15 @@ function main() {
     process.exit(2);
   }
   if (opts.category !== null && !VALID_CATEGORIES.has(opts.category)) {
+    const cat = String(opts.category);
     process.stderr.write(
-      `Invalid --category=${opts.category}. Allowed: ${[...VALID_CATEGORIES].join("|")}\n`,
+      `Invalid --category=${cat}. Allowed: ${[...VALID_CATEGORIES].join("|")}\n`,
     );
     process.exit(2);
   }
   if (opts.lang !== null && !VALID_LANGS.has(opts.lang)) {
-    process.stderr.write(`Invalid --lang=${opts.lang}. Allowed: ${[...VALID_LANGS].join("|")}\n`);
+    const lang = String(opts.lang);
+    process.stderr.write(`Invalid --lang=${lang}. Allowed: ${[...VALID_LANGS].join("|")}\n`);
     process.exit(2);
   }
   const sinceISO = sinceToISO(opts.since);


### PR DESCRIPTION
## Summary
- `search.mjs` の `--q` を FTS5 オペレータ汚染から守るためサニタイズ処理を追加
  - `"`, `*`, `^`, `(`, `)`, `:`, `;`, `-` を除去し、FTS5 予約語 (`AND`/`OR`/`NOT`) も除去。トークンを quoted phrase として再構築
- `--category` `--lang` をホワイトリスト検証 (`bigtech|ai|jp|zenn` / `ja|en`)。不正値で exit 2

## Test plan
- [ ] 通常キーワード ("MCP", "Rust") の検索結果が変わらない
- [ ] FTS5 特殊文字を含む `--q` でクラッシュしない
- [ ] `--category=invalid` で exit 2
- [ ] CI green

## Notes
recent.mjs の同様対応は別 PR で進行中 (#311 関連)。