### PR TITLE
fix(reports): harden pipeline (curl logs, action timeout, period validation, utf8 chunking)

### DIFF
--- a/.github/workflows/report-daily.yml
+++ b/.github/workflows/report-daily.yml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   generate-and-save:
@@ -42,6 +41,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_tools: "Bash,Read,Write,WebFetch,Skill"
+          timeout_minutes: 30
           # daily digest 生成プロンプト。skill 起動と最終ファイル書き出しを明示する。
           prompt: |
             あなたは tech-news-bot の自動レポート生成エージェントです。
@@ -122,11 +122,16 @@ jobs:
               meta: { dedup_total: .dedup_total, by_category: .by_category, by_feed: .by_feed, included_categories: .included_categories }
             }' /tmp/report-meta.json > /tmp/report-payload.json
 
-          curl -fsS -X POST "$WORKER_URL/api/admin/reports" \
+          HTTP_STATUS=$(curl -sS -w '%{http_code}' -X POST "$WORKER_URL/api/admin/reports" \
             -H "Authorization: Bearer $ADMIN_TOKEN" \
             -H "Content-Type: application/json" \
             -o /tmp/post-resp.json \
-            --data-binary @/tmp/report-payload.json
+            --data-binary @/tmp/report-payload.json)
+          if [[ "$HTTP_STATUS" != 2* ]]; then
+            echo "API returned HTTP $HTTP_STATUS" >&2
+            cat /tmp/post-resp.json >&2
+            exit 1
+          fi
 
       - name: Post to Slack (threaded)
         if: ${{ success() }}
@@ -155,31 +160,13 @@ jobs:
           fi
           VIEWER_URL="$WORKER_URL/reports/$REPORT_ID"
 
-          KIND=$(jq -r '.kind' /tmp/report-meta.json)
-          PERIOD_START=$(jq -r '.period_start' /tmp/report-meta.json)
           PERIOD_END=$(jq -r '.period_end' /tmp/report-meta.json)
           GENERATED_AT=$(jq -r '.generated_at' /tmp/report-meta.json)
 
-          # Build title (emoji + label + period)
-          case "$KIND" in
-            daily)
-              EMOJI="🟢"; SEVERITY="重要度: 低"; LABEL="Daily"
-              DATE_LABEL=$(echo "$PERIOD_END" | cut -c1-10)
-              TITLE="$EMOJI $LABEL Tech Report ($DATE_LABEL)"
-              ;;
-            weekly)
-              EMOJI="🟡"; SEVERITY="重要度: 中"; LABEL="Weekly"
-              START=$(echo "$PERIOD_START" | cut -c1-10); END=$(echo "$PERIOD_END" | cut -c1-10)
-              TITLE="$EMOJI $LABEL Tech Report ($START 〜 $END)"
-              ;;
-            monthly)
-              EMOJI="🔴"; SEVERITY="重要度: 高"; LABEL="Monthly"
-              START=$(echo "$PERIOD_START" | cut -c1-10); END=$(echo "$PERIOD_END" | cut -c1-10)
-              TITLE="$EMOJI $LABEL Tech Report ($START 〜 $END)"
-              ;;
-            *)
-              echo "Unknown kind $KIND – skipping"; exit 0 ;;
-          esac
+          # Build title (daily is fixed)
+          DATE_LABEL=$(echo "$PERIOD_END" | cut -c1-10)
+          TITLE="🟢 Daily Tech Report ($DATE_LABEL)"
+          SEVERITY="重要度: 低"
 
           # ===== Step A: post parent (title + severity) =====
           PARENT_PAYLOAD=$(jq -n \
@@ -212,14 +199,31 @@ jobs:
           fi
 
           # ===== Step B: post child (chunked body in thread) =====
-          # python で安全に chunk 分割。runner 標準で python3 が入っている。
+          # python で UTF-8 バイト境界で安全に chunk 分割。runner 標準で python3 が入っている。
           CHILD_PAYLOAD=$(VIEWER_URL="$VIEWER_URL" SLACK_CHANNEL_ID="$SLACK_CHANNEL_ID" THREAD_TS="$THREAD_TS" python3 - <<'PYEOF'
           import json, os
+          def split_by_utf8_bytes(text, max_bytes):
+              """Split text into chunks where each chunk is at most max_bytes UTF-8 bytes.
+              Splits only at character boundaries to avoid breaking surrogates."""
+              encoded = text.encode('utf-8')
+              chunks = []
+              start = 0
+              while start < len(encoded):
+                  end = start + max_bytes
+                  if end >= len(encoded):
+                      chunks.append(encoded[start:].decode('utf-8'))
+                      break
+                  # Walk back to a valid UTF-8 character boundary
+                  while end > start and (encoded[end] & 0xC0) == 0x80:
+                      end -= 1
+                  chunks.append(encoded[start:end].decode('utf-8'))
+                  start = end
+              return chunks
           with open('/tmp/slack-message.md', encoding='utf-8') as f:
               msg = f.read().rstrip()
-          CHUNK = 2800       # Slack mrkdwn block limit 3000 chars 安全側
+          MAX_BYTES = 2800   # Slack mrkdwn block limit 3000 bytes (UTF-8) 安全側
           MAX_BLOCKS = 48    # divider + section (viewer link) のために 2 枠残す
-          chunks = [msg[i:i+CHUNK] for i in range(0, len(msg), CHUNK)]
+          chunks = split_by_utf8_bytes(msg, MAX_BYTES)
           truncated = False
           if len(chunks) > MAX_BLOCKS:
               chunks = chunks[:MAX_BLOCKS]

--- a/.github/workflows/report-monthly.yml
+++ b/.github/workflows/report-monthly.yml
@@ -11,7 +11,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   generate-and-save:
@@ -40,6 +39,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_tools: "Bash,Read,Write,WebFetch,Skill"
+          timeout_minutes: 45
           # monthly digest 生成プロンプト。tech-news-weekly skill を since=month で起動する。
           prompt: |
             あなたは tech-news-bot の自動レポート生成エージェントです。
@@ -115,11 +115,16 @@ jobs:
               meta: { dedup_total: .dedup_total, by_category: .by_category, by_feed: .by_feed, included_categories: .included_categories }
             }' /tmp/report-meta.json > /tmp/report-payload.json
 
-          curl -fsS -X POST "$WORKER_URL/api/admin/reports" \
+          HTTP_STATUS=$(curl -sS -w '%{http_code}' -X POST "$WORKER_URL/api/admin/reports" \
             -H "Authorization: Bearer $ADMIN_TOKEN" \
             -H "Content-Type: application/json" \
             -o /tmp/post-resp.json \
-            --data-binary @/tmp/report-payload.json
+            --data-binary @/tmp/report-payload.json)
+          if [[ "$HTTP_STATUS" != 2* ]]; then
+            echo "API returned HTTP $HTTP_STATUS" >&2
+            cat /tmp/post-resp.json >&2
+            exit 1
+          fi
 
       - name: Post to Slack (threaded)
         if: ${{ success() }}
@@ -148,31 +153,14 @@ jobs:
           fi
           VIEWER_URL="$WORKER_URL/reports/$REPORT_ID"
 
-          KIND=$(jq -r '.kind' /tmp/report-meta.json)
           PERIOD_START=$(jq -r '.period_start' /tmp/report-meta.json)
           PERIOD_END=$(jq -r '.period_end' /tmp/report-meta.json)
           GENERATED_AT=$(jq -r '.generated_at' /tmp/report-meta.json)
 
-          # Build title (emoji + label + period)
-          case "$KIND" in
-            daily)
-              EMOJI="🟢"; SEVERITY="重要度: 低"; LABEL="Daily"
-              DATE_LABEL=$(echo "$PERIOD_END" | cut -c1-10)
-              TITLE="$EMOJI $LABEL Tech Report ($DATE_LABEL)"
-              ;;
-            weekly)
-              EMOJI="🟡"; SEVERITY="重要度: 中"; LABEL="Weekly"
-              START=$(echo "$PERIOD_START" | cut -c1-10); END=$(echo "$PERIOD_END" | cut -c1-10)
-              TITLE="$EMOJI $LABEL Tech Report ($START 〜 $END)"
-              ;;
-            monthly)
-              EMOJI="🔴"; SEVERITY="重要度: 高"; LABEL="Monthly"
-              START=$(echo "$PERIOD_START" | cut -c1-10); END=$(echo "$PERIOD_END" | cut -c1-10)
-              TITLE="$EMOJI $LABEL Tech Report ($START 〜 $END)"
-              ;;
-            *)
-              echo "Unknown kind $KIND – skipping"; exit 0 ;;
-          esac
+          # Build title (monthly is fixed)
+          START=$(echo "$PERIOD_START" | cut -c1-10); END=$(echo "$PERIOD_END" | cut -c1-10)
+          TITLE="🔴 Monthly Tech Report ($START 〜 $END)"
+          SEVERITY="重要度: 高"
 
           # ===== Step A: post parent (title + severity) =====
           PARENT_PAYLOAD=$(jq -n \
@@ -205,14 +193,31 @@ jobs:
           fi
 
           # ===== Step B: post child (chunked body in thread) =====
-          # python で安全に chunk 分割。runner 標準で python3 が入っている。
+          # python で UTF-8 バイト境界で安全に chunk 分割。runner 標準で python3 が入っている。
           CHILD_PAYLOAD=$(VIEWER_URL="$VIEWER_URL" SLACK_CHANNEL_ID="$SLACK_CHANNEL_ID" THREAD_TS="$THREAD_TS" python3 - <<'PYEOF'
           import json, os
+          def split_by_utf8_bytes(text, max_bytes):
+              """Split text into chunks where each chunk is at most max_bytes UTF-8 bytes.
+              Splits only at character boundaries to avoid breaking surrogates."""
+              encoded = text.encode('utf-8')
+              chunks = []
+              start = 0
+              while start < len(encoded):
+                  end = start + max_bytes
+                  if end >= len(encoded):
+                      chunks.append(encoded[start:].decode('utf-8'))
+                      break
+                  # Walk back to a valid UTF-8 character boundary
+                  while end > start and (encoded[end] & 0xC0) == 0x80:
+                      end -= 1
+                  chunks.append(encoded[start:end].decode('utf-8'))
+                  start = end
+              return chunks
           with open('/tmp/slack-message.md', encoding='utf-8') as f:
               msg = f.read().rstrip()
-          CHUNK = 2800       # Slack mrkdwn block limit 3000 chars 安全側
+          MAX_BYTES = 2800   # Slack mrkdwn block limit 3000 bytes (UTF-8) 安全側
           MAX_BLOCKS = 48    # divider + section (viewer link) のために 2 枠残す
-          chunks = [msg[i:i+CHUNK] for i in range(0, len(msg), CHUNK)]
+          chunks = split_by_utf8_bytes(msg, MAX_BYTES)
           truncated = False
           if len(chunks) > MAX_BLOCKS:
               chunks = chunks[:MAX_BLOCKS]

--- a/.github/workflows/report-weekly.yml
+++ b/.github/workflows/report-weekly.yml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   generate-and-save:
@@ -39,6 +38,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_tools: "Bash,Read,Write,WebFetch,Skill"
+          timeout_minutes: 30
           # weekly digest 生成プロンプト。skill 起動と最終ファイル書き出しを明示する。
           prompt: |
             あなたは tech-news-bot の自動レポート生成エージェントです。
@@ -113,11 +113,16 @@ jobs:
               meta: { dedup_total: .dedup_total, by_category: .by_category, by_feed: .by_feed, included_categories: .included_categories }
             }' /tmp/report-meta.json > /tmp/report-payload.json
 
-          curl -fsS -X POST "$WORKER_URL/api/admin/reports" \
+          HTTP_STATUS=$(curl -sS -w '%{http_code}' -X POST "$WORKER_URL/api/admin/reports" \
             -H "Authorization: Bearer $ADMIN_TOKEN" \
             -H "Content-Type: application/json" \
             -o /tmp/post-resp.json \
-            --data-binary @/tmp/report-payload.json
+            --data-binary @/tmp/report-payload.json)
+          if [[ "$HTTP_STATUS" != 2* ]]; then
+            echo "API returned HTTP $HTTP_STATUS" >&2
+            cat /tmp/post-resp.json >&2
+            exit 1
+          fi
 
       - name: Post to Slack (threaded)
         if: ${{ success() }}
@@ -146,31 +151,14 @@ jobs:
           fi
           VIEWER_URL="$WORKER_URL/reports/$REPORT_ID"
 
-          KIND=$(jq -r '.kind' /tmp/report-meta.json)
           PERIOD_START=$(jq -r '.period_start' /tmp/report-meta.json)
           PERIOD_END=$(jq -r '.period_end' /tmp/report-meta.json)
           GENERATED_AT=$(jq -r '.generated_at' /tmp/report-meta.json)
 
-          # Build title (emoji + label + period)
-          case "$KIND" in
-            daily)
-              EMOJI="🟢"; SEVERITY="重要度: 低"; LABEL="Daily"
-              DATE_LABEL=$(echo "$PERIOD_END" | cut -c1-10)
-              TITLE="$EMOJI $LABEL Tech Report ($DATE_LABEL)"
-              ;;
-            weekly)
-              EMOJI="🟡"; SEVERITY="重要度: 中"; LABEL="Weekly"
-              START=$(echo "$PERIOD_START" | cut -c1-10); END=$(echo "$PERIOD_END" | cut -c1-10)
-              TITLE="$EMOJI $LABEL Tech Report ($START 〜 $END)"
-              ;;
-            monthly)
-              EMOJI="🔴"; SEVERITY="重要度: 高"; LABEL="Monthly"
-              START=$(echo "$PERIOD_START" | cut -c1-10); END=$(echo "$PERIOD_END" | cut -c1-10)
-              TITLE="$EMOJI $LABEL Tech Report ($START 〜 $END)"
-              ;;
-            *)
-              echo "Unknown kind $KIND – skipping"; exit 0 ;;
-          esac
+          # Build title (weekly is fixed)
+          START=$(echo "$PERIOD_START" | cut -c1-10); END=$(echo "$PERIOD_END" | cut -c1-10)
+          TITLE="🟡 Weekly Tech Report ($START 〜 $END)"
+          SEVERITY="重要度: 中"
 
           # ===== Step A: post parent (title + severity) =====
           PARENT_PAYLOAD=$(jq -n \
@@ -203,14 +191,31 @@ jobs:
           fi
 
           # ===== Step B: post child (chunked body in thread) =====
-          # python で安全に chunk 分割。runner 標準で python3 が入っている。
+          # python で UTF-8 バイト境界で安全に chunk 分割。runner 標準で python3 が入っている。
           CHILD_PAYLOAD=$(VIEWER_URL="$VIEWER_URL" SLACK_CHANNEL_ID="$SLACK_CHANNEL_ID" THREAD_TS="$THREAD_TS" python3 - <<'PYEOF'
           import json, os
+          def split_by_utf8_bytes(text, max_bytes):
+              """Split text into chunks where each chunk is at most max_bytes UTF-8 bytes.
+              Splits only at character boundaries to avoid breaking surrogates."""
+              encoded = text.encode('utf-8')
+              chunks = []
+              start = 0
+              while start < len(encoded):
+                  end = start + max_bytes
+                  if end >= len(encoded):
+                      chunks.append(encoded[start:].decode('utf-8'))
+                      break
+                  # Walk back to a valid UTF-8 character boundary
+                  while end > start and (encoded[end] & 0xC0) == 0x80:
+                      end -= 1
+                  chunks.append(encoded[start:end].decode('utf-8'))
+                  start = end
+              return chunks
           with open('/tmp/slack-message.md', encoding='utf-8') as f:
               msg = f.read().rstrip()
-          CHUNK = 2800       # Slack mrkdwn block limit 3000 chars 安全側
+          MAX_BYTES = 2800   # Slack mrkdwn block limit 3000 bytes (UTF-8) 安全側
           MAX_BLOCKS = 48    # divider + section (viewer link) のために 2 枠残す
-          chunks = [msg[i:i+CHUNK] for i in range(0, len(msg), CHUNK)]
+          chunks = split_by_utf8_bytes(msg, MAX_BYTES)
           truncated = False
           if len(chunks) > MAX_BLOCKS:
               chunks = chunks[:MAX_BLOCKS]

--- a/apps/web/tests/worker/api/reports.test.ts
+++ b/apps/web/tests/worker/api/reports.test.ts
@@ -179,6 +179,38 @@ describe("POST /api/admin/reports", () => {
     });
     expect(res.status).toBe(400);
   });
+
+  it("400: rejects period_start == period_end", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(
+        buildPayload({
+          period_start: "2026-04-29T00:00:00.000Z",
+          period_end: "2026-04-29T00:00:00.000Z",
+        }),
+      ),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("period_end must be after period_start");
+  });
+
+  it("400: rejects period_start > period_end", async () => {
+    const res = await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(
+        buildPayload({
+          period_start: "2026-04-29T00:00:00.000Z",
+          period_end: "2026-04-28T00:00:00.000Z",
+        }),
+      ),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("period_end must be after period_start");
+  });
 });
 
 describe("GET /api/admin/reports", () => {

--- a/apps/web/worker/api/reports.ts
+++ b/apps/web/worker/api/reports.ts
@@ -88,6 +88,9 @@ function parseInput(
   if (!isISO8601(body.period_end)) {
     return { ok: false, error: "period_end must be ISO 8601 string" };
   }
+  if (new Date(body.period_end).getTime() <= new Date(body.period_start).getTime()) {
+    return { ok: false, error: "period_end must be after period_start" };
+  }
   if (!isISO8601(body.generated_at)) {
     return { ok: false, error: "generated_at must be ISO 8601 string" };
   }


### PR DESCRIPTION
## Summary
report パイプライン監査で出た改善点を一括対応:

- **workflow**: `claude-code-base-action` に `timeout_minutes` を設定 (daily=30, weekly=30, monthly=45) / curl 失敗時にレスポンスボディを stderr 出力 / `id-token: write` を削除 / dead な `KIND` 変数・case 分岐を削除 / Slack チャンクを UTF-8 バイト境界で分割
- **API**: `period_start >= period_end` を 400 で拒否 + テスト追加

## Test plan
- [ ] 既存 `apps/web/tests/worker/api/reports.test.ts` が pass
- [ ] 新規 period validation テストが pass
- [ ] CI all green
- [ ] workflow YAML 構文エラーなし

## Out of scope
- timingSafeEqual / authGuard 共通化 (別 PR 予定)
- recent.mjs / search.mjs 改善 (別 PR で進行中)