### PR TITLE
docs(skills): clean up tech-news skill SKILL.md

### DIFF
--- a/.claude/skills/tech-news-digest/SKILL.md
+++ b/.claude/skills/tech-news-digest/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tech-news-digest
-description: D1 に蓄積された tech blog の記事を「今日 / 今週 / 任意期間」の粒度で抽出し、Stage 1〜4 (収集 → 選定 → WebFetch で本文取得 → トレンド分析) で日本語ダイジェストを生成する。"今日のニュースまとめて" "週次サマリ作って" "最近のトレンド何？" のような問い合わせで起動する。要約品質を本文ベースで保つため、デフォルトで WebFetch を使う deep モードで動作する。
+description: D1 に蓄積された tech blog の記事を「今日 / 今週 / 任意期間」の粒度でリスト形式に抽出し、Stage 1〜4 (収集 → 選定 → WebFetch で本文取得 → トレンド分析) で日本語ダイジェストを生成する。デイリー速報や「今日何があった？」程度の素早い確認に最適。"今日のニュースまとめて" "最近のトレンド何？" のような問い合わせで起動する。要約品質を本文ベースで保つため、デフォルトで WebFetch を使う deep モードで動作する。
 ---
 
 # tech-news-digest
@@ -46,7 +46,7 @@ D1 (`articles` テーブル) から期間指定で記事メタデータを取得
 
 - `--since=<today|week|month|N>` (必須)
 - `--target=<local|remote>` (省略時 `local`)
-- `--category=<bigtech|ai|jp>` (任意)
+- `--category=<bigtech|ai|jp>` (任意。`zenn` は対象外 — フィードノイズが多いため)
 - `--lang=<ja|en>` (任意)
 - `--limit=<N>` (デフォルト 200)
 
@@ -252,6 +252,7 @@ Stage 2 で選定した重要記事のリンク集。
   - `--target=local` で 0 件 → `pnpm migrate:local` + `pnpm dev` でローカル収集を 1 回回すよう案内
 - **記事 0 件**: 「該当期間に記事なし」と正直に報告する。creative writing で埋めない
 - **WebFetch 連続失敗**: deep モードで選定記事の半数以上が fetch 失敗したら、残りは `quick` 相当 (`(summary based)` 付き) に退避し、出力末尾に `_注: WebFetch が複数失敗したため一部 summary ベース_` を付ける
+- **ストーリー形式・読み物が要求された場合**: 本 skill はリスト形式のダイジェスト専用。テーマ別ストーリーやニュースレター形式が必要な場合は `tech-news-weekly` を案内する
 
 ## 評価
 

--- a/.claude/skills/tech-news-related/SKILL.md
+++ b/.claude/skills/tech-news-related/SKILL.md
@@ -29,16 +29,19 @@ description: ピボット記事 1 本を起点に D1 から関連記事を探し
 
 ### Stage 1: ピボット解決 — 記事を D1 で特定
 
-`tools/d1-client/recent.mjs` を Node から実行してピボット記事を特定する。
+**URL 入力の場合**: まず `tools/d1-client/search.mjs` で URL を照合する (1 クエリで完結するため効率的):
+
+```sh
+node tools/d1-client/search.mjs --q=<URL> --since=month --target=remote
+```
+
+`search.mjs` でヒットしない場合のみ、`tools/d1-client/recent.mjs` で全件取得して `articles[].url` と完全一致で検索するフォールバックに切り替える:
 
 ```sh
 node tools/d1-client/recent.mjs --since=month --target=remote
 ```
 
-取得した JSON の `articles` 配列から以下の方法でピボット記事を照合する:
-
-- **URL 入力の場合**: `articles[].url` と完全一致で検索する
-- **タイトル文字列の場合**: `articles[].title` と大文字小文字を区別せず部分一致で検索する
+**タイトル文字列の場合**: `recent.mjs` で全件取得し、`articles[].title` と大文字小文字を区別せず部分一致で検索する。
 
 照合できない場合:
 
@@ -166,7 +169,8 @@ D1 に未収録の記事をピボットとした場合は、冒頭に `> この�
 
 ## 関連ファイル
 
-- 実装: `tools/d1-client/recent.mjs`
+- 実装: `tools/d1-client/search.mjs` (Stage 1 URL 照合のメイン)
+- 実装: `tools/d1-client/recent.mjs` (Stage 1 フォールバック・全件取得)
 - スキーマ: `migrations/0001_initial.sql` (`articles`, `feeds` テーブル)
 - 型: `apps/web/worker/types.ts` (`Article`, `FeedConfig` interface)
 - 関連 skill: `.claude/skills/tech-news-digest/SKILL.md` (期間ベースのダイジェスト)

--- a/.claude/skills/tech-news-summary/SKILL.md
+++ b/.claude/skills/tech-news-summary/SKILL.md
@@ -78,15 +78,20 @@ Step 1・Step 2 のチェックを通過した場合、WebFetch で URL を取�
 
 ### Step 5: 関連記事の検索 (detailed モードのみ)
 
-`tools/d1-client/recent.mjs --since=month --target=remote` を実行し、`articles[]` から関連記事を探す。
+元記事のタイトルまたは `summary` から主要キーワードを 1〜2 個抽出し、`tools/d1-client/search.mjs` で D1 を検索する:
+
+```sh
+node tools/d1-client/search.mjs --q=<keyword> --since=month --target=remote
+```
 
 選定基準:
 
-- 元記事のタイトルまたは `summary` に含まれる主要キーワードが `title` または `summary` に含まれる
 - 元記事と URL が異なる
 - 元記事とタイトルが一致しない (同一記事の重複を除く)
 
-条件を満たす記事が見つかれば 1〜3 件を「コメント / 注意点 / 関連性」セクションに含める。見つからなければ「関連記事なし」と記載する。
+条件を満たす記事が見つかれば 1〜3 件を「コメント / 注意点 / 関連性」セクションに含める。
+
+**フォールバック**: `search.mjs` でヒットしない場合のみ、`tools/d1-client/recent.mjs --since=month --target=remote` で全件取得して in-memory キーワード一致で再検索する。それでも見つからなければ「関連記事なし」と記載する。
 
 ## 出力フォーマット
 
@@ -164,7 +169,8 @@ _元記事: <URL>_ <(D1 summary ベース — WebFetch ブロック対象ホス�
 
 ## 関連ファイル
 
-- D1 検索: `tools/d1-client/recent.mjs` (関連記事検索・D1 フォールバック)
+- D1 検索: `tools/d1-client/search.mjs` (関連記事検索 — Step 5 のメイン)
+- D1 フォールバック: `tools/d1-client/recent.mjs` (search.mjs ヒットなし時の全件フォールバック・D1 フォールバック)
 - スキーマ: `migrations/0001_initial.sql` (`articles`, `feeds` テーブル)
 - 型: `apps/web/worker/types.ts` (`Article`, `FeedConfig` interface)
 - 関連 skill: `.claude/skills/tech-news-digest/SKILL.md` (期間ベースのダイジェスト)

--- a/.claude/skills/tech-news-weekly/SKILL.md
+++ b/.claude/skills/tech-news-weekly/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tech-news-weekly
-description: 週次・月次でテック業界の動きをストーリー形式でまとめる skill。"先週のまとめ作って" "月次レポート" "週次トレンドレポート" のような問い合わせで起動する。長期トレンドの意味的テーマ抽出とニュースレター的 narrative が必要な場合に使う。
+description: 週次・月次でテック業界の動きをニュースレター/読み物形式でまとめる skill。"先週のまとめ作って" "月次レポート" "週次トレンドレポート" のような問い合わせで起動する。テーマ別ストーリー・前週との比較・カテゴリ間の温度差分析など、長期トレンドの意味的テーマ抽出が必要な場合に使う。
 ---
 
 # tech-news-weekly
@@ -36,7 +36,7 @@ D1 (`articles` テーブル) から週次・月次の記事を取得し、意味
 
 - `--since=<week|month>` (必須)
 - `--target=<local|remote>` (省略時 `local`)
-- `--category=<bigtech|ai|jp>` (任意)
+- `--category=<bigtech|ai|jp>` (任意。`zenn` は対象外 — フィードノイズが多いため)
 - `--lang=<ja|en>` (任意)
 - `--limit=<N>` (デフォルト 200、月次は 500 推奨)
 
@@ -82,24 +82,9 @@ for (const a of [...bigtech, ...ai].sort((x, y) => x.published_at.localeCompare(
 
 以降の Stage はマージ済み `merged` を `articles` として扱う。
 
-stdout の JSON 形式は `tech-news-digest` と同一 (`since`, `total`, `articles`, `by_category`, `by_feed`, `by_lang`)。
+stdout の JSON 形式は `tech-news-digest` と同一 (`since`, `total`, `deduped_total`, `articles`, `by_category`, `by_feed`, `by_lang`)。
 
-**URL による de-dup**:
-
-Stage 1 完了後、`articles` を `url` でグループ化し、重複 URL は最も古い `published_at` のものを 1 件だけ残す:
-
-```js
-const seen = new Map();
-const deduped = [];
-for (const a of articles.sort((x, y) => x.published_at.localeCompare(y.published_at))) {
-  if (!seen.has(a.url)) {
-    seen.set(a.url, true);
-    deduped.push(a);
-  }
-}
-```
-
-de-dup 後の件数をレポート冒頭の期間ヘッダに反映する。
+> **注**: 単一カテゴリで取得した場合は `recent.mjs` が返す `deduped_total` をそのまま信頼する。複数カテゴリを結合した場合は上記コードブロックで URL de-dup 済みの `merged` が `articles` になるため、追加の de-dup 処理は不要。レポート冒頭の期間ヘッダには de-dup 後の件数 (単一カテゴリ: `deduped_total`、複数カテゴリ結合: `merged.length`) を表示する。
 
 エラーハンドリング:
 


### PR DESCRIPTION
## Summary
SKILL audit で指摘された軽微な整理を一括対応 (コード変更なし):

1. `tech-news-weekly` の de-dup 二重記述を 1 箇所に統合
2. `tech-news-summary` Step 5 を `search.mjs` ベースに変更 (recent 全件取得を回避)
3. `tech-news-digest` / `tech-news-weekly` の `description` 重複を整理
4. 各 SKILL.md に `zenn` カテゴリが対象外である旨を明示
5. `tech-news-related` Stage 1 を `search.mjs` フォールバックを追加
6. `tech-news-digest` のガードレールに weekly への誘導を追記

## Test plan
- [ ] `git diff --stat` でコード変更が含まれていないこと
- [ ] 各 SKILL.md の YAML frontmatter が valid

## Out of scope
- EVALUATION.md / runs.md の整備 (別 issue)
- recent.mjs / search.mjs のコード改善 (別 PR で進行中)