### PR TITLE
chore(ci): add minimal permissions to deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,9 @@ on:
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- `.github/workflows/deploy.yml` に `permissions: contents: read` を明示し、最小権限原則に統一
- 他 workflow は既に明示済みで、deploy.yml だけ未定義だったため

## Test plan
- [ ] CI all green (deploy job 自体は main マージ後に走るのでこの PR では実行されない)
- [ ] actionlint 通過 (手元で確認可能なら)