### PR TITLE
docs: fix doc inaccuracies and broken rule links

### DIFF
--- a/.claude/rules/00-overview.md
+++ b/.claude/rules/00-overview.md
@@ -46,7 +46,7 @@ PoC 規模 (Worker 1 個) のため `packages/` は廃止し、すべての work
 | 目的                        | コマンド                                       | pnpm script          |
 | --------------------------- | ---------------------------------------------- | -------------------- |
 | dev サーバー起動            | `vp dev` (`apps/web/`)                         | `pnpm dev`           |
-| 本番ビルド                  | `vp run build`                                 | `pnpm build`         |
+| 本番ビルド                  | `vp build`                                     | `pnpm build`         |
 | lint                        | `vp lint`                                      | `pnpm lint`          |
 | format                      | `vp fmt --write`                               | `pnpm format`        |
 | typecheck                   | `pnpm -r typecheck`                            | `pnpm typecheck`     |

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,13 +16,13 @@
 
 <!-- どうやって動作を確認したか。手動確認・テスト追加など -->
 
-- [ ] `pnpm test` pass
 - [ ] 手動動作確認済み (該当する場合)
 
 ## Checklist
 
-- [ ] `pnpm check` (lint + format + typecheck + build) pass
-- [ ] `pnpm test` pass
+- [ ] `pnpm check` (lint + format + typecheck) pass
+- [ ] `pnpm test` pass (worker テスト)
+- [ ] `pnpm test:client` pass (client コードを変更した場合)
 - [ ] migration を追加した場合は `pnpm migrate:local` で適用確認済み
 - [ ] 新機能・バグ修正の場合はテストを追加した
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to tech-news-bot
 
-Cloudflare Workers (無料枠) 上で 3 時間ごとに tech blog の RSS / Atom を収集し、D1 に保存して Web UI と JSON Feed / RSS で配信するアプリケーション。Worker は Hono ベース、フロントエンドは React 18 + Vite SPA、ツールチェインは [Vite+](https://viteplus.dev/) (`vp`) を使う。
+Cloudflare Workers (無料枠) 上で 6 時間ごとに tech blog の RSS / Atom を収集し、D1 に保存して Web UI と JSON Feed / RSS で配信するアプリケーション。Worker は Hono ベース、フロントエンドは React 19 + Vite SPA、ツールチェインは [Vite+](https://viteplus.dev/) (`vp`) を使う。
 
 ---
 
@@ -10,7 +10,7 @@ Cloudflare Workers (無料枠) 上で 3 時間ごとに tech blog の RSS / Atom
 
 - Node.js 24 以上
 - pnpm 10 以上
-- Vite+ (`vp`): `curl -fsSL https://vite.plus | bash`
+- Vite+ (`vp`): 公式サイト [viteplus.dev](https://viteplus.dev/) の手順を参照してインストール
 
 **手順**
 
@@ -29,20 +29,7 @@ pnpm migrate:local
 
 ---
 
-## 主要コマンド
-
-| 目的                          | コマンド             |
-| ----------------------------- | -------------------- |
-| dev サーバー起動              | `pnpm dev`           |
-| 本番ビルド                    | `pnpm build`         |
-| lint                          | `pnpm lint`          |
-| format                        | `pnpm format`        |
-| typecheck                     | `pnpm typecheck`     |
-| lint + fmt + typecheck まとめ | `pnpm check`         |
-| テスト                        | `pnpm test`          |
-| D1 マイグレーション (local)   | `pnpm migrate:local` |
-| D1 マイグレーション (prod)    | `pnpm migrate:prod`  |
-| デプロイ                      | `pnpm deploy`        |
+主要コマンドの一覧は [README.md#主要コマンド](README.md#主要コマンド) を参照。
 
 ---
 
@@ -59,7 +46,7 @@ pnpm migrate:local
 
 ## コーディング規約
 
-詳細は [`.claude/rules/01-coding-style.md`](.claude/rules/01-coding-style.md) を参照。要点:
+詳細は [`.claude/rules/01-typescript.md`](.claude/rules/01-typescript.md) を参照。要点:
 
 - **TypeScript strict mode**。`any` は最小限、必要なら `unknown` で受けて narrow する
 - **Lint**: oxlint (`vp lint`)。**Format**: oxfmt (`vp fmt`)。ESLint/Prettier は使用しない
@@ -75,10 +62,10 @@ pnpm migrate:local
 
 ## テスト規約
 
-詳細は [`.claude/rules/02-testing.md`](.claude/rules/02-testing.md) を参照。要点:
+詳細は [`.claude/rules/20-testing-overview.md`](.claude/rules/20-testing-overview.md) を参照。要点:
 
-- **テストランナー**: `vite-plus/test` (vitest 4) + `@cloudflare/vitest-pool-workers` v0.15
-- **起動**: `pnpm test`（root から）または `apps/web/` で `vp test run`
+- **テストランナー**: `vite-plus/test` (vitest) + `@cloudflare/vitest-pool-workers`
+- **起動**: `pnpm test` (worker) / `pnpm test:client` (client) / `pnpm e2e` (Playwright)
 - **テストファイル配置**: `apps/web/tests/<area>/<file>.test.ts`（area は `worker` / `collector` / `db` / `api` など）
 - テスト実行前に **`pnpm build` が必要**（vitest-pool-workers が `apps/web/dist/client` を要求するため）
 - `vitest` の API は `vite-plus/test` から import する。生 `vitest` は import しない
@@ -126,11 +113,12 @@ PR テンプレートに従って以下を記載する:
 ```
 tech-news-bot/
 ├── apps/web/
-│   ├── client/          React 18 + Vite SPA
+│   ├── client/          React 19 + Vite SPA
 │   ├── worker/          Hono API + cron collector
 │   │   ├── api/         /api/* エンドポイント
 │   │   ├── collector/   RSS/Atom 取得・パース
 │   │   ├── db/          D1 アクセス層
+│   │   ├── notify/      Slack 通知 (日次ダイジェスト)
 │   │   └── feeds.yaml   収集対象フィード定義
 │   └── tests/           vitest テスト
 ├── migrations/          D1 マイグレーション

--- a/README.md
+++ b/README.md
@@ -161,19 +161,20 @@ pnpm exec wrangler secret put COLLECTOR_ALERT_WEBHOOK
 | 変数名                      | デフォルト | 説明                                     |
 | --------------------------- | ---------- | ---------------------------------------- |
 | `COLLECTOR_CONCURRENCY`     | `"1"`      | 並列フィード取得数                       |
-| `COLLECTOR_TIMEOUT_MS`      | `"5000"`   | フィード取得タイムアウト (ms)            |
+| `COLLECTOR_TIMEOUT_MS`      | `"10000"`  | フィード取得タイムアウト (ms)            |
 | `COLLECTOR_ALERT_THRESHOLD` | `"5"`      | アラートを発火するフィード失敗数の閾値   |
-| `ALERT_MIN_FAILURES`        | —          | アラート通知の最小失敗数                 |
-| `ALERT_FEED_STREAK`         | —          | 連続失敗でアラートを発火するストリーク数 |
+| `ALERT_MIN_FAILURES`        | `"3"`      | アラート通知の最小失敗数                 |
+| `ALERT_FEED_STREAK`         | `"5"`      | 連続失敗でアラートを発火するストリーク数 |
 
 **Worker の Secrets (`wrangler secret put` で登録)**
 
-| Secret 名           | 必須 | 説明                                                                                |
-| ------------------- | ---- | ----------------------------------------------------------------------------------- |
-| `ADMIN_TOKEN`       | 任意 | `/api/admin/*` の Bearer 認証トークン                                               |
-| `ADMIN_TOKEN_NEXT`  | 任意 | ローテーション中の次世代トークン (詳細は `docs/operations/admin-token-rotation.md`) |
-| `ALERT_WEBHOOK_URL` | 任意 | フィード収集失敗アラート用の Webhook URL                                            |
-| `SLACK_WEBHOOK_URL` | 任意 | 日次ダイジェスト通知用の Slack Incoming Webhook URL                                 |
+| Secret 名                 | 必須 | 説明                                                                                   |
+| ------------------------- | ---- | -------------------------------------------------------------------------------------- |
+| `ADMIN_TOKEN`             | 任意 | `/api/admin/*` の Bearer 認証トークン                                                  |
+| `ADMIN_TOKEN_NEXT`        | 任意 | ローテーション中の次世代トークン (詳細は `docs/operations/admin-token-rotation.md`)    |
+| `ALERT_WEBHOOK_URL`       | 任意 | フィード収集失敗アラート用の Webhook URL (高機能アラート)                              |
+| `COLLECTOR_ALERT_WEBHOOK` | 任意 | シンプルな閾値アラート用の Webhook URL (`wrangler secret put COLLECTOR_ALERT_WEBHOOK`) |
+| `SLACK_WEBHOOK_URL`       | 任意 | 日次ダイジェスト通知用の Slack Incoming Webhook URL                                    |
 
 ### GitHub Actions による自動デプロイ
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tech-news-bot
 
-海外 big tech / AI tech / 国内企業の tech blog を 3 時間ごとに RSS / Atom フィードから収集し、Cloudflare 無料枠のみで動作する Web UI と JSON Feed / RSS で配信する PoC アプリケーション。Worker 1 つで Cron 収集・API・SPA 配信をすべて担う。
+海外 big tech / AI tech / 国内企業の tech blog を 6 時間ごとに RSS / Atom フィードから収集し、Cloudflare 無料枠のみで動作する Web UI と JSON Feed / RSS で配信する PoC アプリケーション。Worker 1 つで Cron 収集・API・SPA 配信をすべて担う。
 
 コントリビューター向けの詳細は [CONTRIBUTING.md](CONTRIBUTING.md) を参照。AI エージェント (Claude Code) 向けのガイドは [CLAUDE.md](CLAUDE.md) を参照。
 
@@ -16,7 +16,7 @@ graph LR
     end
 
     subgraph Cloudflare Worker
-        C[Cron 0 */3 * * *] --> COL[collectAll\nconcurrency 4]
+        C[Cron 0 */6 * * *] --> COL[collectAll\nconcurrency 1]
         COL --> D1[(D1 SQLite\narticles / feeds)]
         API[Hono /api/*] --> D1
         SPA[Static Assets\nReact SPA] --> API
@@ -32,15 +32,11 @@ graph LR
 
 | レイヤ       | サービス                                                  |
 | ------------ | --------------------------------------------------------- |
-| RSS 収集     | Cloudflare Workers Cron Triggers (3 時間ごと)             |
+| RSS 収集     | Cloudflare Workers Cron Triggers (6 時間ごと)             |
 | データベース | Cloudflare D1 (SQLite) + FTS5 全文検索                    |
 | API          | 同 Worker 内で Hono が `/api/*` と `/feed.*` を処理       |
-| 静的フロント | Worker Static Assets (Vite でビルドした React 18 SPA)     |
+| 静的フロント | Worker Static Assets (Vite でビルドした React 19 SPA)     |
 | 設定         | `apps/web/worker/feeds.yaml` を Worker に build 時 inline |
-
-## SPA スクリーンショット
-
-<!-- TODO: screenshot here -->
 
 ## クイックスタート
 
@@ -48,45 +44,50 @@ graph LR
 
 - Node.js 24 以上
 - pnpm 10 以上
-- Vite+ (`vp`): `curl -fsSL https://vite.plus | bash`
+- Vite+ (`vp`): 公式サイト [viteplus.dev](https://viteplus.dev/) の手順を参照してインストール
 - Cloudflare アカウント + `wrangler login`
 
 ```bash
 # 1. 依存インストール
 pnpm install
 
-# 2. ローカル D1 にマイグレーションを適用
+# 2. Cloudflare Worker の型を生成 (wrangler.toml から自動生成)
+pnpm cf-typegen
+
+# 3. ローカル D1 にマイグレーションを適用
 pnpm migrate:local
 
-# 3. 開発サーバー起動 (http://localhost:8787)
+# 4. 開発サーバー起動 (http://localhost:8787)
 pnpm dev
 ```
 
 ローカルで Cron を手動実行する場合:
 
 ```bash
-curl "http://localhost:8787/__scheduled?cron=0+*/3+*+*+*"
+curl "http://localhost:8787/__scheduled?cron=0+*/6+*+*+*"
 ```
 
 ## 主要コマンド
 
 ツールチェインは [Vite+](https://viteplus.dev/) (`vp`) ベース。
 
-| 目的                        | vp 直                              | pnpm script          |
-| --------------------------- | ---------------------------------- | -------------------- |
-| dev サーバー起動            | `vp dev` (`apps/web/` で実行)      | `pnpm dev`           |
-| 本番ビルド                  | `vp run build`                     | `pnpm build`         |
-| lint                        | `vp lint`                          | `pnpm lint`          |
-| format                      | `vp fmt --write`                   | `pnpm format`        |
-| typecheck                   | `pnpm -r typecheck`                | `pnpm typecheck`     |
-| lint + fmt + typecheck      | `vp check`                         | `pnpm check`         |
-| テスト                      | `vp test run` (`apps/web/` で実行) | `pnpm test`          |
-| Cloudflare 型生成           | —                                  | `pnpm cf-typegen`    |
-| D1 マイグレーション (local) | —                                  | `pnpm migrate:local` |
-| D1 マイグレーション (prod)  | —                                  | `pnpm migrate:prod`  |
-| デプロイ                    | —                                  | `pnpm deploy`        |
+| 目的                        | vp 直                                                        | pnpm script          |
+| --------------------------- | ------------------------------------------------------------ | -------------------- |
+| dev サーバー起動            | `vp dev` (`apps/web/` で実行)                                | `pnpm dev`           |
+| 本番ビルド                  | `vp build`                                                   | `pnpm build`         |
+| lint                        | `vp lint`                                                    | `pnpm lint`          |
+| format                      | `vp fmt --write`                                             | `pnpm format`        |
+| typecheck                   | `pnpm -r typecheck`                                          | `pnpm typecheck`     |
+| lint + fmt + typecheck      | `vp check`                                                   | `pnpm check`         |
+| worker テスト               | `vp test run` (`apps/web/` で実行)                           | `pnpm test`          |
+| client テスト               | `vp test run --config vitest.client.config.ts` (`apps/web/`) | `pnpm test:client`   |
+| e2e テスト (Playwright)     | —                                                            | `pnpm e2e`           |
+| Cloudflare 型生成           | —                                                            | `pnpm cf-typegen`    |
+| D1 マイグレーション (local) | —                                                            | `pnpm migrate:local` |
+| D1 マイグレーション (prod)  | —                                                            | `pnpm migrate:prod`  |
+| デプロイ                    | —                                                            | `pnpm deploy`        |
 
-テスト実行前に `pnpm build` が必要です (`@cloudflare/vitest-pool-workers` が `dist/client` を要求するため)。
+worker テスト実行前に `pnpm build` が必要です (`@cloudflare/vitest-pool-workers` が `dist/client` を要求するため)。
 
 ## API 使用例
 
@@ -108,20 +109,27 @@ curl "https://tech-news-bot.rikeda71.workers.dev/feed.xml?lang=ja"
 # JSON Feed v1.1
 curl "https://tech-news-bot.rikeda71.workers.dev/feed.json"
 
-# TODO: OpenAPI スキーマ (#33 マージ後に追加)
-# curl "https://tech-news-bot.rikeda71.workers.dev/api/openapi.json"
+# OpenAPI スキーマ
+curl "https://tech-news-bot.rikeda71.workers.dev/api/openapi.json"
 ```
 
 ### API リファレンス
 
-| Method | Path            | 説明                                                                    |
-| ------ | --------------- | ----------------------------------------------------------------------- |
-| GET    | `/api/articles` | 記事一覧。クエリ: `category`, `lang`, `feed_id`, `q`, `limit`, `cursor` |
-| GET    | `/api/feeds`    | フィード一覧と最終収集状況                                              |
-| GET    | `/api/stats`    | カテゴリ別・フィード別の記事数統計                                      |
-| GET    | `/api/health`   | DB 接続疎通と総記事数                                                   |
-| GET    | `/feed.json`    | JSON Feed v1.1 (直近 50 件、`category` / `lang` 絞り込み可)             |
-| GET    | `/feed.xml`     | RSS 2.0 (同上)                                                          |
+| Method | Path                | 説明                                                                    |
+| ------ | ------------------- | ----------------------------------------------------------------------- |
+| GET    | `/api/articles`     | 記事一覧。クエリ: `category`, `lang`, `feed_id`, `q`, `limit`, `cursor` |
+| GET    | `/api/feeds`        | フィード一覧と最終収集状況                                              |
+| GET    | `/api/stats`        | カテゴリ別・フィード別の記事数統計                                      |
+| GET    | `/api/categories`   | カテゴリ一覧                                                            |
+| GET    | `/api/health`       | DB 接続疎通と総記事数                                                   |
+| GET    | `/api/reports`      | レポート一覧 (`kind` フィルタ可)                                        |
+| GET    | `/api/reports/:id`  | レポート詳細 (content + meta_json)                                      |
+| GET    | `/api/openapi.json` | OpenAPI スキーマ (JSON)                                                 |
+| GET    | `/api/docs`         | Swagger UI                                                              |
+| GET    | `/feed.json`        | JSON Feed v1.1 (直近 50 件、`category` / `lang` 絞り込み可)             |
+| GET    | `/feed.xml`         | RSS 2.0 (同上)                                                          |
+| GET    | `/feed.atom`        | Atom 1.0 (同上)                                                         |
+| GET    | `/feeds.opml`       | OPML 2.0 (フィード一覧)                                                 |
 
 `/api/articles` のページングは Base64 エンコードされた cursor を `nextCursor` で返します。
 
@@ -146,14 +154,36 @@ pnpm exec wrangler secret put ADMIN_TOKEN
 pnpm exec wrangler secret put COLLECTOR_ALERT_WEBHOOK
 ```
 
+### 環境変数 / Secrets
+
+**Worker の `vars` (wrangler.toml で設定)**
+
+| 変数名                      | デフォルト | 説明                                     |
+| --------------------------- | ---------- | ---------------------------------------- |
+| `COLLECTOR_CONCURRENCY`     | `"1"`      | 並列フィード取得数                       |
+| `COLLECTOR_TIMEOUT_MS`      | `"5000"`   | フィード取得タイムアウト (ms)            |
+| `COLLECTOR_ALERT_THRESHOLD` | `"5"`      | アラートを発火するフィード失敗数の閾値   |
+| `ALERT_MIN_FAILURES`        | —          | アラート通知の最小失敗数                 |
+| `ALERT_FEED_STREAK`         | —          | 連続失敗でアラートを発火するストリーク数 |
+
+**Worker の Secrets (`wrangler secret put` で登録)**
+
+| Secret 名           | 必須 | 説明                                                                                |
+| ------------------- | ---- | ----------------------------------------------------------------------------------- |
+| `ADMIN_TOKEN`       | 任意 | `/api/admin/*` の Bearer 認証トークン                                               |
+| `ADMIN_TOKEN_NEXT`  | 任意 | ローテーション中の次世代トークン (詳細は `docs/operations/admin-token-rotation.md`) |
+| `ALERT_WEBHOOK_URL` | 任意 | フィード収集失敗アラート用の Webhook URL                                            |
+| `SLACK_WEBHOOK_URL` | 任意 | 日次ダイジェスト通知用の Slack Incoming Webhook URL                                 |
+
 ### GitHub Actions による自動デプロイ
 
 `main` ブランチへの push で `.github/workflows/deploy.yml` が自動デプロイします。以下の Repository Secrets を設定してください:
 
-| Secret 名               | 取得場所                                                    |
-| ----------------------- | ----------------------------------------------------------- |
-| `CLOUDFLARE_API_TOKEN`  | Cloudflare Dashboard > My Profile > API Tokens              |
-| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare Dashboard > アカウントのホームページ右サイドバー |
+| Secret 名               | 取得場所                                                                                   |
+| ----------------------- | ------------------------------------------------------------------------------------------ |
+| `CLOUDFLARE_API_TOKEN`  | Cloudflare Dashboard > My Profile > API Tokens                                             |
+| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare Dashboard > アカウントのホームページ右サイドバー                                |
+| `WORKER_ADMIN_TOKEN`    | `openssl rand -hex 32` で生成。deploy 時に Worker の `ADMIN_TOKEN` secret へ自動同期される |
 
 ### 手動デプロイ
 
@@ -167,7 +197,7 @@ pnpm deploy
 ```
 tech-news-bot/                    pnpm workspace root
 ├── apps/web/                     デプロイ単位 (Cloudflare Worker + SPA)
-│   ├── client/                   React 18 + Vite SPA
+│   ├── client/                   React 19 + Vite SPA
 │   ├── worker/                   Hono API + cron collector
 │   │   ├── api/                  /api/* エンドポイント群
 │   │   ├── collector/            RSS / Atom 取得・パース・de-dup
@@ -202,6 +232,17 @@ feeds:
 
 YAML は `@modyfi/vite-plugin-yaml` により build 時に JSON へ変換され Worker bundle に inline されます (runtime 依存なし)。設定変更は再デプロイで反映されます。
 
+## D1 スキーマ概要
+
+| テーブル         | 説明                                                      |
+| ---------------- | --------------------------------------------------------- |
+| `articles`       | 収集した記事 (URL, タイトル, 公開日, カテゴリ等)          |
+| `feeds`          | フィード定義と最終収集状況 (ETag / Last-Modified)         |
+| `collector_runs` | Cron 実行履歴 (収集件数・失敗数・所要時間)                |
+| `reports`        | 自動生成されたダイジェストレポート (daily/weekly/monthly) |
+
+マイグレーション SQL は `migrations/` ディレクトリを参照。
+
 ## D1 コスト監視 (Analytics Engine)
 
 Cron 収集が完了するたびに、D1 読み書き回数と実行時間を Cloudflare Analytics Engine (dataset: `tnb_collector_events`) に記録します。
@@ -232,7 +273,7 @@ ORDER BY hour DESC
 | ------------------ | --------- | ------------------------------ |
 | Workers リクエスト | 10 万/日  | UI 含めて数千 / 日             |
 | Workers CPU        | 10ms/req  | API は D1 1 クエリで数 ms      |
-| Cron wall clock    | 15 分     | 38 フィード × 数秒             |
+| Cron wall clock    | 15 分     | 45 フィード × 数秒             |
 | D1 ストレージ      | 5GB       | 1 記事 ≈ 2KB → 10 万件 = 200MB |
 | D1 Reads           | 500 万/日 | 余裕                           |
 | D1 Writes          | 10 万/日  | Cron 1 回 ≈ 数百件             |
@@ -244,6 +285,7 @@ ORDER BY hour DESC
 | [CONTRIBUTING.md](CONTRIBUTING.md)                                                   | コントリビューター | 開発ワークフロー・コーディング規約・PR の作り方                  |
 | [.claude/rules/](.claude/rules/)                                                     | Claude Code        | コーディング・テスト・Cloudflare・フィード・タスクフローのルール |
 | [.claude/skills/tech-news-digest/SKILL.md](.claude/skills/tech-news-digest/SKILL.md) | Claude Code        | D1 から記事を抽出して日本語で要約するスキル                      |
+| [docs/reports-pipeline.md](docs/reports-pipeline.md)                                 | 運用者             | 自動レポート pipeline (GitHub Actions + Claude Code + D1)        |
 | [docs/operations/admin-token-rotation.md](docs/operations/admin-token-rotation.md)   | 運用者             | Admin API Token のローテーション手順                             |
 
 ## ライセンス

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,8 +18,6 @@ Please use GitHub's Private Vulnerability Reporting instead:
 
 https://github.com/rikeda71/tech-news-bot/security/advisories/new
 
-<!-- セキュリティ上の問題は上記の GitHub Private Vulnerability Reporting を使って報告してください。公開 issue / PR での報告はお控えください。 -->
-
 Include the following in your report:
 
 - Description of the vulnerability and its potential impact
@@ -44,17 +42,13 @@ The following are considered out of scope for this project's security policy:
 - **Issues in feed sources**: Problems with the RSS/Atom feeds themselves (e.g., a blog serving malicious content) are outside our control.
 - **Denial of Service (DoS)**: Rate limiting and traffic absorption are handled by Cloudflare's infrastructure.
 
-<!-- 上記はこのプロジェクトのセキュリティポリシーの対象外です。依存パッケージの脆弱性は Dependabot 経由でアップストリームに報告してください。 -->
-
 ## Secret Handling
 
-Secrets such as `ADMIN_TOKEN` must never be committed to the repository.
+Secrets (such as `ADMIN_TOKEN`, `SLACK_WEBHOOK_URL`, and API tokens) must never be committed to the repository.
 
 - Secrets are registered via `wrangler secret put` or GitHub Actions repository secrets.
 - If a secret is accidentally exposed, rotate it immediately. Rotation procedures are documented in [`docs/operations/admin-token-rotation.md`](docs/operations/admin-token-rotation.md).
 - After rotating, report the exposure through a private advisory using the link above.
-
-<!-- `ADMIN_TOKEN` などのシークレットは絶対にコミットしないでください。漏洩した場合はただちにローテーションし、上記の private advisory で報告してください。 -->
 
 ## Disclosure Policy
 
@@ -62,5 +56,3 @@ Secrets such as `ADMIN_TOKEN` must never be committed to the repository.
 - Once a fix is deployed to `main`, we will publish the GitHub Security Advisory.
 - If the vulnerability warrants a CVE, we will request one after the advisory is published.
 - The timing of the public advisory will be agreed upon with the reporter.
-
-<!-- 修正が main にデプロイされた後、GitHub Security Advisory を公開します。CVE が適切な場合は公開後に申請します。公開タイミングはレポーターと合意した上で決定します。 -->

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -63,7 +63,7 @@ const handler: ExportedHandler<Env> = {
       return;
     }
 
-    // 3 時間ごとの cron (0 */3 * * *): RSS 収集
+    // 6 時間ごとの cron (0 */6 * * *): RSS 収集
     ctx.waitUntil(
       collectAll(env).catch((err) => {
         console.error("[scheduled] collectAll failed", err);

--- a/docs/operations/admin-token-rotation.md
+++ b/docs/operations/admin-token-rotation.md
@@ -1,6 +1,29 @@
 # ADMIN_TOKEN ローテーション手順
 
-`/api/admin/collect` エンドポイントを保護する `ADMIN_TOKEN` のローテーション手順を示す。
+`/api/admin/*` エンドポイントを保護する `ADMIN_TOKEN` のローテーション手順を示す。
+
+## GitHub Actions との自動同期について
+
+`WORKER_ADMIN_TOKEN` (GitHub Actions Secret) は **single source of truth** として扱う。
+`.github/workflows/deploy.yml` に "Sync admin secret to Worker" ステップが含まれており、
+`main` への push / deploy 実行時に `wrangler secret put ADMIN_TOKEN` で Worker 側に自動同期される。
+
+### 自動同期パターン (推奨)
+
+Worker の `ADMIN_TOKEN` を GitHub Actions の `WORKER_ADMIN_TOKEN` に従って自動更新する方式。
+
+1. GitHub Actions Secret の `WORKER_ADMIN_TOKEN` を新しい値に更新する
+2. `main` ブランチへの push (または GitHub Actions UI から deploy workflow を手動実行) する
+3. deploy workflow が完了すると Worker の `ADMIN_TOKEN` も自動的に新しい値に更新される
+
+この方式では GH と Cloudflare の 2 箇所に同じ値を個別に登録する手間が不要。
+
+### 手動管理パターン
+
+GitHub Actions を使わず、`wrangler secret put` で直接 Worker secret を更新する方式。
+下記「ローテーション手順」に従って操作する。
+
+---
 
 Worker は `ADMIN_TOKEN`（現行）と `ADMIN_TOKEN_NEXT`（次世代）の両方を timing-safe で検証し、
 どちらかに一致した場合に認証を通す。これによりダウンタイムなしでトークンを切り替えられる。
@@ -25,16 +48,16 @@ Worker は自動的に再デプロイされ、旧トークン (ADMIN_TOKEN) と�
 
 ### 2. クライアント側を新トークンに切り替える
 
-`/api/admin/collect` を呼び出しているすべてのクライアント（GitHub Actions の secrets、
+`/api/admin/*` を呼び出しているすべてのクライアント（GitHub Actions の secrets、
 外部スクリプト等）を新トークン (`ADMIN_TOKEN_NEXT` に設定した値) に切り替える。
 
 ### 3. 稼働確認
 
-新トークンで `/api/admin/collect` が正常に動作することを確認する（例: 200 レスポンスを受信）。
+新トークンで `/api/admin/*` が正常に動作することを確認する（例: `/api/admin/reports` から 200 レスポンスを受信）。
 
 ```bash
 curl -s -o /dev/null -w "%{http_code}" \
-  -X POST https://tech-news-bot.rikeda71.workers.dev/api/admin/collect \
+  https://tech-news-bot.rikeda71.workers.dev/api/admin/reports \
   -H "Authorization: Bearer <new-token>"
 # → 200 であれば OK
 ```

--- a/docs/reports-pipeline.md
+++ b/docs/reports-pipeline.md
@@ -173,7 +173,7 @@ repository secrets に以下を登録する。
 | `CLOUDFLARE_API_TOKEN`    | `wrangler d1 execute --remote` を打つために必要                      | Cloudflare dashboard → API Tokens                                  |
 | `CLOUDFLARE_ACCOUNT_ID`   | wrangler の account 自動選択                                         | Cloudflare dashboard                                               |
 | `SLACK_BOT_TOKEN`         | report workflow の Slack スレッド投稿 (`chat.postMessage` API)       | Slack App 管理画面 → OAuth & Permissions → Bot Token (`xoxb-...`)  |
-| `SLACK_CHANNEL_ID`        | report workflow の投稿先 channel ID (= `CTPQ8SP98`)                  | Slack channel の URL または右クリック → Copy link から取得         |
+| `SLACK_CHANNEL_ID`        | report workflow の投稿先 channel ID                                  | Slack channel の URL または右クリック → Copy link から取得         |
 | `SLACK_WEBHOOK_URL`       | collector 日次ダイジェスト用 (apps/web/worker/notify/slack-daily.ts) | Slack ワークスペースで incoming webhook を作成 (report では未使用) |
 
 `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` は既に deploy workflow で使っている
@@ -236,48 +236,18 @@ UNIQUE index が `(kind, period, category)` で張られているため、catego
 Slack への投稿は Worker ではなく GitHub Actions 側で行う。
 Slack Bot Token + `chat.postMessage` API を使い、**スレッド化した 2 段構成**で投稿する。
 
-フロー:
-
 1. Skill (Claude Code) が `/tmp/slack-message.md` を生成 (Slack mrkdwn 形式、30000 文字以内)
 2. `Save report to D1` ステップで POST レスポンス (`{ ok, id }`) を `/tmp/post-resp.json` に保存
 3. `Post to Slack (threaded)` ステップが 2 段階の `chat.postMessage` を実行:
    - **Step A (親メッセージ)**: タイトル + 重要度を header/context block で投稿。レスポンスの `.ts` を取得
    - **Step B (子メッセージ)**: 取得した `ts` を `thread_ts` に指定し、`slack-message.md` を chunks に分割して thread にぶら下げる
 
-### Blocks payload 構造
-
-**親メッセージ** (`chat.postMessage`):
-
-```
-header block   : 🟢/🟡/🔴 + 種別 + 期間
-context block  : 重要度テキスト · generated_at
-```
-
-**子メッセージ** (thread_ts 付き `chat.postMessage`):
-
-```
-section block × N : slack-message.md を 2800 chars 単位でチャンク分割 (最大 48 チャンク)
-[context block    : 省略された場合の注記 (超過時のみ)]
-divider
-section block  : レポート全文を Web で開く (viewer URL)
-```
-
-重要度と絵文字:
-
-| kind    | 絵文字 | タイトル例                                          | 重要度テキスト |
-| ------- | ------ | --------------------------------------------------- | -------------- |
-| daily   | 🟢     | `🟢 Daily Tech Report (2026-04-29)`                 | 重要度: 低     |
-| weekly  | 🟡     | `🟡 Weekly Tech Report (2026-04-22 〜 2026-04-29)`  | 重要度: 中     |
-| monthly | 🔴     | `🔴 Monthly Tech Report (2026-03-30 〜 2026-04-29)` | 重要度: 高     |
-
 特性:
 
-- 30000 文字以内を推奨上限とし、blocks 分割で長文に対応
-- 子メッセージの blocks 総数は最大 50 (Slack 制約)。チャンク数は上限 48 に制限し、divider + viewer link の 2 枠を確保
 - `SLACK_BOT_TOKEN` または `SLACK_CHANNEL_ID` が未設定の場合は no-op でスキップ (投稿しないだけで workflow は正常終了)
 - `continue-on-error: true` を付けているため、Slack 投稿が失敗しても workflow 全体が fail しない
 - bot token リテラルをコードに埋め込まない。`${{ secrets.SLACK_BOT_TOKEN }}` 経由でのみ参照する
-- **bot を channel に invite する必要がある**: Slack ワークスペースで `/invite @<bot名>` を channel (CTPQ8SP98) で実行しないと `not_in_channel` エラーになる
+- **bot を channel に invite する必要がある**: Slack ワークスペースで `/invite @<bot名>` を投稿先 channel で実行しないと `not_in_channel` エラーになる
 
 > **注**: `apps/web/worker/notify/slack-daily.ts` (collector の日次ダイジェスト) は引き続き
 > `SLACK_WEBHOOK_URL` (incoming webhook) を使用する。この webhook は削除しないこと。
@@ -289,13 +259,11 @@ section block  : レポート全文を Web で開く (viewer URL)
 gh secret set SLACK_BOT_TOKEN
 # プロンプトに xoxb-... トークンを入力
 
-# SLACK_CHANNEL_ID は登録済み (CTPQ8SP98)
-# 未登録の場合:
+# SLACK_CHANNEL_ID の取得: Slack channel の URL または右クリック → Copy link から取得
 gh secret set SLACK_CHANNEL_ID
-# プロンプトに CTPQ8SP98 を入力
 
 # Slack App に chat:write スコープを付与し、bot を channel に invite:
-# Slack ワークスペース内で /invite @<bot名> を CTPQ8SP98 channel で実行
+# Slack ワークスペース内で /invite @<bot名> を該当 channel で実行
 ```
 
 ---

--- a/tools/d1-client/README.md
+++ b/tools/d1-client/README.md
@@ -6,7 +6,9 @@ D1 からデータを抽出する Node.js CLI スクリプト群。Claude skills
 
 - `pnpm` がインストール済み
 - `apps/web/wrangler.toml` に D1 バインディングが設定済み
-- `--target=remote` の場合は `pnpm --filter @tnb/web exec wrangler login` で認証済み
+- `--target=remote` の場合は以下のいずれかで認証済み:
+  - `pnpm --filter @tnb/web exec wrangler login` (対話ログイン)
+  - または環境変数 `CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_API_TOKEN` を設定 (CI/script 用)
 
 ## recent.mjs — 期間ベースで記事を取得
 
@@ -16,13 +18,13 @@ D1 からデータを抽出する Node.js CLI スクリプト群。Claude skills
 node tools/d1-client/recent.mjs --since=<today|week|month|N> [options]
 ```
 
-| オプション   | デフォルト | 説明                             |
-| ------------ | ---------- | -------------------------------- |
-| `--since`    | (必須)     | `today` / `week` / `month` / `N` |
-| `--target`   | `local`    | `local` または `remote`          |
-| `--category` | なし       | `bigtech` / `ai` / `jp` / `zenn` |
-| `--lang`     | なし       | `ja` または `en`                 |
-| `--limit`    | `200`      | 最大取得件数 (上限 1000)         |
+| オプション   | デフォルト | 説明                                                                                 |
+| ------------ | ---------- | ------------------------------------------------------------------------------------ |
+| `--since`    | (必須)     | `today` / `week` / `month` / `N`                                                     |
+| `--target`   | `local`    | `local` または `remote`                                                              |
+| `--category` | なし       | `bigtech` / `ai` / `jp` / `zenn`                                                     |
+| `--lang`     | なし       | `ja` または `en`                                                                     |
+| `--limit`    | `200`      | 最大取得件数 (上限 1000 — D1 の 1 invocation あたり 50 queries 制限に基づく実装上限) |
 
 例:
 
@@ -48,7 +50,7 @@ node tools/d1-client/recent.mjs --since=week --category=ai --target=remote
 
 ## search.mjs — キーワード全文検索で記事を取得
 
-FTS5 (trigram tokenizer, `migration/0003_fts5_trigram.sql` で設定) を使ってキーワード検索した記事を返す。`tech-news-search` skill が使用する。
+FTS5 (trigram tokenizer, `migrations/0003_fts5_trigram.sql` で設定) を使ってキーワード検索した記事を返す。`tech-news-search` skill が使用する。
 
 ```sh
 node tools/d1-client/search.mjs --q=<keyword> [options]


### PR DESCRIPTION
## Summary

- cron 間隔の事実誤認 (3h→6h)、concurrency (4→1)、React バージョン (18→19) を修正
- CONTRIBUTING.md の rules リンク切れ修正 (`01-coding-style.md`→`01-typescript.md`、`02-testing.md`→`20-testing-overview.md`)
- pipe-to-shell vp インストール手順を「公式サイト参照」に変更 (hook でブロックされる形式を除去)
- API リファレンス表に未掲載エンドポイント追記 (categories, reports, openapi, atom, opml)
- フィード件数 38→45 (feeds.yaml の enabled: true 実件数)
- 環境変数/Secrets 一覧、D1 スキーマ概要、pnpm test:client/e2e コマンドを README に追加
- SECURITY.md の重複 HTML コメント削除 (英語に一本化)
- pull_request_template.md: pnpm test 重複解消、pnpm test:client 追加
- docs/reports-pipeline.md: SLACK_CHANNEL_ID ハードコード削除、Blocks payload 詳細削除
- docs/operations/admin-token-rotation.md: 自動同期パターン vs 手動管理パターンの説明追加

## Test plan

- [ ] markdown のみの変更のため動作確認不要
- [ ] `vp fmt` pass (自動修正済み)

## Related issue

Closes #344