### PR TITLE
fix(collector): エラー分類・observability・URL 正規化の改善

### DIFF
--- a/apps/web/tests/worker/collector/alert.test.ts
+++ b/apps/web/tests/worker/collector/alert.test.ts
@@ -29,6 +29,7 @@ const errResult = (id: string, error = "HTTP 503"): CollectResult => ({
   inserted: 0,
   parsed: 0,
   error,
+  errorKind: "http_server",
 });
 
 const TEST_FEEDS: FeedConfig[] = [

--- a/apps/web/tests/worker/collector/deduplicator.test.ts
+++ b/apps/web/tests/worker/collector/deduplicator.test.ts
@@ -1,5 +1,66 @@
 import { describe, expect, it } from "vite-plus/test";
-import { buildGuid } from "../../../worker/collector/deduplicator";
+import { buildGuid, normalizeUrl } from "../../../worker/collector/deduplicator";
+
+describe("normalizeUrl", () => {
+  it("normalizes http to https", () => {
+    expect(normalizeUrl("http://example.com/page")).toBe("https://example.com/page");
+  });
+
+  it("keeps https unchanged", () => {
+    expect(normalizeUrl("https://example.com/page")).toBe("https://example.com/page");
+  });
+
+  it("removes trailing slash from path", () => {
+    expect(normalizeUrl("https://example.com/page/")).toBe("https://example.com/page");
+  });
+
+  it("does not remove trailing slash from root path", () => {
+    // ルートパス "/" はそのまま保持する
+    expect(normalizeUrl("https://example.com/")).toBe("https://example.com/");
+  });
+
+  it("trims whitespace", () => {
+    expect(normalizeUrl("  https://example.com/page  ")).toBe("https://example.com/page");
+  });
+
+  it("returns trimmed input for invalid URLs", () => {
+    expect(normalizeUrl("  not-a-url  ")).toBe("not-a-url");
+  });
+
+  it("combines http and trailing slash normalization", () => {
+    expect(normalizeUrl("http://example.com/page/")).toBe("https://example.com/page");
+  });
+});
+
+describe("buildGuid url-based dedup", () => {
+  it("generates same guid for http and https variant of the same URL", async () => {
+    const httpGuid = await buildGuid({
+      feedId: "f1",
+      rawGuid: null,
+      url: "http://example.com/page",
+    });
+    const httpsGuid = await buildGuid({
+      feedId: "f1",
+      rawGuid: null,
+      url: "https://example.com/page",
+    });
+    expect(httpGuid).toBe(httpsGuid);
+  });
+
+  it("generates same guid for URL with and without trailing slash", async () => {
+    const withSlash = await buildGuid({
+      feedId: "f1",
+      rawGuid: null,
+      url: "https://example.com/page/",
+    });
+    const withoutSlash = await buildGuid({
+      feedId: "f1",
+      rawGuid: null,
+      url: "https://example.com/page",
+    });
+    expect(withSlash).toBe(withoutSlash);
+  });
+});
 
 describe("buildGuid", () => {
   it("uses raw guid when present", async () => {

--- a/apps/web/tests/worker/collector/retry.test.ts
+++ b/apps/web/tests/worker/collector/retry.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
-import { fetchFeed, isRetryableError } from "../../../worker/collector/index";
+import { classifyError, fetchFeed, isRetryableError } from "../../../worker/collector/index";
 
 // fetchFeedOnce が内部で setTimeout を使うので fake timers で制御する
 // vi.useFakeTimers は cloudflare worker pool 環境でも setTimeout を置き換える
@@ -46,6 +46,51 @@ describe("isRetryableError", () => {
     expect(isRetryableError("string error")).toBe(false);
     expect(isRetryableError(null)).toBe(false);
     expect(isRetryableError(42)).toBe(false);
+  });
+});
+
+describe("classifyError", () => {
+  it("classifies AbortError as timeout", () => {
+    const err = new DOMException("timeout", "AbortError");
+    expect(classifyError(err)).toBe("timeout");
+  });
+
+  it("classifies TypeError as network", () => {
+    expect(classifyError(new TypeError("Failed to fetch"))).toBe("network");
+  });
+
+  it("classifies HTTP 503 as http_server", () => {
+    expect(classifyError(new Error("HTTP 503 Service Unavailable"))).toBe("http_server");
+  });
+
+  it("classifies HTTP 500 as http_server", () => {
+    expect(classifyError(new Error("HTTP 500 Internal Server Error"))).toBe("http_server");
+  });
+
+  it("classifies HTTP 429 as http_server", () => {
+    expect(classifyError(new Error("HTTP 429 Too Many Requests"))).toBe("http_server");
+  });
+
+  it("classifies HTTP 404 as http_client", () => {
+    expect(classifyError(new Error("HTTP 404 Not Found"))).toBe("http_client");
+  });
+
+  it("classifies HTTP 403 as http_client", () => {
+    expect(classifyError(new Error("HTTP 403 Forbidden"))).toBe("http_client");
+  });
+
+  it("classifies HTTP 400 as http_client", () => {
+    expect(classifyError(new Error("HTTP 400 Bad Request"))).toBe("http_client");
+  });
+
+  it("classifies generic Error as unknown", () => {
+    expect(classifyError(new Error("Feed body too large: 9999 bytes"))).toBe("unknown");
+  });
+
+  it("classifies non-Error values as unknown", () => {
+    expect(classifyError("string error")).toBe("unknown");
+    expect(classifyError(null)).toBe("unknown");
+    expect(classifyError(42)).toBe("unknown");
   });
 });
 

--- a/apps/web/worker/collector/deduplicator.ts
+++ b/apps/web/worker/collector/deduplicator.ts
@@ -6,6 +6,31 @@ async function sha256Hex(input: string): Promise<string> {
     .join("");
 }
 
+/**
+ * URL を正規化して GUID の衝突リスクを下げる。
+ * - スキームを https に統一 (http://example.com → https://example.com)
+ * - パス末尾のスラッシュを除去 (https://example.com/page/ → https://example.com/page)
+ * - トリミング
+ * 正規化に失敗した場合 (URL として不正など) は元の文字列をトリムして返す。
+ */
+export function normalizeUrl(url: string): string {
+  const trimmed = url.trim();
+  try {
+    const parsed = new URL(trimmed);
+    // http: → https: に統一
+    if (parsed.protocol === "http:") {
+      parsed.protocol = "https:";
+    }
+    // パス末尾スラッシュを除去 ("/path/" → "/path"、"/" はそのまま)
+    if (parsed.pathname.length > 1 && parsed.pathname.endsWith("/")) {
+      parsed.pathname = parsed.pathname.slice(0, -1);
+    }
+    return parsed.toString();
+  } catch {
+    return trimmed;
+  }
+}
+
 export interface BuildGuidInput {
   feedId: string;
   rawGuid?: string | null;
@@ -20,7 +45,8 @@ export async function buildGuid(opts: BuildGuidInput): Promise<string> {
     return `${feedId}:${rawGuid.trim()}`.slice(0, 255);
   }
   if (url && url.trim()) {
-    const hash = await sha256Hex(`${feedId}${url.trim()}`);
+    const normalized = normalizeUrl(url);
+    const hash = await sha256Hex(`${feedId}${normalized}`);
     return `${feedId}:url:${hash.slice(0, 32)}`;
   }
   const hash = await sha256Hex(`${feedId}${title ?? ""}${publishedAt ?? ""}`);

--- a/apps/web/worker/collector/index.ts
+++ b/apps/web/worker/collector/index.ts
@@ -24,11 +24,52 @@ const ALLOWED_URL_PREFIXES = ["http://", "https://"];
 // backoff: 500ms, 1000ms の 2 回まで。並列度 4 × max 1.5s = 6s < 30s cron 制限
 const BACKOFF_BASE_MS = 500;
 
-/** discriminated union: status に応じて error フィールドの有無が変わる */
+/**
+ * エラーの種別。alert や監視ダッシュボードでエラーをフィルタリングできるよう型で区別する。
+ * - timeout: AbortError (fetchFeed のタイムアウト)
+ * - network: TypeError (DNS 解決失敗・接続拒否など)
+ * - http_client: HTTP 4xx (404, 403 など恒久エラー)
+ * - http_server: HTTP 5xx / 429 (一時障害。リトライ後も失敗した場合)
+ * - parse: XML パース失敗または空フィード
+ * - unknown: 上記に分類できないエラー
+ */
+export type CollectErrorKind =
+  | "timeout"
+  | "network"
+  | "http_client"
+  | "http_server"
+  | "parse"
+  | "unknown";
+
+/** discriminated union: status に応じて error / errorKind フィールドの有無が変わる */
 export type CollectResult =
   | { feedId: string; status: "ok"; inserted: number; parsed: number }
   | { feedId: string; status: "not_modified"; inserted: number; parsed: number }
-  | { feedId: string; status: "error"; inserted: number; parsed: number; error: string };
+  | {
+      feedId: string;
+      status: "error";
+      inserted: number;
+      parsed: number;
+      error: string;
+      errorKind: CollectErrorKind;
+    };
+
+/**
+ * 例外からエラー種別を分類する。
+ * isRetryableError と対になる分類で、同じ判定ロジックを使う。
+ */
+export function classifyError(err: unknown): CollectErrorKind {
+  if (!(err instanceof Error)) return "unknown";
+  if (err.name === "AbortError") return "timeout";
+  if (err instanceof TypeError) return "network";
+  const m = /^HTTP (\d+)/.exec(err.message);
+  if (m) {
+    const code = Number(m[1]);
+    if (code === 429 || (code >= 500 && code < 600)) return "http_server";
+    if (code >= 400 && code < 500) return "http_client";
+  }
+  return "unknown";
+}
 
 export interface CollectAllResult {
   total: number;
@@ -248,6 +289,7 @@ async function collectFeed(
     return { feedId: feed.id, status: "ok", inserted, parsed: allItems.length };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
+    const errorKind = classifyError(err);
     try {
       await recordFetchError(env.DB, feed.id, fetchedAt, message);
     } catch (logErr) {
@@ -262,7 +304,14 @@ async function collectFeed(
       ms: Math.round(performance.now() - t0),
       statusCode,
     });
-    return { feedId: feed.id, status: "error", inserted: 0, parsed: 0, error: message };
+    return {
+      feedId: feed.id,
+      status: "error",
+      inserted: 0,
+      parsed: 0,
+      error: message,
+      errorKind,
+    };
   }
 }
 
@@ -478,9 +527,13 @@ export async function collectAll(
       `[collector] writeD1CostEvent failed: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
+  // feedId → url のマップを作り、失敗ログに URL と errorKind を含める。
+  // wrangler tail で直接問題 URL を確認できるようにするため。
+  const feedUrlMap = new Map(activeFeeds.map((f) => [f.id, f.url]));
   for (const r of results) {
     if (r.status === "error") {
-      console.warn(`[collector] ${r.feedId} ERROR: ${r.error}`);
+      const url = feedUrlMap.get(r.feedId) ?? "(unknown)";
+      console.warn(`[collector] ${r.feedId} ERROR kind=${r.errorKind} url=${url}: ${r.error}`);
     }
   }
 


### PR DESCRIPTION
## 概要

collector パイプラインの監査で発見した 3 点の問題を修正する。

## 変更内容

### 1. CollectResult にエラー種別 \`errorKind\` を追加
- \`CollectErrorKind\` 型 (\`timeout\` / \`network\` / \`http_client\` / \`http_server\` / \`parse\` / \`unknown\`) を新設
- \`classifyError()\` 関数を export し、\`collectFeed\` の catch で分類を付与
- alert ロジックや将来の監視ツールでエラー種別ごとのフィルタリングが可能になる

### 2. 失敗ログに feed URL と errorKind を追加
- \`[collector] {feedId} ERROR: ...\` → \`[collector] {feedId} ERROR kind={kind} url={url}: ...\`
- \`wrangler tail\` から直接問題 URL を確認できるようになる

### 3. \`deduplicator.ts\` に URL 正規化を追加
- \`normalizeUrl()\` 関数を追加 (http→https 統一、末尾スラッシュ除去、トリム)
- \`buildGuid\` の URL ベース hash 生成に \`normalizeUrl\` を適用
- \`http://\` vs \`https://\`、末尾スラッシュ有無の差異で同一記事に別 GUID が生成される問題を修正

#### 互換性影響 (要確認)
\`buildGuid\` は \`rawGuid\` が無く \`url\` フォールバックする経路でのみ hash 入力が変わる。RSS/Atom feed の大半は \`rawGuid\` を提供するためこの経路はマイナーだが、URL ベース GUID の既存記事は再収集時に新 GUID で 1 回だけ重複 INSERT される可能性がある。
- 影響対象: \`rawGuid\` を持たず \`http://\` または末尾スラッシュ付き URL の articles
- 影響規模: 多くて数十件 (PoC 規模)
- 自然消滅: 次回以降の収集は新 GUID で dedup されるので継続的な dup は発生しない

## テスト

- [x] \`pnpm -C apps/web typecheck\` 通過
- [x] \`pnpm -C apps/web build\` 通過
- [x] \`pnpm -C apps/web test run\` 通過 (635 tests passed)
- [x] \`pnpm lint\` 通過 (errors: 0、warnings は既存コードの pre-existing)
- [x] \`pnpm format\` 通過
- [x] \`classifyError\` の全エラー種別カバーするテストを追加
- [x] \`normalizeUrl\` の正規化ロジックと \`buildGuid\` の http/https・末尾スラッシュ正規化テストを追加