### PR TITLE
fix(client): improve accessibility in FilterBar, ArticleCard, ReportsList, EmptyState and SearchInput

### DIFF
--- a/apps/web/client/components/ArticleCard.tsx
+++ b/apps/web/client/components/ArticleCard.tsx
@@ -161,6 +161,7 @@ export function ArticleCard({
                 onClick={() => {
                   if (article.author) onNavigateToAuthor(article.author);
                 }}
+                title={`${article.author} の記事一覧`}
                 aria-label={`${article.author} の記事一覧`}
               >
                 {article.author}

--- a/apps/web/client/components/ArticleCard.tsx
+++ b/apps/web/client/components/ArticleCard.tsx
@@ -132,6 +132,7 @@ export function ArticleCard({
           type="button"
           className={`inline-flex items-center px-[var(--space-2)] py-0.5 rounded-full text-[var(--font-size-xs)] font-semibold uppercase tracking-[0.04em] border-none font-[inherit] leading-[var(--line-height-tight)] whitespace-nowrap align-middle cursor-pointer transition-[opacity,filter] duration-100 hover:brightness-110 hover:opacity-90 focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2 ${catBadgeClass}`}
           onClick={() => onFilterByCategory(article.category)}
+          title={`${CATEGORY_LABEL[article.category] ?? article.category} で絞り込む`}
           aria-label={`${CATEGORY_LABEL[article.category] ?? article.category} で絞り込む`}
         >
           <span aria-hidden="true" className="mr-[3px]">
@@ -143,6 +144,7 @@ export function ArticleCard({
           type="button"
           className="text-[var(--fg-primary)] font-medium border-none bg-transparent font-[inherit] text-inherit p-0 cursor-pointer transition-colors duration-100 hover:text-[var(--accent)] hover:underline focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2 focus-visible:rounded-[var(--radius-sm)]"
           onClick={() => onFilterByFeedId(article.feed_id)}
+          title={`${article.feed_name ?? article.feed_id} で絞り込む`}
           aria-label={`${article.feed_name ?? article.feed_id} で絞り込む`}
         >
           {article.feed_name ?? article.feed_id}

--- a/apps/web/client/components/ArticleCard.tsx
+++ b/apps/web/client/components/ArticleCard.tsx
@@ -91,6 +91,8 @@ export function ArticleCard({
       tabIndex={-1}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
+      onFocus={() => setHovered(true)}
+      onBlur={() => setHovered(false)}
     >
       {/* カードヘッダ行 (タイトル + アクションボタン) */}
       <div className="flex items-start gap-[var(--space-2)]">
@@ -130,7 +132,7 @@ export function ArticleCard({
           type="button"
           className={`inline-flex items-center px-[var(--space-2)] py-0.5 rounded-full text-[var(--font-size-xs)] font-semibold uppercase tracking-[0.04em] border-none font-[inherit] leading-[var(--line-height-tight)] whitespace-nowrap align-middle cursor-pointer transition-[opacity,filter] duration-100 hover:brightness-110 hover:opacity-90 focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2 ${catBadgeClass}`}
           onClick={() => onFilterByCategory(article.category)}
-          title={`${CATEGORY_LABEL[article.category] ?? article.category} で絞り込む`}
+          aria-label={`${CATEGORY_LABEL[article.category] ?? article.category} で絞り込む`}
         >
           <span aria-hidden="true" className="mr-[3px]">
             {CATEGORY_ICON[article.category] ?? ""}
@@ -141,7 +143,7 @@ export function ArticleCard({
           type="button"
           className="text-[var(--fg-primary)] font-medium border-none bg-transparent font-[inherit] text-inherit p-0 cursor-pointer transition-colors duration-100 hover:text-[var(--accent)] hover:underline focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2 focus-visible:rounded-[var(--radius-sm)]"
           onClick={() => onFilterByFeedId(article.feed_id)}
-          title={`${article.feed_name ?? article.feed_id} で絞り込む`}
+          aria-label={`${article.feed_name ?? article.feed_id} で絞り込む`}
         >
           {article.feed_name ?? article.feed_id}
         </button>
@@ -157,7 +159,7 @@ export function ArticleCard({
                 onClick={() => {
                   if (article.author) onNavigateToAuthor(article.author);
                 }}
-                title={`${article.author} の記事一覧`}
+                aria-label={`${article.author} の記事一覧`}
               >
                 {article.author}
               </button>

--- a/apps/web/client/components/ArticlesView.tsx
+++ b/apps/web/client/components/ArticlesView.tsx
@@ -149,7 +149,6 @@ export function ArticlesView({
           className={`py-[5px] px-[var(--space-3)] bg-[var(--bg-elevated)] border border-[var(--border-subtle)] rounded-[var(--radius-full)] text-[var(--font-size-sm)] font-[inherit] cursor-pointer whitespace-nowrap shrink-0 transition-[border-color,color,background] duration-100 hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2${bookmarkedOnly ? " bg-[var(--accent-soft)] border-[var(--accent)] text-[var(--accent)] font-semibold" : " text-[var(--fg-muted)]"}`}
           onClick={onBookmarkedOnlyToggle}
           aria-pressed={bookmarkedOnly}
-          aria-label={`ブックマーク ${bookmarks.size} 件${bookmarkedOnly ? "を表示中" : "のみ表示"}`}
         >
           ★ {bookmarks.size} 件{bookmarkedOnly ? " (表示中)" : ""}
         </button>

--- a/apps/web/client/components/ArticlesView.tsx
+++ b/apps/web/client/components/ArticlesView.tsx
@@ -149,7 +149,7 @@ export function ArticlesView({
           className={`py-[5px] px-[var(--space-3)] bg-[var(--bg-elevated)] border border-[var(--border-subtle)] rounded-[var(--radius-full)] text-[var(--font-size-sm)] font-[inherit] cursor-pointer whitespace-nowrap shrink-0 transition-[border-color,color,background] duration-100 hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2${bookmarkedOnly ? " bg-[var(--accent-soft)] border-[var(--accent)] text-[var(--accent)] font-semibold" : " text-[var(--fg-muted)]"}`}
           onClick={onBookmarkedOnlyToggle}
           aria-pressed={bookmarkedOnly}
-          aria-label={`★ ブックマーク ${bookmarks.size} 件${bookmarkedOnly ? "を表示中" : "のみ表示"}`}
+          aria-label={`ブックマーク ${bookmarks.size} 件${bookmarkedOnly ? "を表示中" : "のみ表示"}`}
         >
           ★ {bookmarks.size} 件{bookmarkedOnly ? " (表示中)" : ""}
         </button>

--- a/apps/web/client/components/ArticlesView.tsx
+++ b/apps/web/client/components/ArticlesView.tsx
@@ -149,6 +149,7 @@ export function ArticlesView({
           className={`py-[5px] px-[var(--space-3)] bg-[var(--bg-elevated)] border border-[var(--border-subtle)] rounded-[var(--radius-full)] text-[var(--font-size-sm)] font-[inherit] cursor-pointer whitespace-nowrap shrink-0 transition-[border-color,color,background] duration-100 hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2${bookmarkedOnly ? " bg-[var(--accent-soft)] border-[var(--accent)] text-[var(--accent)] font-semibold" : " text-[var(--fg-muted)]"}`}
           onClick={onBookmarkedOnlyToggle}
           aria-pressed={bookmarkedOnly}
+          aria-label={`ブックマーク ${bookmarks.size} 件${bookmarkedOnly ? "を表示中" : "のみ表示"}`}
         >
           ★ {bookmarks.size} 件{bookmarkedOnly ? " (表示中)" : ""}
         </button>
@@ -182,6 +183,7 @@ export function ArticlesView({
             onChange={onQChange}
             onFocus={handleSearchFocusIn}
             onBlur={handleSearchBlur}
+            suggestVisible={suggestVisible}
           />
           <SearchSuggestions
             items={recentSearches.items}
@@ -212,12 +214,19 @@ export function ArticlesView({
       </div>
 
       {loading && (
-        <div className="text-center text-[var(--fg-muted)] py-[var(--space-8)] px-[var(--space-3)] border border-dashed border-[var(--border-subtle)] rounded-[var(--radius-lg)] mt-[var(--space-4)] text-[var(--font-size-base)] leading-[var(--line-height-relaxed)]">
+        <div
+          role="status"
+          aria-live="polite"
+          className="text-center text-[var(--fg-muted)] py-[var(--space-8)] px-[var(--space-3)] border border-dashed border-[var(--border-subtle)] rounded-[var(--radius-lg)] mt-[var(--space-4)] text-[var(--font-size-base)] leading-[var(--line-height-relaxed)]"
+        >
           読み込み中…
         </div>
       )}
       {error && !loading && (
-        <div className="text-center text-[var(--danger)] py-[var(--space-8)] px-[var(--space-3)] border border-[rgba(207,34,46,0.3)] rounded-[var(--radius-lg)] bg-[var(--danger-soft)] mt-[var(--space-4)] text-[var(--font-size-base)] leading-[var(--line-height-relaxed)]">
+        <div
+          role="alert"
+          className="text-center text-[var(--danger)] py-[var(--space-8)] px-[var(--space-3)] border border-[rgba(207,34,46,0.3)] rounded-[var(--radius-lg)] bg-[var(--danger-soft)] mt-[var(--space-4)] text-[var(--font-size-base)] leading-[var(--line-height-relaxed)]"
+        >
           取得エラー: {error}
         </div>
       )}

--- a/apps/web/client/components/ArticlesView.tsx
+++ b/apps/web/client/components/ArticlesView.tsx
@@ -149,7 +149,7 @@ export function ArticlesView({
           className={`py-[5px] px-[var(--space-3)] bg-[var(--bg-elevated)] border border-[var(--border-subtle)] rounded-[var(--radius-full)] text-[var(--font-size-sm)] font-[inherit] cursor-pointer whitespace-nowrap shrink-0 transition-[border-color,color,background] duration-100 hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2${bookmarkedOnly ? " bg-[var(--accent-soft)] border-[var(--accent)] text-[var(--accent)] font-semibold" : " text-[var(--fg-muted)]"}`}
           onClick={onBookmarkedOnlyToggle}
           aria-pressed={bookmarkedOnly}
-          aria-label={`ブックマーク ${bookmarks.size} 件${bookmarkedOnly ? "を表示中" : "のみ表示"}`}
+          aria-label={`★ ブックマーク ${bookmarks.size} 件${bookmarkedOnly ? "を表示中" : "のみ表示"}`}
         >
           ★ {bookmarks.size} 件{bookmarkedOnly ? " (表示中)" : ""}
         </button>

--- a/apps/web/client/components/EmptyState.tsx
+++ b/apps/web/client/components/EmptyState.tsx
@@ -7,7 +7,9 @@ interface Props {
 export function EmptyState({ icon, title, body }: Props) {
   return (
     <div className="text-center text-[var(--fg-muted)] py-[var(--space-8)] px-[var(--space-3)] border border-dashed border-[var(--border-subtle)] rounded-[var(--radius-lg)] mt-[var(--space-4)] text-[var(--font-size-base)] leading-[var(--line-height-relaxed)]">
-      <span className="text-[2.5rem] block mb-[var(--space-3)] leading-none" aria-hidden="true">{icon}</span>
+      <span className="text-[2.5rem] block mb-[var(--space-3)] leading-none" aria-hidden="true">
+        {icon}
+      </span>
       <div className="text-[var(--font-size-md)] font-semibold text-[var(--fg-secondary)] mb-[var(--space-1)]">
         {title}
       </div>

--- a/apps/web/client/components/EmptyState.tsx
+++ b/apps/web/client/components/EmptyState.tsx
@@ -7,7 +7,7 @@ interface Props {
 export function EmptyState({ icon, title, body }: Props) {
   return (
     <div className="text-center text-[var(--fg-muted)] py-[var(--space-8)] px-[var(--space-3)] border border-dashed border-[var(--border-subtle)] rounded-[var(--radius-lg)] mt-[var(--space-4)] text-[var(--font-size-base)] leading-[var(--line-height-relaxed)]">
-      <span className="text-[2.5rem] block mb-[var(--space-3)] leading-none">{icon}</span>
+      <span className="text-[2.5rem] block mb-[var(--space-3)] leading-none" aria-hidden="true">{icon}</span>
       <div className="text-[var(--font-size-md)] font-semibold text-[var(--fg-secondary)] mb-[var(--space-1)]">
         {title}
       </div>

--- a/apps/web/client/components/FilterBar.tsx
+++ b/apps/web/client/components/FilterBar.tsx
@@ -59,6 +59,7 @@ export function FilterBar({
       <select
         className={`${inputClass} min-w-[130px]`}
         value={category}
+        aria-label="カテゴリ"
         onChange={(e) => onCategoryChange(e.target.value as FeedCategory | "")}
       >
         <option value="">All categories</option>
@@ -71,6 +72,7 @@ export function FilterBar({
       <select
         className={`${inputClass} min-w-[130px]`}
         value={lang}
+        aria-label="言語"
         onChange={(e) => onLangChange(e.target.value as FeedLang | "")}
       >
         <option value="">All langs</option>
@@ -81,6 +83,7 @@ export function FilterBar({
       <select
         className={`${inputClass} min-w-[130px]`}
         value={feedId}
+        aria-label="フィード"
         onChange={(e) => onFeedChange(e.target.value)}
       >
         <option value="">All feeds</option>

--- a/apps/web/client/components/ReportsList.tsx
+++ b/apps/web/client/components/ReportsList.tsx
@@ -44,11 +44,12 @@ export function ReportsList({ onSelectReport }: Props) {
       </h2>
 
       {/* kind フィルタ chip */}
-      <div className="flex flex-wrap gap-[var(--space-2)] mb-[var(--space-4)]">
+      <div role="group" aria-label="レポートの種別フィルタ" className="flex flex-wrap gap-[var(--space-2)] mb-[var(--space-4)]">
         {chips.map(({ label, value }) => (
           <button
             key={label}
             type="button"
+            aria-pressed={kindFilter === value}
             className={`inline-flex items-center px-[var(--space-3)] py-[5px] rounded-full text-[var(--font-size-sm)] font-medium border-none font-[inherit] cursor-pointer whitespace-nowrap transition-[background,color] duration-100 focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2${
               kindFilter === value
                 ? " bg-[var(--accent-soft)] text-[var(--accent)] font-semibold"
@@ -62,11 +63,11 @@ export function ReportsList({ onSelectReport }: Props) {
       </div>
 
       {loading && (
-        <p className="text-[var(--fg-muted)] text-[var(--font-size-sm)]">読み込み中...</p>
+        <p role="status" aria-live="polite" className="text-[var(--fg-muted)] text-[var(--font-size-sm)]">読み込み中...</p>
       )}
 
       {error && (
-        <p className="text-[var(--fg-muted)] text-[var(--font-size-sm)]">エラー: {error}</p>
+        <p role="alert" className="text-[var(--fg-muted)] text-[var(--font-size-sm)]">エラー: {error}</p>
       )}
 
       {!loading && !error && reports.length === 0 && (

--- a/apps/web/client/components/ReportsList.tsx
+++ b/apps/web/client/components/ReportsList.tsx
@@ -44,7 +44,11 @@ export function ReportsList({ onSelectReport }: Props) {
       </h2>
 
       {/* kind フィルタ chip */}
-      <div role="group" aria-label="レポートの種別フィルタ" className="flex flex-wrap gap-[var(--space-2)] mb-[var(--space-4)]">
+      <div
+        role="group"
+        aria-label="レポートの種別フィルタ"
+        className="flex flex-wrap gap-[var(--space-2)] mb-[var(--space-4)]"
+      >
         {chips.map(({ label, value }) => (
           <button
             key={label}
@@ -63,11 +67,19 @@ export function ReportsList({ onSelectReport }: Props) {
       </div>
 
       {loading && (
-        <p role="status" aria-live="polite" className="text-[var(--fg-muted)] text-[var(--font-size-sm)]">読み込み中...</p>
+        <p
+          role="status"
+          aria-live="polite"
+          className="text-[var(--fg-muted)] text-[var(--font-size-sm)]"
+        >
+          読み込み中...
+        </p>
       )}
 
       {error && (
-        <p role="alert" className="text-[var(--fg-muted)] text-[var(--font-size-sm)]">エラー: {error}</p>
+        <p role="alert" className="text-[var(--fg-muted)] text-[var(--font-size-sm)]">
+          エラー: {error}
+        </p>
       )}
 
       {!loading && !error && reports.length === 0 && (

--- a/apps/web/client/components/SearchInput.tsx
+++ b/apps/web/client/components/SearchInput.tsx
@@ -6,10 +6,12 @@ interface Props {
   delayMs?: number;
   onFocus?: () => void;
   onBlur?: () => void;
+  /** サジェストドロップダウンが開いているかどうか (aria-expanded 制御用) */
+  suggestVisible?: boolean;
 }
 
 export const SearchInput = forwardRef<HTMLInputElement, Props>(function SearchInput(
-  { value, onChange, delayMs = 300, onFocus, onBlur },
+  { value, onChange, delayMs = 300, onFocus, onBlur, suggestVisible = false },
   ref,
 ) {
   const [local, setLocal] = useState(value);
@@ -30,6 +32,11 @@ export const SearchInput = forwardRef<HTMLInputElement, Props>(function SearchIn
     <input
       ref={ref}
       type="search"
+      aria-label="記事を検索"
+      aria-expanded={suggestVisible}
+      aria-haspopup="listbox"
+      aria-controls="search-suggestions"
+      aria-autocomplete="list"
       className="w-full px-[var(--space-3)] py-[var(--space-2)] bg-[var(--bg-overlay)] border border-[var(--border-subtle)] rounded-[var(--radius-md)] text-[var(--fg-primary)] text-[var(--font-size-base)] font-[inherit] transition-[border-color] duration-100 placeholder:text-[var(--fg-muted)] focus:outline-none focus:border-[var(--accent)] focus:shadow-[0_0_0_3px_var(--accent-soft)]"
       placeholder="記事を検索 (タイトル / 概要)"
       value={local}

--- a/apps/web/client/components/SearchSuggestions.tsx
+++ b/apps/web/client/components/SearchSuggestions.tsx
@@ -11,7 +11,9 @@ export function SearchSuggestions({ items, onPick, onRemove, onClearAll, visible
 
   return (
     <ul
+      id="search-suggestions"
       role="listbox"
+      aria-label="検索履歴"
       className="absolute top-full left-0 right-0 bg-[var(--bg-elevated)] border border-[var(--border-subtle)] rounded-b-[var(--radius-md)] max-h-[300px] overflow-y-auto z-50 list-none m-0 py-[var(--space-1)] shadow-[var(--shadow-md)]"
     >
       {items.map((item) => (

--- a/apps/web/e2e/filter/bookmarks-only.spec.ts
+++ b/apps/web/e2e/filter/bookmarks-only.spec.ts
@@ -7,27 +7,14 @@ test.describe("bookmarks only toggle", () => {
     await waitForArticles(page);
 
     // ブックマークボタン (BookmarkButton) をクリック — aria-label "ブックマークに追加"
-    const firstCard = page.locator("[data-article-id]").first();
-    const bookmarkBtn = firstCard.getByRole("button", { name: "ブックマークに追加" });
-    await bookmarkBtn.click();
+    const bookmarkBtn = page
+      .locator("[data-article-id]")
+      .first()
+      .getByRole("button", { name: /ブックマーク/i });
+    await bookmarkBtn.first().click();
 
-    // ブックマーク追加が localStorage に書き込まれるまで待つ
-    await page.waitForFunction(
-      () => {
-        const raw = localStorage.getItem("tnb:bookmarks:v1");
-        if (!raw) return false;
-        try {
-          const arr: unknown = JSON.parse(raw);
-          return Array.isArray(arr) && (arr as unknown[]).length > 0;
-        } catch {
-          return false;
-        }
-      },
-      { timeout: 5_000 },
-    );
-
-    // ブックマークのみ表示ボタンをクリック (aria-label "ブックマーク N 件のみ表示")
-    const bookmarkOnlyBtn = page.getByRole("button", { name: /ブックマーク \d+ 件のみ表示/ });
+    // ブックマークのみ表示ボタンをクリック (aria-pressed 属性を持つ ★ N 件ボタン)
+    const bookmarkOnlyBtn = page.getByRole("button", { name: /★.+件/ });
     await bookmarkOnlyBtn.click();
 
     // URL に bookmarks=only が付く

--- a/apps/web/e2e/filter/bookmarks-only.spec.ts
+++ b/apps/web/e2e/filter/bookmarks-only.spec.ts
@@ -7,15 +7,17 @@ test.describe("bookmarks only toggle", () => {
     await waitForArticles(page);
 
     // ブックマークボタン (BookmarkButton) をクリック — aria-label "ブックマークに追加"
-    const bookmarkBtn = page
-      .locator("[data-article-id]")
-      .first()
-      .getByRole("button", { name: /ブックマーク/i });
-    await bookmarkBtn.first().click();
+    const firstCard = page.locator("[data-article-id]").first();
+    const bookmarkBtn = firstCard.getByRole("button", { name: "ブックマークに追加" });
+    await bookmarkBtn.click();
+
+    // ブックマーク追加が反映され aria-label が "ブックマークから削除" に変わるまで待つ
+    await expect(firstCard.getByRole("button", { name: "ブックマークから削除" })).toBeVisible({
+      timeout: 5_000,
+    });
 
     // ブックマークのみ表示ボタンをクリック (aria-label "ブックマーク N 件のみ表示")
-    // ブックマーク追加後に aria-label が 1 件以上になるまで待ってからクリック
-    const bookmarkOnlyBtn = page.getByRole("button", { name: /ブックマーク [1-9]/ });
+    const bookmarkOnlyBtn = page.getByRole("button", { name: /ブックマーク \d+ 件のみ表示/ });
     await bookmarkOnlyBtn.click();
 
     // URL に bookmarks=only が付く

--- a/apps/web/e2e/filter/bookmarks-only.spec.ts
+++ b/apps/web/e2e/filter/bookmarks-only.spec.ts
@@ -7,11 +7,14 @@ test.describe("bookmarks only toggle", () => {
     await waitForArticles(page);
 
     // ブックマークボタン (BookmarkButton) をクリック — aria-label "ブックマークに追加"
+    // hover してから click することで ArticleCard の onFocus による DOM 変化の前に
+    // hover 状態を安定させ、確実に BookmarkButton の onClick を発火させる
     const bookmarkBtn = page
       .locator("[data-article-id]")
       .first()
       .getByRole("button", { name: "ブックマークに追加" });
-    await bookmarkBtn.click({ force: true });
+    await bookmarkBtn.hover();
+    await bookmarkBtn.click();
 
     // ブックマーク件数ボタンが ★ 1 件 以上に更新されるまで待つ
     // (localStorage への書き込みと React 再レンダリングが完了するのを確認)

--- a/apps/web/e2e/filter/bookmarks-only.spec.ts
+++ b/apps/web/e2e/filter/bookmarks-only.spec.ts
@@ -10,13 +10,15 @@ test.describe("bookmarks only toggle", () => {
     const bookmarkBtn = page
       .locator("[data-article-id]")
       .first()
-      .getByRole("button", { name: /ブックマーク/i });
-    await bookmarkBtn.first().click();
+      .getByRole("button", { name: "ブックマークに追加" });
+    await bookmarkBtn.click({ force: true });
 
-    // ブックマークのみ表示ボタンをクリック (aria-pressed 属性を持つ ★ N 件ボタン)
-    // /★ [1-9]/ を使って ★ 0 件 の状態では一致しないようにし、
-    // ブックマーク追加後 (★ 1 件以上) になるまで Playwright に待機させる
+    // ブックマーク件数ボタンが ★ 1 件 以上に更新されるまで待つ
+    // (localStorage への書き込みと React 再レンダリングが完了するのを確認)
     const bookmarkOnlyBtn = page.getByRole("button", { name: /★ [1-9]/ });
+    await expect(bookmarkOnlyBtn).toBeVisible({ timeout: 5_000 });
+
+    // ブックマークのみ表示ボタンをクリック
     await bookmarkOnlyBtn.click();
 
     // URL に bookmarks=only が付く

--- a/apps/web/e2e/filter/bookmarks-only.spec.ts
+++ b/apps/web/e2e/filter/bookmarks-only.spec.ts
@@ -13,8 +13,9 @@ test.describe("bookmarks only toggle", () => {
       .getByRole("button", { name: /ブックマーク/i });
     await bookmarkBtn.first().click();
 
-    // ブックマークのみ表示ボタンをクリック (aria-pressed 属性を持つ ★ N 件ボタン)
-    const bookmarkOnlyBtn = page.getByRole("button", { name: /★.+件/ });
+    // ブックマークのみ表示ボタンをクリック (aria-label "ブックマーク N 件のみ表示")
+    // ブックマーク追加後に aria-label が 1 件以上になるまで待ってからクリック
+    const bookmarkOnlyBtn = page.getByRole("button", { name: /ブックマーク [1-9]/ });
     await bookmarkOnlyBtn.click();
 
     // URL に bookmarks=only が付く

--- a/apps/web/e2e/filter/bookmarks-only.spec.ts
+++ b/apps/web/e2e/filter/bookmarks-only.spec.ts
@@ -11,10 +11,20 @@ test.describe("bookmarks only toggle", () => {
     const bookmarkBtn = firstCard.getByRole("button", { name: "ブックマークに追加" });
     await bookmarkBtn.click();
 
-    // ブックマーク追加が反映され aria-label が "ブックマークから削除" に変わるまで待つ
-    await expect(firstCard.getByRole("button", { name: "ブックマークから削除" })).toBeVisible({
-      timeout: 5_000,
-    });
+    // ブックマーク追加が localStorage に書き込まれるまで待つ
+    await page.waitForFunction(
+      () => {
+        const raw = localStorage.getItem("tnb:bookmarks:v1");
+        if (!raw) return false;
+        try {
+          const arr: unknown = JSON.parse(raw);
+          return Array.isArray(arr) && (arr as unknown[]).length > 0;
+        } catch {
+          return false;
+        }
+      },
+      { timeout: 5_000 },
+    );
 
     // ブックマークのみ表示ボタンをクリック (aria-label "ブックマーク N 件のみ表示")
     const bookmarkOnlyBtn = page.getByRole("button", { name: /ブックマーク \d+ 件のみ表示/ });

--- a/apps/web/e2e/filter/bookmarks-only.spec.ts
+++ b/apps/web/e2e/filter/bookmarks-only.spec.ts
@@ -14,7 +14,9 @@ test.describe("bookmarks only toggle", () => {
     await bookmarkBtn.first().click();
 
     // ブックマークのみ表示ボタンをクリック (aria-pressed 属性を持つ ★ N 件ボタン)
-    const bookmarkOnlyBtn = page.getByRole("button", { name: /★.+件/ });
+    // /★ [1-9]/ を使って ★ 0 件 の状態では一致しないようにし、
+    // ブックマーク追加後 (★ 1 件以上) になるまで Playwright に待機させる
+    const bookmarkOnlyBtn = page.getByRole("button", { name: /★ [1-9]/ });
     await bookmarkOnlyBtn.click();
 
     // URL に bookmarks=only が付く

--- a/apps/web/tests/client/EmptyState.test.tsx
+++ b/apps/web/tests/client/EmptyState.test.tsx
@@ -28,4 +28,10 @@ describe("EmptyState", () => {
     const span = container.querySelector("span");
     expect(span?.textContent).toBe("✨");
   });
+
+  it("icon span has aria-hidden to prevent screen reader from reading the emoji", () => {
+    const { container } = render(<EmptyState icon="✨" title="テスト" body="説明文" />);
+    const span = container.querySelector("span");
+    expect(span?.getAttribute("aria-hidden")).toBe("true");
+  });
 });

--- a/apps/web/tests/client/FilterBar.test.tsx
+++ b/apps/web/tests/client/FilterBar.test.tsx
@@ -28,6 +28,13 @@ describe("FilterBar", () => {
     expect(screen.getByText("All categories")).toBeTruthy();
   });
 
+  it("each select has an accessible aria-label", () => {
+    render(<FilterBar {...defaultProps} />);
+    expect(screen.getByRole("combobox", { name: "カテゴリ" })).toBeTruthy();
+    expect(screen.getByRole("combobox", { name: "言語" })).toBeTruthy();
+    expect(screen.getByRole("combobox", { name: "フィード" })).toBeTruthy();
+  });
+
   it("calls onCategoryChange when a category is selected", async () => {
     const onCategoryChange = vi.fn<(c: string) => void>();
     const user = userEvent.setup();

--- a/apps/web/tests/client/ReportsList.test.tsx
+++ b/apps/web/tests/client/ReportsList.test.tsx
@@ -89,6 +89,28 @@ describe("ReportsList", () => {
     }
   });
 
+  it("kind フィルタ chip は選択状態を aria-pressed で表す", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeListResponse([])));
+
+    const user = userEvent.setup();
+    render(<ReportsList onSelectReport={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("読み込み中...")).toBeNull();
+    });
+
+    // 初期状態: 「すべて」が選択中
+    const allButton = screen.getByRole("button", { name: "すべて" });
+    expect(allButton.getAttribute("aria-pressed")).toBe("true");
+
+    // 「日次」クリック後: aria-pressed が切り替わる
+    await user.click(screen.getByRole("button", { name: "日次" }));
+    expect(screen.getByRole("button", { name: "日次" }).getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByRole("button", { name: "すべて" }).getAttribute("aria-pressed")).toBe(
+      "false",
+    );
+  });
+
   it("kind フィルタ chip をクリックすると fetch URL が変わる", async () => {
     const mockFetch = vi
       .fn<() => Promise<Response>>()

--- a/apps/web/tests/client/SearchInput.test.tsx
+++ b/apps/web/tests/client/SearchInput.test.tsx
@@ -79,8 +79,8 @@ describe("SearchInput", () => {
       <SearchInput value="" onChange={vi.fn<(q: string) => void>()} suggestVisible={false} />,
     );
     const input = screen.getByRole("searchbox");
-    // aria-expanded={false} は React が DOM から属性を除去するため null になる
-    expect(input.getAttribute("aria-expanded")).toBeNull();
+    // React は aria-* 属性を boolean false でも "false" として DOM に残す
+    expect(input.getAttribute("aria-expanded")).toBe("false");
 
     rerender(
       <SearchInput value="" onChange={vi.fn<(q: string) => void>()} suggestVisible={true} />,

--- a/apps/web/tests/client/SearchInput.test.tsx
+++ b/apps/web/tests/client/SearchInput.test.tsx
@@ -67,4 +67,24 @@ describe("SearchInput", () => {
     expect(ref.current?.tagName).toBe("INPUT");
     expect(ref.current?.value).toBe("test");
   });
+
+  it("has aria-label for screen readers", () => {
+    render(<SearchInput value="" onChange={vi.fn<(q: string) => void>()} />);
+    const input = screen.getByRole("searchbox");
+    expect(input.getAttribute("aria-label")).toBe("記事を検索");
+  });
+
+  it("reflects suggestVisible in aria-expanded", () => {
+    const { rerender } = render(
+      <SearchInput value="" onChange={vi.fn<(q: string) => void>()} suggestVisible={false} />,
+    );
+    const input = screen.getByRole("searchbox");
+    // aria-expanded={false} は React が DOM から属性を除去するため null になる
+    expect(input.getAttribute("aria-expanded")).toBeNull();
+
+    rerender(
+      <SearchInput value="" onChange={vi.fn<(q: string) => void>()} suggestVisible={true} />,
+    );
+    expect(input.getAttribute("aria-expanded")).toBe("true");
+  });
 });


### PR DESCRIPTION
## Summary

- **FilterBar**: `<select>` 要素 (カテゴリ・言語・フィード) に `aria-label` を追加し、スクリーンリーダーが各 select を識別できるように対応
- **ArticlesView**: ローディング状態に `role="status" aria-live="polite"`、エラー状態に `role="alert"` を追加。ブックマークトグルボタンに `aria-label` を追加
- **ArticleCard**: カードへの focus で既読/未読切替ボタンを表示 (キーボードユーザーもアクセス可能に)。カテゴリバッジ・フィード名・著者名ボタンに `aria-label` を追加 (`title` 属性はスクリーンリーダーで読み上げられないため)
- **ReportsList**: kind フィルタチップに `aria-pressed` を追加し選択状態をスクリーンリーダーに通知。フィルタ group に `role="group" aria-label` を追加
- **EmptyState**: 装飾用絵文字 `<span>` に `aria-hidden="true"` を追加し、スクリーンリーダーによる読み上げを抑制
- **SearchInput/SearchSuggestions**: combobox パターンの aria 属性 (`aria-expanded`, `aria-haspopup`, `aria-controls`, `aria-autocomplete`) と `id="search-suggestions"` / `aria-label="検索履歴"` を追加

## Test plan

- [ ] `pnpm typecheck` が通ること
- [ ] `pnpm -C apps/web test:client` が通ること (FilterBar・EmptyState・ReportsList・SearchInput のテストを新規追加)
- [ ] `pnpm build` が通ること
- [ ] `pnpm format && pnpm lint` がエラー 0 であること
- [ ] キーボードのみで記事フィルタ・検索・既読切り替えが操作できること
- [ ] スクリーンリーダー (VoiceOver / NVDA) でフィルタ変更時の通知が聞こえること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Keyboard focus now activates UI elements like mouse hover for improved keyboard navigation

* **Accessibility**
  * Added ARIA labels to filter controls and action buttons for screen reader users
  * Loading and error states now announced via live regions for better assistive technology support
  * Search input expanded with state tracking and improved listbox semantics
  * Enhanced filter chip selection with proper accessibility indicators

<!-- end of auto-generated comment: release notes by coderabbit.ai -->