### PR TITLE
fix(syndication): ISO 8601 日付保証・空フィード ETag 安定化・RSS channel link フォールバック

### DIFF
--- a/apps/web/tests/worker/api/syndication.test.ts
+++ b/apps/web/tests/worker/api/syndication.test.ts
@@ -762,3 +762,129 @@ describe("/feeds/lang/:lang.atom (lang Atom)", () => {
     expect(res2.status).toBe(304);
   });
 });
+
+// ---------------------------------------------------------------------------
+// エッジケース: 空フィード / 特殊文字 / ヘッダー
+// ---------------------------------------------------------------------------
+
+describe("empty feed edge cases", () => {
+  it("RSS /feed.xml with no articles returns valid RSS with no <item> elements", async () => {
+    // beforeEach でシードされるが、カテゴリ zenn は記事がないはず
+    const res = await SELF.fetch("https://example.com/feed.xml?category=zenn");
+    expect.soft(res.status).toBe(200);
+    const text = await res.text();
+    // 空でも RSS 2.0 必須構造が揃っていること
+    expect.soft(text).toContain('<rss version="2.0"');
+    expect.soft(text).toContain("<channel>");
+    expect.soft(text).toContain("<title>");
+    expect.soft(text).toContain("<link>");
+    expect.soft(text).toContain("<description>");
+    expect.soft(text).not.toContain("<item>");
+  });
+
+  it("JSON /feed.json with no articles returns valid JSON Feed with empty items", async () => {
+    const res = await SELF.fetch("https://example.com/feed.json?category=zenn");
+    expect.soft(res.status).toBe(200);
+    const body = (await res.json()) as { version: string; items: unknown[] };
+    expect.soft(body.version).toBe("https://jsonfeed.org/version/1.1");
+    expect.soft(body.items).toEqual([]);
+  });
+
+  it("Atom /feed.atom with no articles returns valid Atom feed with no <entry>", async () => {
+    const res = await SELF.fetch("https://example.com/feed.atom?category=zenn");
+    expect.soft(res.status).toBe(200);
+    const text = await res.text();
+    expect.soft(text).toContain('<feed xmlns="http://www.w3.org/2005/Atom">');
+    expect.soft(text).toContain("<updated>");
+    expect.soft(text).not.toContain("<entry>");
+  });
+
+  // 空フィード時の ETag が安定している (毎回同じ) ことを確認する
+  it("RSS empty feed ETag is stable across two requests", async () => {
+    const res1 = await SELF.fetch("https://example.com/feed.xml?category=zenn");
+    const res2 = await SELF.fetch("https://example.com/feed.xml?category=zenn");
+    const etag1 = res1.headers.get("ETag");
+    const etag2 = res2.headers.get("ETag");
+    expect(etag1).not.toBeNull();
+    expect(etag1).toBe(etag2);
+  });
+
+  it("RSS empty feed supports 304 round-trip", async () => {
+    const res1 = await SELF.fetch("https://example.com/feed.xml?category=zenn");
+    const etag = res1.headers.get("ETag")!;
+    const res2 = await SELF.fetch("https://example.com/feed.xml?category=zenn", {
+      headers: { "If-None-Match": etag },
+    });
+    expect(res2.status).toBe(304);
+  });
+});
+
+describe("special characters in article fields", () => {
+  beforeEach(async () => {
+    await insertArticles(env.DB, [
+      {
+        guid: "g-special",
+        feed_id: "openai-blog",
+        // タイトル・summary に XML/HTML の特殊文字を含む
+        title: "Special <chars> & \"quotes\" and 'apostrophe'",
+        url: "https://x.test/o/special",
+        summary: "<script>alert('xss')</script> & <b>bold</b>",
+        author: "O'Reilly & Associates",
+        published_at: "2024-05-01T00:00:00.000Z",
+        category: "ai",
+        lang: "en",
+      },
+    ]);
+  });
+
+  it("RSS escapes special characters in item title, summary, author", async () => {
+    const res = await SELF.fetch("https://example.com/feed.xml?category=ai");
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    // エスケープ確認
+    expect.soft(text).toContain("Special &lt;chars&gt; &amp; &quot;quotes&quot;");
+    expect.soft(text).toContain("&lt;script&gt;alert(");
+    expect.soft(text).toContain("O&apos;Reilly &amp; Associates");
+  });
+
+  it("Atom escapes special characters in entry title and summary", async () => {
+    const res = await SELF.fetch("https://example.com/feed.atom?category=ai");
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect.soft(text).toContain("Special &lt;chars&gt; &amp; &quot;quotes&quot;");
+    expect.soft(text).toContain("&lt;script&gt;alert(");
+  });
+
+  it("JSON Feed preserves raw characters in title (no XML escaping needed)", async () => {
+    const res = await SELF.fetch("https://example.com/feed.json?category=ai");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { items: { title: string; content_text: string }[] };
+    const special = body.items.find((i) => i.title.includes("Special"));
+    expect(special).toBeDefined();
+    // JSON では XML エスケープ不要; 生の文字列が入っていること
+    expect.soft(special?.title).toContain("<chars>");
+    expect.soft(special?.content_text).toContain("<script>");
+  });
+
+  it("Atom entry date fields are valid ISO 8601", async () => {
+    const res = await SELF.fetch("https://example.com/feed.atom?category=ai");
+    const text = await res.text();
+    // <updated> タグの値が ISO 8601 形式であること (簡易チェック)
+    const updatedMatches = [...text.matchAll(/<updated>([^<]+)<\/updated>/g)];
+    for (const m of updatedMatches) {
+      expect(Number.isNaN(new Date(m[1] ?? "").getTime())).toBe(false);
+    }
+    const publishedMatches = [...text.matchAll(/<published>([^<]+)<\/published>/g)];
+    for (const m of publishedMatches) {
+      expect(Number.isNaN(new Date(m[1] ?? "").getTime())).toBe(false);
+    }
+  });
+
+  it("JSON Feed date_published is valid ISO 8601", async () => {
+    const res = await SELF.fetch("https://example.com/feed.json?category=ai");
+    const body = (await res.json()) as { items: { date_published: string }[] };
+    for (const item of body.items) {
+      expect(Number.isNaN(new Date(item.date_published).getTime())).toBe(false);
+    }
+  });
+});

--- a/apps/web/worker/api/syndication/atom.ts
+++ b/apps/web/worker/api/syndication/atom.ts
@@ -1,19 +1,22 @@
-import { escapeXml } from "./shared";
+import { escapeXml, feedUpdatedAt, toIso8601 } from "./shared";
 import type { FeedMeta } from "./shared";
 
 export function renderAtomFeed(meta: FeedMeta): { contentType: string; body: string } {
-  const updated = meta.articles[0]?.published_at ?? new Date().toISOString();
+  const updated = toIso8601(feedUpdatedAt(meta.articles));
 
   const entries = meta.articles
     .map((a) => {
       const authorName = a.author ?? a.feed_name ?? "";
+      // toIso8601 で無効な日付文字列を安全な RFC 3339 値に変換する。
+      // 素通しにすると XML パーサーが壊れる可能性がある。
+      const publishedIso = toIso8601(a.published_at);
       const parts = [
         `<entry>`,
         `<title>${escapeXml(a.title)}</title>`,
         `<id>${escapeXml(a.guid)}</id>`,
         `<link href="${escapeXml(a.url)}" rel="alternate"/>`,
-        `<updated>${a.published_at}</updated>`,
-        `<published>${a.published_at}</published>`,
+        `<updated>${publishedIso}</updated>`,
+        `<published>${publishedIso}</published>`,
       ];
       if (authorName) parts.push(`<author><name>${escapeXml(authorName)}</name></author>`);
       parts.push(`<category term="${escapeXml(a.category)}"/>`);

--- a/apps/web/worker/api/syndication/json.ts
+++ b/apps/web/worker/api/syndication/json.ts
@@ -1,3 +1,4 @@
+import { toIso8601 } from "./shared";
 import type { FeedMeta } from "./shared";
 
 export function renderJsonFeed(meta: FeedMeta): { contentType: string; body: string } {
@@ -14,7 +15,9 @@ export function renderJsonFeed(meta: FeedMeta): { contentType: string; body: str
       title: a.title,
       content_text: a.summary ?? "",
       summary: a.summary ?? undefined,
-      date_published: a.published_at,
+      // JSON Feed 1.1 は date_published を RFC 3339 と規定しているため
+      // DB 値をそのまま使わず必ず有効な ISO 8601 に変換する
+      date_published: toIso8601(a.published_at),
       authors: a.author ? [{ name: a.author }] : undefined,
       tags: [a.category, a.lang, ...(a.feed_name ? [a.feed_name] : [])],
       _feed_id: a.feed_id,

--- a/apps/web/worker/api/syndication/rss.ts
+++ b/apps/web/worker/api/syndication/rss.ts
@@ -1,8 +1,18 @@
-import { escapeXml, toRfc822 } from "./shared";
+import { escapeXml, feedUpdatedAt, toRfc822 } from "./shared";
 import type { FeedMeta } from "./shared";
 
 export function renderRssFeed(meta: FeedMeta): { contentType: string; body: string } {
-  const lastBuild = meta.articles[0]?.published_at ?? new Date().toISOString();
+  const lastBuild = feedUpdatedAt(meta.articles);
+  // RSS 2.0 の <channel><link> は必須要素。
+  // siteOrigin() が空文字を返すケース（不正な URL など）では feedUrl の origin を代替使用する。
+  let channelLink = meta.origin;
+  if (!channelLink) {
+    try {
+      channelLink = new URL(meta.feedUrl).origin;
+    } catch {
+      channelLink = meta.feedUrl;
+    }
+  }
 
   const items = meta.articles
     .map((a) => {
@@ -30,7 +40,7 @@ export function renderRssFeed(meta: FeedMeta): { contentType: string; body: stri
     `<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">` +
     `<channel>` +
     `<title>${escapeXml(meta.title)}</title>` +
-    `<link>${escapeXml(meta.origin)}</link>` +
+    `<link>${escapeXml(channelLink)}</link>` +
     `<description>${escapeXml(meta.description)}</description>` +
     languageTag +
     `<lastBuildDate>${toRfc822(lastBuild)}</lastBuildDate>` +

--- a/apps/web/worker/api/syndication/shared.ts
+++ b/apps/web/worker/api/syndication/shared.ts
@@ -43,6 +43,27 @@ export function toRfc822(iso: string): string {
   return d.toUTCString();
 }
 
+/**
+ * ISO 8601 / RFC 3339 形式の日時文字列を返す。
+ * 入力が無効な場合は現在時刻の ISO 文字列にフォールバックする。
+ * Atom の <updated> / <published> は必ず有効な RFC 3339 値が必要なため、
+ * DB から来た published_at を素通しにすると XML パーサーが壊れる。
+ */
+export function toIso8601(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return new Date().toISOString();
+  return d.toISOString();
+}
+
+/**
+ * フィードの <updated> / <lastBuildDate> に使う基準時刻を返す。
+ * 空フィード時に毎回異なる現在時刻を使うと ETag が安定しないため、
+ * 記事が 0 件の場合は固定の epoch 値を使って ETag キャッシュを有効にする。
+ */
+export function feedUpdatedAt(articles: { published_at: string }[]): string {
+  return articles[0]?.published_at ?? "1970-01-01T00:00:00.000Z";
+}
+
 function siteOrigin(reqUrl: string): string {
   try {
     const u = new URL(reqUrl);


### PR DESCRIPTION
## 概要

`apps/web/worker/api/syndication/` の監査で発見した 3 件の問題を修正する。

## 変更内容

### 1. Atom / JSON Feed の日付フィールド ISO 8601 保証

**問題:** `atom.ts` の `<updated>`/`<published>` は `a.published_at` を escapeXml なしで直接埋め込んでいた。DB に異常値が入ると XML パーサーが壊れる。`json.ts` の `date_published` も同様で、JSON Feed 1.1 仕様 (RFC 3339 必須) に違反した出力になる可能性があった。

**修正:** `shared.ts` に `toIso8601(iso: string): string` を追加。無効な日付文字列は現在時刻の ISO 8601 値にフォールバックする。`atom.ts` と `json.ts` でこのヘルパーを通して出力する。

### 2. 空フィード時の ETag 安定化

**問題:** 記事が 0 件の場合、`lastBuildDate` / Atom `<updated>` に `new Date().toISOString()` を使っていた。リクエストのたびに値が変わり、ETag も変わるため 304 が機能しない。

**修正:** `shared.ts` に `feedUpdatedAt(articles)` を追加。記事が 0 件の場合は `"1970-01-01T00:00:00.000Z"` の固定値を返して ETag を安定させる。

### 3. RSS `<channel><link>` が空になるケースへのフォールバック

**問題:** `renderRssFeed` の channel `<link>` は `meta.origin` をそのまま使っていた。`siteOrigin()` が例外をキャッチして空文字を返すケースで `<link></link>` になり、RSS 2.0 必須要素が不正になる。

**修正:** `rss.ts` で `meta.origin` が空の場合は `new URL(meta.feedUrl).origin` を代替として使うフォールバックを追加。

## テスト

- [x] `pnpm -C apps/web typecheck` (pass)
- [x] `pnpm -C apps/web build` (pass)
- [x] `vp test run tests/worker/api/syndication.test.ts` (71件 pass)
- [x] 全 worker テスト `vp test run` (626件 pass)
- [x] `vp fmt --check` / `vp lint` (変更ファイルはクリーン)

### 追加したテスト

- 空フィード (zenn カテゴリ) で RSS 2.0 必須構造が揃っていること
- 空フィードで JSON Feed items が `[]` であること
- 空フィードで Atom `<entry>` が出力されないこと
- 空フィード ETag が 2 リクエスト間で同一であること
- 空フィード 304 round-trip が機能すること
- 特殊文字 (`<`, `>`, `&`, `"`, `'`) が RSS/Atom で正しくエスケープされること
- JSON Feed では XML エスケープされず生の文字列が保持されること
- Atom `<updated>`/`<published>` が有効な ISO 8601 であること
- JSON Feed `date_published` が有効な ISO 8601 であること