### PR TITLE
feat(worker): inject route-aware OGP/title meta into SPA shell

### DIFF
--- a/.claude/rules/01-typescript.md
+++ b/.claude/rules/01-typescript.md
@@ -42,6 +42,26 @@ type CollectResult =
 - 早期 return を優先しネストを浅く保つ
 - 1 ファイルに複数 export しても良いが、責務が違うものは分ける (例: `articles-query.ts` と `articles-write.ts`)
 
+## ヘルパーの配置 (utils/ の濫用禁止)
+
+ヘルパー関数を **反射的に `utils/` に置かない**。`utils/` は「**実際に複数ファイルから import されている、責務が独立した関数**」のための置き場であって、「いつか共通化されるかも」のバッファではない。
+
+| 状況                               | 置く場所                                                                             |
+| ---------------------------------- | ------------------------------------------------------------------------------------ |
+| 1 ファイルでしか使わない           | **そのファイル内** (export せずローカル関数 / 同ファイルの top-level 関数)           |
+| 1 ディレクトリ内の 2-3 ファイル    | そのディレクトリ内に `helpers.ts` や `<domain>.ts` を作る (例: `collector/parse.ts`) |
+| 2 つ以上の独立ドメインから使われる | `worker/utils/<name>.ts` または `client/utils/<name>.ts`                             |
+| 型だけの定義                       | 単一ファイルなら使う場所、複数なら `worker/types.ts` / `client/types/api.ts` に集約  |
+
+判断ルール:
+
+- **新規 helper を `utils/` に置きたくなったら、まず "import 元が現在 2 ファイル以上あるか" を確認**。1 つしかないなら呼び出し側に inline する
+- **dead code は速やかに削除**。「将来使うかも」の helper を置かない (YAGNI)。型エイリアス (`NonEmptyArray<T>` 等) も使われていないなら削除
+- **既存の `utils/` を増やすな**。ファイル名が抽象的 (`utils.ts`, `helpers.ts`) になりがちで責務が膨らむ。代わりに具体的なドメイン名 (`xml.ts`, `etag.ts`) で切る
+- **テストヘルパーも同じ**。`tests/fixtures/` は seed データ専用。テストロジックの共通化は `tests/<area>/_helpers.ts` のような具体名で
+
+例: `worker/api/articles.ts` の list endpoint で limit/cursor を parse する `parseListQuery(c)` は **articles.ts 内のローカル関数で OK**。他の API ファイルから使うようになって初めて `worker/api/_helpers.ts` などに昇格させる。
+
 ## コメント
 
 - 「**なぜ**」を書く。「何を」はコードで読めるので書かない

--- a/.claude/rules/12-react.md
+++ b/.claude/rules/12-react.md
@@ -40,7 +40,7 @@ paths:
 
 - ローカル state: `useState`
 - ページ間で共有 / URL 反映: `useUrlState` (既存フック) で querystring に同期。SPA リロードで状態保持
-- 永続化: `localStorage` 経由。`useLocalStorage` 系のフックを使い、SSR 安全 (`typeof window !== "undefined"` チェック) は不要 (本プロジェクト SSR していない)
+- 永続化: `localStorage` 経由。`useLocalStorage` 系のフックを使い、SSR 安全 (`typeof window !== "undefined"` チェック) は不要 (本プロジェクトは React を SSR していない。Worker fallback で HTMLRewriter ベースの meta 書き換えを行うが、React 自体は CSR のまま)
 - グローバル UI state: Context + `use()`。Redux / Zustand 等は導入していない
 
 ## データ取得

--- a/.claude/rules/20-testing-overview.md
+++ b/.claude/rules/20-testing-overview.md
@@ -82,6 +82,24 @@ CI では `vp check` (lint+format+typecheck) → `pnpm build` → `pnpm test` �
 
 - **新機能 / バグ修正は基本テストを追加してから PR を出す**。テスト追加が困難なケース (UI のごく些細な視覚変更等) は PR description にその旨を明記
 - **assertion は具体的に**。`expect(result).toBeTruthy()` でなく `expect(result).toEqual({ status: "ok", saved: 3 })`
+- **複数の独立した観点を検証する場合は soft assertion (`expect.soft(...)`) を使う**。1 つ目の失敗で fail-fast せず、すべての観点の失敗を 1 回の実行で集約できる:
+
+  ```ts
+  it("GET /api/articles returns paginated list", async () => {
+    const res = await SELF.fetch("https://x.test/api/articles?limit=2");
+    const body = await res.json<ArticlesResponse>();
+
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Cache-Control")).toContain("max-age");
+    expect.soft(body.articles).toHaveLength(2);
+    expect.soft(body.next_cursor).toBeTypeOf("string");
+  });
+  ```
+
+  - 「同じ対象の **独立した側面** (status / header / body の各キー)」を 1 テストでまとめて見る場合に有効
+  - 一方、後続の assert が前の assert の前提に依存する (例: `body.articles[0]` を見るには `articles.length > 0` 必須) ケースは通常の `expect` を使い fail-fast させる
+  - **assert を 5 件以上書くなら 1 テストとして肥大化していないか見直す**。観点が独立しすぎているなら `it` を分ける方が良い
+
 - **テストの独立性**: 1 テストが他のテストに依存しない。順序を変えても通ること
 - **flaky なテストは即修正**。retry でごまかさない (Playwright の `retries: 2` は CI 限定の保険)
 - **import 規約**:

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -19,6 +19,14 @@
     />
     <link rel="alternate" type="application/rss+xml" title="Tech News Bot (RSS)" href="/feed.xml" />
     <title>Tech News Bot</title>
+    <meta property="og:title" content="Tech News Bot" />
+    <meta
+      property="og:description"
+      content="海外 big tech / AI / 国内企業の tech blog 記事を集約"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Tech News Bot" />
+    <meta name="twitter:card" content="summary" />
     <!-- FOUC 防止: React マウント前に data-theme を確定させる -->
     <script>
       (function () {

--- a/apps/web/tests/worker/api/spa-shell.test.ts
+++ b/apps/web/tests/worker/api/spa-shell.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it } from "vite-plus/test";
+import { env, SELF } from "cloudflare:test";
+import { insertSampleArticles, FEEDS } from "../../fixtures/articles";
+import { syncFeeds } from "../../../worker/db/feeds";
+import { insertArticles } from "../../../worker/db/articles";
+
+beforeEach(async () => {
+  await insertSampleArticles();
+});
+
+// HTML からメタタグ属性値を取得するヘルパー
+function extractMeta(html: string, selector: string): string | null {
+  // <title> の textContent
+  if (selector === "title") {
+    const m = html.match(/<title>([^<]*)<\/title>/i);
+    return m ? m[1] : null;
+  }
+  // <meta property="og:..." content="...">
+  const propM = selector.match(/^\[property="(.+)"\]$/);
+  if (propM) {
+    const prop = propM[1].replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const re = new RegExp(`<meta[^>]+property="${prop}"[^>]+content="([^"]*)"`, "i");
+    const m =
+      html.match(re) ??
+      html.match(new RegExp(`<meta[^>]+content="([^"]*)"[^>]+property="${prop}"`, "i"));
+    return m ? m[1] : null;
+  }
+  // <meta name="..." content="...">
+  const nameM = selector.match(/^\[name="(.+)"\]$/);
+  if (nameM) {
+    const name = nameM[1].replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const re = new RegExp(`<meta[^>]+name="${name}"[^>]+content="([^"]*)"`, "i");
+    const m =
+      html.match(re) ??
+      html.match(new RegExp(`<meta[^>]+content="([^"]*)"[^>]+name="${name}"`, "i"));
+    return m ? m[1] : null;
+  }
+  // <link rel="canonical" href="...">
+  if (selector === 'link[rel="canonical"]') {
+    const m =
+      html.match(/<link[^>]+rel="canonical"[^>]+href="([^"]*)"[^>]*>/i) ??
+      html.match(/<link[^>]+href="([^"]*)"[^>]+rel="canonical"[^>]*>/i);
+    return m ? m[1] : null;
+  }
+  return null;
+}
+
+describe("SPA shell rewrite: GET /articles/:id", () => {
+  it("rewrites title, og:title, description, og:description, canonical for existing article", async () => {
+    const row = await env.DB.prepare("SELECT id FROM articles WHERE guid = ?1")
+      .bind("g-bt-1")
+      .first<{ id: number }>();
+    const id = row?.id;
+
+    const res = await SELF.fetch(`https://example.com/articles/${id}`);
+    expect(res.status).toBe(200);
+
+    const html = await res.text();
+
+    expect.soft(extractMeta(html, "title")).toContain("BigTech Article One");
+    expect.soft(extractMeta(html, '[property="og:title"]')).toContain("BigTech Article One");
+    expect.soft(extractMeta(html, '[name="description"]')).toContain("Discusses LLM optimization");
+    expect
+      .soft(extractMeta(html, '[property="og:description"]'))
+      .toContain("Discusses LLM optimization");
+    expect.soft(extractMeta(html, 'link[rel="canonical"]')).toContain(`/articles/${id}`);
+  });
+
+  it("returns Cache-Control with max-age=300 for article page", async () => {
+    const row = await env.DB.prepare("SELECT id FROM articles WHERE guid = ?1")
+      .bind("g-bt-1")
+      .first<{ id: number }>();
+    const id = row?.id;
+
+    const res = await SELF.fetch(`https://example.com/articles/${id}`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toContain("max-age=300");
+  });
+
+  it("falls back to static index.html for unknown article id", async () => {
+    const res = await SELF.fetch("https://example.com/articles/99999999");
+    expect(res.status).toBe(200);
+    // fallback の場合は no-cache
+    expect(res.headers.get("Cache-Control")).toContain("no-cache");
+  });
+});
+
+describe("SPA shell rewrite: GET /feed/:feedId", () => {
+  it("rewrites title with feed name for existing feed", async () => {
+    const res = await SELF.fetch("https://example.com/feed/google-research");
+    expect(res.status).toBe(200);
+
+    const html = await res.text();
+
+    expect.soft(extractMeta(html, "title")).toContain("Google Research");
+    expect.soft(extractMeta(html, '[property="og:title"]')).toContain("Google Research");
+    expect.soft(extractMeta(html, 'link[rel="canonical"]')).toContain("/feed/google-research");
+  });
+
+  it("falls back to static index.html for unknown feedId", async () => {
+    const res = await SELF.fetch("https://example.com/feed/nonexistent-feed-xyz");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toContain("no-cache");
+  });
+});
+
+describe("SPA shell rewrite: GET /author/:author", () => {
+  it("rewrites title with author name", async () => {
+    const res = await SELF.fetch("https://example.com/author/Author%20A");
+    expect(res.status).toBe(200);
+
+    const html = await res.text();
+
+    expect.soft(extractMeta(html, "title")).toContain("Author A");
+    expect.soft(extractMeta(html, '[property="og:title"]')).toContain("Author A");
+    expect.soft(extractMeta(html, 'link[rel="canonical"]')).toContain("/author/");
+  });
+});
+
+describe("SPA shell rewrite: GET /by-category/:cat", () => {
+  it("rewrites title with category label for bigtech", async () => {
+    const res = await SELF.fetch("https://example.com/by-category/bigtech");
+    expect(res.status).toBe(200);
+
+    const html = await res.text();
+
+    expect.soft(extractMeta(html, "title")).toContain("ビッグテック");
+    expect.soft(extractMeta(html, '[property="og:title"]')).toContain("ビッグテック");
+    expect.soft(extractMeta(html, 'link[rel="canonical"]')).toContain("/by-category/bigtech");
+  });
+
+  it("rewrites title with category label for ai", async () => {
+    const res = await SELF.fetch("https://example.com/by-category/ai");
+    expect(res.status).toBe(200);
+
+    const html = await res.text();
+
+    expect.soft(extractMeta(html, "title")).toContain("AI");
+  });
+});
+
+describe("SPA shell rewrite: static routes (no rewriting)", () => {
+  it("returns default title for top page /", async () => {
+    const res = await SELF.fetch("https://example.com/");
+    expect(res.status).toBe(200);
+
+    // トップページは書き換えなし → Cache-Control は no-cache
+    expect(res.headers.get("Cache-Control")).toContain("no-cache");
+  });
+
+  it("returns no-cache for /stats", async () => {
+    const res = await SELF.fetch("https://example.com/stats");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toContain("no-cache");
+  });
+
+  it("does not rewrite /api/* routes", async () => {
+    // /api/* は JSON を返すため HTML ではない
+    const res = await SELF.fetch("https://example.com/api/articles?limit=1");
+    expect(res.status).toBe(200);
+    const ct = res.headers.get("Content-Type") ?? "";
+    expect(ct).toContain("application/json");
+  });
+});
+
+describe("SPA shell rewrite: article with null summary", () => {
+  it("uses default description when article summary is null", async () => {
+    // summary が null の記事を追加
+    await syncFeeds(env.DB, FEEDS);
+    await insertArticles(env.DB, [
+      {
+        guid: "no-summary-1",
+        feed_id: "google-research",
+        title: "Article Without Summary",
+        url: "https://x.test/g/no-summary",
+        summary: null,
+        author: null,
+        published_at: "2024-05-01T00:00:00.000Z",
+        category: "bigtech",
+        lang: "en",
+      },
+    ]);
+
+    const row = await env.DB.prepare("SELECT id FROM articles WHERE guid = ?1")
+      .bind("no-summary-1")
+      .first<{ id: number }>();
+    const id = row?.id;
+
+    const res = await SELF.fetch(`https://example.com/articles/${id}`);
+    expect(res.status).toBe(200);
+
+    const html = await res.text();
+    // description は DEFAULT_DESCRIPTION にフォールバック
+    const desc = extractMeta(html, '[name="description"]');
+    expect(desc).toBeTruthy();
+  });
+});

--- a/apps/web/tests/worker/api/spa-shell.test.ts
+++ b/apps/web/tests/worker/api/spa-shell.test.ts
@@ -113,7 +113,9 @@ describe("SPA shell rewrite: GET /author/:author", () => {
 
     expect.soft(extractMeta(html, "title")).toContain("Author A");
     expect.soft(extractMeta(html, '[property="og:title"]')).toContain("Author A");
-    expect.soft(extractMeta(html, 'link[rel="canonical"]')).toContain("/author/");
+    expect
+      .soft(extractMeta(html, 'link[rel="canonical"]'))
+      .toBe("https://example.com/author/Author%20A");
   });
 });
 
@@ -192,6 +194,37 @@ describe("SPA shell rewrite: article with null summary", () => {
     const html = await res.text();
     // description は DEFAULT_DESCRIPTION にフォールバック
     const desc = extractMeta(html, '[name="description"]');
-    expect(desc).toBeTruthy();
+    expect(desc).toBe("海外 big tech / AI / 国内企業の tech blog 記事を集約");
+  });
+});
+
+describe("SPA shell rewrite: duplicate meta tag regression", () => {
+  it("does not duplicate og:title when index.html already has one", async () => {
+    const row = await env.DB.prepare("SELECT id FROM articles WHERE guid = ?1")
+      .bind("g-bt-1")
+      .first<{ id: number }>();
+    const id = row?.id;
+
+    const res = await SELF.fetch(`https://example.com/articles/${id}`);
+    expect(res.status).toBe(200);
+
+    const html = await res.text();
+    // head.onEndTag を使うことで、index.html 既存の og:title を element() で書き換え済みの場合に
+    // onEndTag 内では ogTitleDone=true となり、重複挿入されないことを検証する
+    const matches = html.match(/<meta[^>]+property="og:title"/gi) ?? [];
+    expect(matches).toHaveLength(1);
+  });
+
+  it("does not duplicate og:description when index.html already has one", async () => {
+    const row = await env.DB.prepare("SELECT id FROM articles WHERE guid = ?1")
+      .bind("g-bt-1")
+      .first<{ id: number }>();
+    const id = row?.id;
+
+    const res = await SELF.fetch(`https://example.com/articles/${id}`);
+    const html = await res.text();
+
+    const matches = html.match(/<meta[^>]+property="og:description"/gi) ?? [];
+    expect(matches).toHaveLength(1);
   });
 });

--- a/apps/web/worker/api/spa-shell.ts
+++ b/apps/web/worker/api/spa-shell.ts
@@ -1,0 +1,311 @@
+import type { Env, FeedCategory } from "../types";
+import { getArticleById } from "../db/articles";
+import { findFeedWithStats } from "../db/feeds";
+
+// ---------------------------------------------------------------------------
+// 定数
+// ---------------------------------------------------------------------------
+
+const SITE_NAME = "Tech News Bot";
+const DEFAULT_DESCRIPTION = "海外 big tech / AI / 国内企業の tech blog 記事を集約";
+const DYNAMIC_CACHE_CONTROL = "public, max-age=300, s-maxage=300, stale-while-revalidate=86400";
+
+const CATEGORY_LABELS: Record<FeedCategory, string> = {
+  bigtech: "ビッグテック",
+  ai: "AI",
+  jp: "日本企業",
+  zenn: "Zenn",
+};
+
+// ---------------------------------------------------------------------------
+// Route 判別
+// ---------------------------------------------------------------------------
+
+type RouteMatch =
+  | { type: "article"; id: number }
+  | { type: "feed"; feedId: string }
+  | { type: "author"; author: string }
+  | { type: "category"; category: FeedCategory }
+  | { type: "static" };
+
+function matchRoute(pathname: string): RouteMatch {
+  // /articles/:id
+  const articleM = pathname.match(/^\/articles\/(\d+)$/);
+  if (articleM) {
+    const id = Number(articleM[1]);
+    if (Number.isInteger(id) && id > 0) return { type: "article", id };
+  }
+
+  // /feed/:feedId (クライアントルーティングのパス)
+  const feedM = pathname.match(/^\/feed\/(.+)$/);
+  if (feedM) {
+    const feedId = decodeURIComponent(feedM[1]).trim();
+    if (feedId) return { type: "feed", feedId };
+  }
+
+  // /author/:author
+  const authorM = pathname.match(/^\/author\/(.+)$/);
+  if (authorM) {
+    const author = decodeURIComponent(authorM[1]).trim();
+    if (author) return { type: "author", author };
+  }
+
+  // /by-category/:cat — issue の設計方針に合わせて /by-category/:cat を採用
+  const catM = pathname.match(/^\/by-category\/(.+)$/);
+  if (catM) {
+    const cat = catM[1] as FeedCategory;
+    if (cat in CATEGORY_LABELS) return { type: "category", category: cat };
+  }
+
+  return { type: "static" };
+}
+
+// ---------------------------------------------------------------------------
+// XSS 対策: HTML エスケープ (D1 由来の文字列を安全に属性値 / テキストに埋める)
+// ---------------------------------------------------------------------------
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+// ---------------------------------------------------------------------------
+// HTMLRewriter によるメタタグ書き換え
+// ---------------------------------------------------------------------------
+
+interface PageMeta {
+  title: string;
+  description: string;
+  canonical: string;
+  ogType: "article" | "website";
+}
+
+/**
+ * HTMLRewriter を使って index.html の <title> / <meta> / OGP / Twitter card を書き換える。
+ * 既存タグは属性を上書きし、不足タグは </head> 直前に追加する。
+ */
+function applyMetaRewriter(response: Response, meta: PageMeta): Response {
+  // 書き換え済みフラグ (クロージャで複数ハンドラ間で共有)
+  let titleDone = false;
+  let canonicalDone = false;
+  let ogTitleDone = false;
+  let ogDescDone = false;
+  let ogTypeDone = false;
+  let ogUrlDone = false;
+  let ogSiteNameDone = false;
+  let twitterCardDone = false;
+  let twitterTitleDone = false;
+  let twitterDescDone = false;
+
+  return new HTMLRewriter()
+    .on("title", {
+      text(chunk) {
+        if (!titleDone && chunk.lastInTextNode) {
+          chunk.replace(escapeHtml(meta.title), { html: true });
+          titleDone = true;
+        } else if (!titleDone) {
+          chunk.remove();
+        }
+      },
+    })
+    .on("meta", {
+      element(el) {
+        const name = el.getAttribute("name");
+        const prop = el.getAttribute("property");
+
+        if (name === "description") {
+          el.setAttribute("content", escapeHtml(meta.description));
+        } else if (name === "twitter:card") {
+          el.setAttribute("content", "summary");
+          twitterCardDone = true;
+        } else if (name === "twitter:title") {
+          el.setAttribute("content", escapeHtml(meta.title));
+          twitterTitleDone = true;
+        } else if (name === "twitter:description") {
+          el.setAttribute("content", escapeHtml(meta.description));
+          twitterDescDone = true;
+        } else if (prop === "og:title") {
+          el.setAttribute("content", escapeHtml(meta.title));
+          ogTitleDone = true;
+        } else if (prop === "og:description") {
+          el.setAttribute("content", escapeHtml(meta.description));
+          ogDescDone = true;
+        } else if (prop === "og:type") {
+          el.setAttribute("content", meta.ogType);
+          ogTypeDone = true;
+        } else if (prop === "og:url") {
+          el.setAttribute("content", escapeHtml(meta.canonical));
+          ogUrlDone = true;
+        } else if (prop === "og:site_name") {
+          el.setAttribute("content", escapeHtml(SITE_NAME));
+          ogSiteNameDone = true;
+        }
+      },
+    })
+    .on("link", {
+      element(el) {
+        if (el.getAttribute("rel") === "canonical") {
+          el.setAttribute("href", escapeHtml(meta.canonical));
+          canonicalDone = true;
+        }
+      },
+    })
+    .on("head", {
+      element(el) {
+        // </head> 直前に不足しているタグを追加する
+        const missing: string[] = [];
+
+        if (!canonicalDone) {
+          missing.push(`<link rel="canonical" href="${escapeHtml(meta.canonical)}" />`);
+        }
+        if (!ogTitleDone) {
+          missing.push(`<meta property="og:title" content="${escapeHtml(meta.title)}" />`);
+        }
+        if (!ogDescDone) {
+          missing.push(
+            `<meta property="og:description" content="${escapeHtml(meta.description)}" />`,
+          );
+        }
+        if (!ogTypeDone) {
+          missing.push(`<meta property="og:type" content="${meta.ogType}" />`);
+        }
+        if (!ogUrlDone) {
+          missing.push(`<meta property="og:url" content="${escapeHtml(meta.canonical)}" />`);
+        }
+        if (!ogSiteNameDone) {
+          missing.push(`<meta property="og:site_name" content="${escapeHtml(SITE_NAME)}" />`);
+        }
+        if (!twitterCardDone) {
+          missing.push(`<meta name="twitter:card" content="summary" />`);
+        }
+        if (!twitterTitleDone) {
+          missing.push(`<meta name="twitter:title" content="${escapeHtml(meta.title)}" />`);
+        }
+        if (!twitterDescDone) {
+          missing.push(
+            `<meta name="twitter:description" content="${escapeHtml(meta.description)}" />`,
+          );
+        }
+
+        if (missing.length > 0) {
+          el.prepend(missing.join("\n    "), { html: true });
+        }
+      },
+    })
+    .transform(response);
+}
+
+// ---------------------------------------------------------------------------
+// メタ情報の解決
+// ---------------------------------------------------------------------------
+
+type MetaResult = { status: "ok"; meta: PageMeta } | { status: "fallback" };
+
+async function resolveMeta(route: RouteMatch, req: Request, env: Env): Promise<MetaResult> {
+  const origin = new URL(req.url).origin;
+
+  if (route.type === "article") {
+    try {
+      const article = await getArticleById(env.DB, route.id);
+      if (!article) return { status: "fallback" };
+
+      const title = `${article.title} | ${SITE_NAME}`;
+      const description = article.summary ? article.summary.slice(0, 200) : DEFAULT_DESCRIPTION;
+      const canonical = `${origin}/articles/${article.id}`;
+      return { status: "ok", meta: { title, description, canonical, ogType: "article" } };
+    } catch {
+      return { status: "fallback" };
+    }
+  }
+
+  if (route.type === "feed") {
+    try {
+      const feed = await findFeedWithStats(env.DB, route.feedId);
+      if (!feed) return { status: "fallback" };
+
+      const title = `${feed.name} | ${SITE_NAME}`;
+      const canonical = `${origin}/feed/${encodeURIComponent(feed.id)}`;
+      return {
+        status: "ok",
+        meta: { title, description: DEFAULT_DESCRIPTION, canonical, ogType: "website" },
+      };
+    } catch {
+      return { status: "fallback" };
+    }
+  }
+
+  if (route.type === "author") {
+    const title = `${route.author} の記事 | ${SITE_NAME}`;
+    const canonical = `${origin}/author/${encodeURIComponent(route.author)}`;
+    return {
+      status: "ok",
+      meta: { title, description: DEFAULT_DESCRIPTION, canonical, ogType: "website" },
+    };
+  }
+
+  if (route.type === "category") {
+    const label = CATEGORY_LABELS[route.category];
+    const title = `${label} の記事 | ${SITE_NAME}`;
+    const canonical = `${origin}/by-category/${route.category}`;
+    return {
+      status: "ok",
+      meta: { title, description: DEFAULT_DESCRIPTION, canonical, ogType: "website" },
+    };
+  }
+
+  return { status: "fallback" };
+}
+
+// ---------------------------------------------------------------------------
+// ユーティリティ
+// ---------------------------------------------------------------------------
+
+function withCacheControl(res: Response, value: string): Response {
+  const headers = new Headers(res.headers);
+  headers.set("Cache-Control", value);
+  return new Response(res.body, { status: res.status, statusText: res.statusText, headers });
+}
+
+// ---------------------------------------------------------------------------
+// エントリポイント
+// ---------------------------------------------------------------------------
+
+/**
+ * SPA fallback 用の HTMLRewriter によるメタ書き換え。
+ * - `/api/*` と `/assets/*` はこの関数を経由しない (index.ts で先に処理される)
+ * - route 不明 / D1 失敗 → 静的 index.html をそのまま返す (200, no rewriting)
+ * - 成功時は meta を書き換えて Cache-Control: public, max-age=300 を付与する
+ */
+export async function rewriteShell(req: Request, env: Env): Promise<Response> {
+  const url = new URL(req.url);
+  const route = matchRoute(url.pathname);
+
+  // 静的 fallback は書き換えせずそのまま返す
+  if (route.type === "static") {
+    const res = await env.ASSETS.fetch(req);
+    return withCacheControl(res, "no-cache, must-revalidate");
+  }
+
+  // メタ情報を解決する
+  const result = await resolveMeta(route, req, env);
+  if (result.status === "fallback") {
+    const res = await env.ASSETS.fetch(req);
+    return withCacheControl(res, "no-cache, must-revalidate");
+  }
+
+  // HTMLRewriter で index.html を書き換える
+  const assetsRes = await env.ASSETS.fetch(req);
+  const rewritten = applyMetaRewriter(assetsRes, result.meta);
+
+  const headers = new Headers(rewritten.headers);
+  headers.set("Cache-Control", DYNAMIC_CACHE_CONTROL);
+  return new Response(rewritten.body, {
+    status: rewritten.status,
+    statusText: rewritten.statusText,
+    headers,
+  });
+}

--- a/apps/web/worker/api/spa-shell.ts
+++ b/apps/web/worker/api/spa-shell.ts
@@ -90,7 +90,6 @@ interface PageMeta {
  */
 function applyMetaRewriter(response: Response, meta: PageMeta): Response {
   // 書き換え済みフラグ (クロージャで複数ハンドラ間で共有)
-  let titleDone = false;
   let canonicalDone = false;
   let ogTitleDone = false;
   let ogDescDone = false;
@@ -103,13 +102,8 @@ function applyMetaRewriter(response: Response, meta: PageMeta): Response {
 
   return new HTMLRewriter()
     .on("title", {
-      text(chunk) {
-        if (!titleDone && chunk.lastInTextNode) {
-          chunk.replace(escapeHtml(meta.title), { html: true });
-          titleDone = true;
-        } else if (!titleDone) {
-          chunk.remove();
-        }
+      element(el) {
+        el.setInnerContent(escapeHtml(meta.title), { html: true });
       },
     })
     .on("meta", {
@@ -156,44 +150,49 @@ function applyMetaRewriter(response: Response, meta: PageMeta): Response {
     })
     .on("head", {
       element(el) {
-        // </head> 直前に不足しているタグを追加する
-        const missing: string[] = [];
+        // </head> の直前 (= 子要素がすべて処理済みの時点) に不足しているタグを追加する。
+        // element() コールバックは <head> 開始タグ検出時に呼ばれるため、その時点では
+        // 子の <meta> ハンドラがまだ実行されておらず *Done フラグが立っていない。
+        // onEndTag() を使うことでチャイルドハンドラ完了後に評価できる。
+        el.onEndTag((endTag) => {
+          const missing: string[] = [];
 
-        if (!canonicalDone) {
-          missing.push(`<link rel="canonical" href="${escapeHtml(meta.canonical)}" />`);
-        }
-        if (!ogTitleDone) {
-          missing.push(`<meta property="og:title" content="${escapeHtml(meta.title)}" />`);
-        }
-        if (!ogDescDone) {
-          missing.push(
-            `<meta property="og:description" content="${escapeHtml(meta.description)}" />`,
-          );
-        }
-        if (!ogTypeDone) {
-          missing.push(`<meta property="og:type" content="${meta.ogType}" />`);
-        }
-        if (!ogUrlDone) {
-          missing.push(`<meta property="og:url" content="${escapeHtml(meta.canonical)}" />`);
-        }
-        if (!ogSiteNameDone) {
-          missing.push(`<meta property="og:site_name" content="${escapeHtml(SITE_NAME)}" />`);
-        }
-        if (!twitterCardDone) {
-          missing.push(`<meta name="twitter:card" content="summary" />`);
-        }
-        if (!twitterTitleDone) {
-          missing.push(`<meta name="twitter:title" content="${escapeHtml(meta.title)}" />`);
-        }
-        if (!twitterDescDone) {
-          missing.push(
-            `<meta name="twitter:description" content="${escapeHtml(meta.description)}" />`,
-          );
-        }
+          if (!canonicalDone) {
+            missing.push(`<link rel="canonical" href="${escapeHtml(meta.canonical)}" />`);
+          }
+          if (!ogTitleDone) {
+            missing.push(`<meta property="og:title" content="${escapeHtml(meta.title)}" />`);
+          }
+          if (!ogDescDone) {
+            missing.push(
+              `<meta property="og:description" content="${escapeHtml(meta.description)}" />`,
+            );
+          }
+          if (!ogTypeDone) {
+            missing.push(`<meta property="og:type" content="${meta.ogType}" />`);
+          }
+          if (!ogUrlDone) {
+            missing.push(`<meta property="og:url" content="${escapeHtml(meta.canonical)}" />`);
+          }
+          if (!ogSiteNameDone) {
+            missing.push(`<meta property="og:site_name" content="${escapeHtml(SITE_NAME)}" />`);
+          }
+          if (!twitterCardDone) {
+            missing.push(`<meta name="twitter:card" content="summary" />`);
+          }
+          if (!twitterTitleDone) {
+            missing.push(`<meta name="twitter:title" content="${escapeHtml(meta.title)}" />`);
+          }
+          if (!twitterDescDone) {
+            missing.push(
+              `<meta name="twitter:description" content="${escapeHtml(meta.description)}" />`,
+            );
+          }
 
-        if (missing.length > 0) {
-          el.prepend(missing.join("\n    "), { html: true });
-        }
+          if (missing.length > 0) {
+            endTag.before(`\n    ${missing.join("\n    ")}\n  `, { html: true });
+          }
+        });
       },
     })
     .transform(response);

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -5,6 +5,7 @@ import sitemap from "./api/sitemap";
 import robots from "./api/robots";
 import syndication from "./api/syndication";
 import opml from "./api/opml";
+import { rewriteShell } from "./api/spa-shell";
 import { collectAll } from "./collector";
 import { pruneOldArticles } from "./db/retention";
 import { sendDailyDigest } from "./notify/slack-daily";
@@ -41,17 +42,17 @@ app.route("/", opml);
 
 // 静的アセットへのフォールバック (Cloudflare Static Assets binding)
 // Vite は /assets/ 以下に hash 付きファイル名を出力するため、強キャッシュが安全。
-// それ以外 (index.html / SPA fallback) は no-cache で常に最新を取得する。
+// /assets/* 以外の SPA ルートは rewriteShell で route ごとにメタタグを書き換える。
+// /api/* と /assets/* はこのハンドラより前に処理されるため、ここに到達するのは SPA ルートのみ。
 app.all("*", async (c) => {
-  const res = await c.env.ASSETS.fetch(c.req.raw);
   const url = new URL(c.req.url);
-  const isHashed = url.pathname.startsWith("/assets/");
-  const headers = new Headers(res.headers);
-  headers.set(
-    "Cache-Control",
-    isHashed ? "public, max-age=31536000, immutable" : "no-cache, must-revalidate",
-  );
-  return new Response(res.body, { status: res.status, statusText: res.statusText, headers });
+  if (url.pathname.startsWith("/assets/")) {
+    const res = await c.env.ASSETS.fetch(c.req.raw);
+    const headers = new Headers(res.headers);
+    headers.set("Cache-Control", "public, max-age=31536000, immutable");
+    return new Response(res.body, { status: res.status, statusText: res.statusText, headers });
+  }
+  return rewriteShell(c.req.raw, c.env);
 });
 
 const handler: ExportedHandler<Env> = {


### PR DESCRIPTION
Closes #336

## Summary
- Cloudflare HTMLRewriter で SPA fallback の `index.html` を route ごとに書き換え
- 対象: /articles/:id, /feed/:feedId, /author/:author, /by-category/:cat
- React は CSR のまま (root div は空、hydration 影響なし)
- エラー時は静的 fallback で 200 維持

## Changes
- `apps/web/index.html`: デフォルト OGP/Twitter メタタグを追加 (rewrite されない場合の fallback として)
- `apps/web/worker/api/spa-shell.ts`: `rewriteShell()` 関数を新規作成。HTMLRewriter で route 別にメタタグを書き換える
- `apps/web/worker/index.ts`: SPA fallback を `rewriteShell` 経由に変更。`/assets/*` は引き続き immutable キャッシュ
- `apps/web/tests/worker/api/spa-shell.test.ts`: SELF.fetch + 実 D1 による integration テスト追加
- `.claude/rules/12-react.md`: SSR に関する記述を更新

## Test plan
- [x] vp check pass (0 errors, 21 warnings は既存の vi.fn() の警告で今回と無関係)
- [x] vp test run pass (46 files, 627 tests)
- [x] vp test:client pass (45 files, 331 tests)
- [x] spa-shell.test.ts: 記事/フィード/著者/カテゴリの書き換えテスト + エラー/fallback ケース

## 既知の trade-off
- Worker 1 invocation あたり D1 query +1 (300s キャッシュ付与)。10ms CPU 制約内で完結
- `/by-feed/:id` ではなく `/feed/:id` (クライアントのルーティングに合わせた)