### PR TITLE
test(worker): adopt soft assertions in articles list endpoint tests (Wave 1)

### DIFF
--- a/.claude/rules/01-typescript.md
+++ b/.claude/rules/01-typescript.md
@@ -42,6 +42,26 @@ type CollectResult =
 - 早期 return を優先しネストを浅く保つ
 - 1 ファイルに複数 export しても良いが、責務が違うものは分ける (例: `articles-query.ts` と `articles-write.ts`)
 
+## ヘルパーの配置 (utils/ の濫用禁止)
+
+ヘルパー関数を **反射的に `utils/` に置かない**。`utils/` は「**実際に複数ファイルから import されている、責務が独立した関数**」のための置き場であって、「いつか共通化されるかも」のバッファではない。
+
+| 状況                               | 置く場所                                                                             |
+| ---------------------------------- | ------------------------------------------------------------------------------------ |
+| 1 ファイルでしか使わない           | **そのファイル内** (export せずローカル関数 / 同ファイルの top-level 関数)           |
+| 1 ディレクトリ内の 2-3 ファイル    | そのディレクトリ内に `helpers.ts` や `<domain>.ts` を作る (例: `collector/parse.ts`) |
+| 2 つ以上の独立ドメインから使われる | `worker/utils/<name>.ts` または `client/utils/<name>.ts`                             |
+| 型だけの定義                       | 単一ファイルなら使う場所、複数なら `worker/types.ts` / `client/types/api.ts` に集約  |
+
+判断ルール:
+
+- **新規 helper を `utils/` に置きたくなったら、まず "import 元が現在 2 ファイル以上あるか" を確認**。1 つしかないなら呼び出し側に inline する
+- **dead code は速やかに削除**。「将来使うかも」の helper を置かない (YAGNI)。型エイリアス (`NonEmptyArray<T>` 等) も使われていないなら削除
+- **既存の `utils/` を増やすな**。ファイル名が抽象的 (`utils.ts`, `helpers.ts`) になりがちで責務が膨らむ。代わりに具体的なドメイン名 (`xml.ts`, `etag.ts`) で切る
+- **テストヘルパーも同じ**。`tests/fixtures/` は seed データ専用。テストロジックの共通化は `tests/<area>/_helpers.ts` のような具体名で
+
+例: `worker/api/articles.ts` の list endpoint で limit/cursor を parse する `parseListQuery(c)` は **articles.ts 内のローカル関数で OK**。他の API ファイルから使うようになって初めて `worker/api/_helpers.ts` などに昇格させる。
+
 ## コメント
 
 - 「**なぜ**」を書く。「何を」はコードで読めるので書かない

--- a/.claude/rules/20-testing-overview.md
+++ b/.claude/rules/20-testing-overview.md
@@ -82,6 +82,24 @@ CI では `vp check` (lint+format+typecheck) → `pnpm build` → `pnpm test` �
 
 - **新機能 / バグ修正は基本テストを追加してから PR を出す**。テスト追加が困難なケース (UI のごく些細な視覚変更等) は PR description にその旨を明記
 - **assertion は具体的に**。`expect(result).toBeTruthy()` でなく `expect(result).toEqual({ status: "ok", saved: 3 })`
+- **複数の独立した観点を検証する場合は soft assertion (`expect.soft(...)`) を使う**。1 つ目の失敗で fail-fast せず、すべての観点の失敗を 1 回の実行で集約できる:
+
+  ```ts
+  it("GET /api/articles returns paginated list", async () => {
+    const res = await SELF.fetch("https://x.test/api/articles?limit=2");
+    const body = await res.json<ArticlesResponse>();
+
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Cache-Control")).toContain("max-age");
+    expect.soft(body.articles).toHaveLength(2);
+    expect.soft(body.next_cursor).toBeTypeOf("string");
+  });
+  ```
+
+  - 「同じ対象の **独立した側面** (status / header / body の各キー)」を 1 テストでまとめて見る場合に有効
+  - 一方、後続の assert が前の assert の前提に依存する (例: `body.articles[0]` を見るには `articles.length > 0` 必須) ケースは通常の `expect` を使い fail-fast させる
+  - **assert を 5 件以上書くなら 1 テストとして肥大化していないか見直す**。観点が独立しすぎているなら `it` を分ける方が良い
+
 - **テストの独立性**: 1 テストが他のテストに依存しない。順序を変えても通ること
 - **flaky なテストは即修正**。retry でごまかさない (Playwright の `retries: 2` は CI 限定の保険)
 - **import 規約**:

--- a/apps/web/tests/worker/api/articles/by-author.test.ts
+++ b/apps/web/tests/worker/api/articles/by-author.test.ts
@@ -12,7 +12,7 @@ describe("GET /api/articles/by-author/:author", () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-author/Author%20A");
     expect.soft(res.status).toBe(200);
     const body = await res.json<{ articles: { author: string }[]; next_cursor: string | null }>();
-    expect.soft(Array.isArray(body.articles)).toBe(true);
+    expect(Array.isArray(body.articles)).toBe(true);
     expect(body.articles.length).toBe(1);
     expect.soft(body.articles[0].author).toBe("Author A");
     expect.soft(body.next_cursor).toBeNull();
@@ -133,7 +133,7 @@ describe("GET /api/articles/by-author/:author", () => {
       articles: { guid: string }[];
       next_cursor: string | null;
     }>();
-    expect.soft(body2.articles.length).toBe(1);
+    expect(body2.articles.length).toBe(1);
     expect.soft(body2.next_cursor).toBeNull();
 
     // 2 ページ合わせて全 guid が揃うことを確認

--- a/apps/web/tests/worker/api/articles/by-author.test.ts
+++ b/apps/web/tests/worker/api/articles/by-author.test.ts
@@ -10,58 +10,58 @@ beforeEach(async () => {
 describe("GET /api/articles/by-author/:author", () => {
   it("returns 200 with articles for a known author", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-author/Author%20A");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ articles: { author: string }[]; next_cursor: string | null }>();
-    expect(Array.isArray(body.articles)).toBe(true);
+    expect.soft(Array.isArray(body.articles)).toBe(true);
     expect(body.articles.length).toBe(1);
-    expect(body.articles[0].author).toBe("Author A");
-    expect(body.next_cursor).toBeNull();
+    expect.soft(body.articles[0].author).toBe("Author A");
+    expect.soft(body.next_cursor).toBeNull();
   });
 
   it("returns 200 with empty array when author has no articles", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-author/NonExistentAuthor");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ articles: unknown[]; next_cursor: string | null }>();
-    expect(body.articles).toEqual([]);
-    expect(body.next_cursor).toBeNull();
+    expect.soft(body.articles).toEqual([]);
+    expect.soft(body.next_cursor).toBeNull();
   });
 
   it("returns 400 when limit=0", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-author/Author%20A?limit=0");
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toMatch(/limit/);
+    expect.soft(body.error).toMatch(/limit/);
   });
 
   it("returns 400 when limit=51", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-author/Author%20A?limit=51");
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toMatch(/limit/);
+    expect.soft(body.error).toMatch(/limit/);
   });
 
   it("returns 400 when limit is non-numeric", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-author/Author%20A?limit=abc");
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toMatch(/limit/);
+    expect.soft(body.error).toMatch(/limit/);
   });
 
   it("returns 400 when cursor is malformed", async () => {
     const res = await SELF.fetch(
       "https://example.com/api/articles/by-author/Author%20A?cursor=not-valid-base64!!!",
     );
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toMatch(/cursor/);
+    expect.soft(body.error).toMatch(/cursor/);
   });
 
   it("decodes URL-encoded author name (space)", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-author/Author%20A");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ articles: { author: string }[] }>();
     expect(body.articles.length).toBeGreaterThan(0);
-    expect(body.articles[0].author).toBe("Author A");
+    expect.soft(body.articles[0].author).toBe("Author A");
   });
 
   it("returns articles in published_at DESC order", async () => {
@@ -80,11 +80,11 @@ describe("GET /api/articles/by-author/:author", () => {
       },
     ]);
     const res = await SELF.fetch("https://example.com/api/articles/by-author/Author%20B");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ articles: { published_at: string }[] }>();
     expect(body.articles.length).toBe(2);
     // published_at DESC: 2024-04-02 が先
-    expect(body.articles[0].published_at > body.articles[1].published_at).toBe(true);
+    expect.soft(body.articles[0].published_at > body.articles[1].published_at).toBe(true);
   });
 
   it("paginates with cursor: first page + second page", async () => {
@@ -116,7 +116,7 @@ describe("GET /api/articles/by-author/:author", () => {
 
     // 1 ページ目: limit=2
     const res1 = await SELF.fetch("https://example.com/api/articles/by-author/Author%20C?limit=2");
-    expect(res1.status).toBe(200);
+    expect.soft(res1.status).toBe(200);
     const body1 = await res1.json<{
       articles: { guid: string }[];
       next_cursor: string | null;
@@ -128,24 +128,24 @@ describe("GET /api/articles/by-author/:author", () => {
     const res2 = await SELF.fetch(
       `https://example.com/api/articles/by-author/Author%20C?limit=2&cursor=${body1.next_cursor}`,
     );
-    expect(res2.status).toBe(200);
+    expect.soft(res2.status).toBe(200);
     const body2 = await res2.json<{
       articles: { guid: string }[];
       next_cursor: string | null;
     }>();
-    expect(body2.articles.length).toBe(1);
-    expect(body2.next_cursor).toBeNull();
+    expect.soft(body2.articles.length).toBe(1);
+    expect.soft(body2.next_cursor).toBeNull();
 
     // 2 ページ合わせて全 guid が揃うことを確認
     const allGuids = [...body1.articles.map((a) => a.guid), ...body2.articles.map((a) => a.guid)];
-    expect(allGuids).toContain("o-ai-2");
-    expect(allGuids).toContain("o-ai-11");
-    expect(allGuids).toContain("o-ai-12");
+    expect.soft(allGuids).toContain("o-ai-2");
+    expect.soft(allGuids).toContain("o-ai-11");
+    expect.soft(allGuids).toContain("o-ai-12");
   });
 
   it("returns Cache-Control: public, max-age=300", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-author/Author%20A");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Cache-Control")).toBe("public, max-age=300");
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Cache-Control")).toBe("public, max-age=300");
   });
 });

--- a/apps/web/tests/worker/api/articles/by-category.test.ts
+++ b/apps/web/tests/worker/api/articles/by-category.test.ts
@@ -15,60 +15,60 @@ describe("GET /api/articles/by-category/:cat", () => {
 
   it("returns 200 with articles for ai category", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-category/ai");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ articles: { category: string }[]; next_cursor: string | null }>();
-    expect(Array.isArray(body.articles)).toBe(true);
-    expect(body.articles.length).toBe(2);
+    expect.soft(Array.isArray(body.articles)).toBe(true);
+    expect.soft(body.articles.length).toBe(2);
     for (const article of body.articles) {
-      expect(article.category).toBe("ai");
+      expect.soft(article.category).toBe("ai");
     }
-    expect(body.next_cursor).toBeNull();
+    expect.soft(body.next_cursor).toBeNull();
   });
 
   it("returns 200 with empty array when category has no articles", async () => {
     // zenn カテゴリの記事は beforeEach では挿入されない
     const res = await SELF.fetch("https://example.com/api/articles/by-category/zenn");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ articles: unknown[]; next_cursor: string | null }>();
-    expect(body.articles).toEqual([]);
-    expect(body.next_cursor).toBeNull();
+    expect.soft(body.articles).toEqual([]);
+    expect.soft(body.next_cursor).toBeNull();
   });
 
   it("returns 400 for invalid category", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-category/foo");
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toMatch(/category/);
+    expect.soft(body.error).toMatch(/category/);
   });
 
   it("returns 400 when limit=0", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-category/ai?limit=0");
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toMatch(/limit/);
+    expect.soft(body.error).toMatch(/limit/);
   });
 
   it("returns 400 when limit=51", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-category/ai?limit=51");
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toMatch(/limit/);
+    expect.soft(body.error).toMatch(/limit/);
   });
 
   it("returns 400 when limit is non-numeric", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-category/ai?limit=abc");
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toMatch(/limit/);
+    expect.soft(body.error).toMatch(/limit/);
   });
 
   it("returns 400 when cursor is malformed", async () => {
     const res = await SELF.fetch(
       "https://example.com/api/articles/by-category/ai?cursor=not-valid-base64!!!",
     );
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toMatch(/cursor/);
+    expect.soft(body.error).toMatch(/cursor/);
   });
 
   it("returns articles in published_at DESC, id DESC order", async () => {
@@ -89,15 +89,15 @@ describe("GET /api/articles/by-category/:cat", () => {
     ]);
     // o-ai-2 も SAME_AT (2024-04-03) なので tie → id DESC が効く
     const res = await SELF.fetch("https://example.com/api/articles/by-category/ai");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ articles: { published_at: string; id: number }[] }>();
     const dates = body.articles.map((a) => a.published_at);
     const sorted = dates.toSorted((a, b) => b.localeCompare(a));
-    expect(dates).toEqual(sorted);
+    expect.soft(dates).toEqual(sorted);
     // 同一 published_at 内は id DESC
     const sameAt = body.articles.filter((a) => a.published_at === SAME_AT);
     if (sameAt.length >= 2) {
-      expect(sameAt[0].id).toBeGreaterThan(sameAt[1].id);
+      expect.soft(sameAt[0].id).toBeGreaterThan(sameAt[1].id);
     }
   });
 
@@ -130,7 +130,7 @@ describe("GET /api/articles/by-category/:cat", () => {
 
     // 1 ページ目: limit=2
     const res1 = await SELF.fetch("https://example.com/api/articles/by-category/ai?limit=2");
-    expect(res1.status).toBe(200);
+    expect.soft(res1.status).toBe(200);
     const body1 = await res1.json<{
       articles: { guid: string }[];
       next_cursor: string | null;
@@ -142,35 +142,35 @@ describe("GET /api/articles/by-category/:cat", () => {
     const res2 = await SELF.fetch(
       `https://example.com/api/articles/by-category/ai?limit=2&cursor=${body1.next_cursor}`,
     );
-    expect(res2.status).toBe(200);
+    expect.soft(res2.status).toBe(200);
     const body2 = await res2.json<{
       articles: { guid: string }[];
       next_cursor: string | null;
     }>();
-    expect(body2.articles.length).toBe(2);
-    expect(body2.next_cursor).toBeNull();
+    expect.soft(body2.articles.length).toBe(2);
+    expect.soft(body2.next_cursor).toBeNull();
 
     // 2 ページ合わせて全 guid が揃う
     const allGuids = [...body1.articles.map((a) => a.guid), ...body2.articles.map((a) => a.guid)];
-    expect(allGuids).toContain("o-ai-1");
-    expect(allGuids).toContain("o-ai-2");
-    expect(allGuids).toContain("o-page-1");
-    expect(allGuids).toContain("o-page-2");
+    expect.soft(allGuids).toContain("o-ai-1");
+    expect.soft(allGuids).toContain("o-ai-2");
+    expect.soft(allGuids).toContain("o-page-1");
+    expect.soft(allGuids).toContain("o-page-2");
   });
 
   it("does not mix articles from different categories", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-category/bigtech");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ articles: { category: string }[] }>();
     expect(body.articles.length).toBeGreaterThan(0);
     for (const article of body.articles) {
-      expect(article.category).toBe("bigtech");
+      expect.soft(article.category).toBe("bigtech");
     }
   });
 
   it("returns Cache-Control: public, max-age=300", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-category/ai");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Cache-Control")).toBe("public, max-age=300");
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Cache-Control")).toBe("public, max-age=300");
   });
 });

--- a/apps/web/tests/worker/api/articles/by-category.test.ts
+++ b/apps/web/tests/worker/api/articles/by-category.test.ts
@@ -17,7 +17,7 @@ describe("GET /api/articles/by-category/:cat", () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-category/ai");
     expect.soft(res.status).toBe(200);
     const body = await res.json<{ articles: { category: string }[]; next_cursor: string | null }>();
-    expect.soft(Array.isArray(body.articles)).toBe(true);
+    expect(Array.isArray(body.articles)).toBe(true);
     expect.soft(body.articles.length).toBe(2);
     for (const article of body.articles) {
       expect.soft(article.category).toBe("ai");
@@ -147,7 +147,7 @@ describe("GET /api/articles/by-category/:cat", () => {
       articles: { guid: string }[];
       next_cursor: string | null;
     }>();
-    expect.soft(body2.articles.length).toBe(2);
+    expect(body2.articles.length).toBe(2);
     expect.soft(body2.next_cursor).toBeNull();
 
     // 2 ページ合わせて全 guid が揃う

--- a/apps/web/tests/worker/api/articles/by-day.test.ts
+++ b/apps/web/tests/worker/api/articles/by-day.test.ts
@@ -15,38 +15,38 @@ describe("GET /api/articles/by-day/:date", () => {
 
   it("returns 200 with articles, total, next_cursor, date for a valid date", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-day/2024-04-01");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{
       date: string;
       articles: { published_at: string }[];
       next_cursor: string | null;
       total: number;
     }>();
-    expect(body.date).toBe("2024-04-01");
-    expect(Array.isArray(body.articles)).toBe(true);
-    expect(body.articles.length).toBe(1);
-    expect(body.next_cursor).toBeNull();
-    expect(body.total).toBe(1);
+    expect.soft(body.date).toBe("2024-04-01");
+    expect.soft(Array.isArray(body.articles)).toBe(true);
+    expect.soft(body.articles.length).toBe(1);
+    expect.soft(body.next_cursor).toBeNull();
+    expect.soft(body.total).toBe(1);
     // 日付境界: 2024-04-01T00:00:00 <= published_at < 2024-04-02T00:00:00
     for (const a of body.articles) {
-      expect(a.published_at >= "2024-04-01T00:00:00.000Z").toBe(true);
-      expect(a.published_at < "2024-04-02T00:00:00.000Z").toBe(true);
+      expect.soft(a.published_at >= "2024-04-01T00:00:00.000Z").toBe(true);
+      expect.soft(a.published_at < "2024-04-02T00:00:00.000Z").toBe(true);
     }
   });
 
   it("returns empty articles and total=0 for a day with no articles", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-day/2024-04-10");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{
       date: string;
       articles: unknown[];
       next_cursor: string | null;
       total: number;
     }>();
-    expect(body.date).toBe("2024-04-10");
-    expect(body.articles).toEqual([]);
-    expect(body.next_cursor).toBeNull();
-    expect(body.total).toBe(0);
+    expect.soft(body.date).toBe("2024-04-10");
+    expect.soft(body.articles).toEqual([]);
+    expect.soft(body.next_cursor).toBeNull();
+    expect.soft(body.total).toBe(0);
   });
 
   it("returns only articles from the specified day (not adjacent days)", async () => {
@@ -77,14 +77,14 @@ describe("GET /api/articles/by-day/:date", () => {
     ]);
 
     const res = await SELF.fetch("https://example.com/api/articles/by-day/2024-04-01");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{
       articles: { guid: string }[];
       total: number;
     }>();
-    expect(body.total).toBe(1);
+    expect.soft(body.total).toBe(1);
     expect(body.articles.length).toBe(1);
-    expect(body.articles[0].guid).toBe("g-bt-1");
+    expect.soft(body.articles[0].guid).toBe("g-bt-1");
   });
 
   it("returns articles in published_at DESC, id DESC order", async () => {
@@ -105,15 +105,15 @@ describe("GET /api/articles/by-day/:date", () => {
     ]);
 
     const res = await SELF.fetch("https://example.com/api/articles/by-day/2024-04-02");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ articles: { published_at: string; id: number }[] }>();
     const dates = body.articles.map((a) => a.published_at);
     const sorted = dates.toSorted((a, b) => b.localeCompare(a));
-    expect(dates).toEqual(sorted);
+    expect.soft(dates).toEqual(sorted);
     // 同一 published_at 内は id DESC
     const sameAt = body.articles.filter((a) => a.published_at === SAME_AT);
     if (sameAt.length >= 2) {
-      expect(sameAt[0].id).toBeGreaterThan(sameAt[1].id);
+      expect.soft(sameAt[0].id).toBeGreaterThan(sameAt[1].id);
     }
   });
 
@@ -157,7 +157,7 @@ describe("GET /api/articles/by-day/:date", () => {
 
     // 1 ページ目: limit=2
     const res1 = await SELF.fetch("https://example.com/api/articles/by-day/2024-04-05?limit=2");
-    expect(res1.status).toBe(200);
+    expect.soft(res1.status).toBe(200);
     const body1 = await res1.json<{
       date: string;
       articles: { guid: string }[];
@@ -167,90 +167,90 @@ describe("GET /api/articles/by-day/:date", () => {
     expect(body1.articles.length).toBe(2);
     expect(body1.next_cursor).not.toBeNull();
     // total はページをまたいでも変わらない
-    expect(body1.total).toBe(3);
+    expect.soft(body1.total).toBe(3);
 
     // 2 ページ目: cursor を使用
     const res2 = await SELF.fetch(
       `https://example.com/api/articles/by-day/2024-04-05?limit=2&cursor=${body1.next_cursor}`,
     );
-    expect(res2.status).toBe(200);
+    expect.soft(res2.status).toBe(200);
     const body2 = await res2.json<{
       articles: { guid: string }[];
       next_cursor: string | null;
       total: number;
     }>();
-    expect(body2.articles.length).toBe(1);
-    expect(body2.next_cursor).toBeNull();
+    expect.soft(body2.articles.length).toBe(1);
+    expect.soft(body2.next_cursor).toBeNull();
     // total は cursor 跨ぎでも同じ値
-    expect(body2.total).toBe(3);
+    expect.soft(body2.total).toBe(3);
 
     // 2 ページ合わせて全 guid が揃う
     const allGuids = [...body1.articles.map((a) => a.guid), ...body2.articles.map((a) => a.guid)];
-    expect(allGuids).toContain("day-page-a");
-    expect(allGuids).toContain("day-page-b");
-    expect(allGuids).toContain("day-page-c");
+    expect.soft(allGuids).toContain("day-page-a");
+    expect.soft(allGuids).toContain("day-page-b");
+    expect.soft(allGuids).toContain("day-page-c");
   });
 
   it("returns 400 when date is not YYYY-MM-DD format", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-day/20240401");
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toBe("invalid date");
+    expect.soft(body.error).toBe("invalid date");
   });
 
   it("returns 400 when date has time component", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-day/2024-04-01T00:00:00");
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toBe("invalid date");
+    expect.soft(body.error).toBe("invalid date");
   });
 
   it("returns 400 when year < 1900", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-day/1899-12-31");
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toBe("invalid date");
+    expect.soft(body.error).toBe("invalid date");
   });
 
   it("returns 400 when year > 2100", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-day/2101-01-01");
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toBe("invalid date");
+    expect.soft(body.error).toBe("invalid date");
   });
 
   it("returns 400 when limit=0", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-day/2024-04-01?limit=0");
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toMatch(/limit/);
+    expect.soft(body.error).toMatch(/limit/);
   });
 
   it("returns 400 when limit=101", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-day/2024-04-01?limit=101");
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toMatch(/limit/);
+    expect.soft(body.error).toMatch(/limit/);
   });
 
   it("returns 400 when cursor is malformed", async () => {
     const res = await SELF.fetch(
       "https://example.com/api/articles/by-day/2024-04-01?cursor=not-valid-base64!!!",
     );
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toMatch(/cursor/);
+    expect.soft(body.error).toMatch(/cursor/);
   });
 
   it("returns Cache-Control: public, max-age=600", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-day/2024-04-01");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Cache-Control")).toBe("public, max-age=600");
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Cache-Control")).toBe("public, max-age=600");
   });
 
   it("returns Content-Type: application/json", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-day/2024-04-01");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Content-Type")).toMatch(/application\/json/);
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Content-Type")).toMatch(/application\/json/);
   });
 });

--- a/apps/web/tests/worker/api/articles/by-day.test.ts
+++ b/apps/web/tests/worker/api/articles/by-day.test.ts
@@ -179,7 +179,7 @@ describe("GET /api/articles/by-day/:date", () => {
       next_cursor: string | null;
       total: number;
     }>();
-    expect.soft(body2.articles.length).toBe(1);
+    expect(body2.articles.length).toBe(1);
     expect.soft(body2.next_cursor).toBeNull();
     // total は cursor 跨ぎでも同じ値
     expect.soft(body2.total).toBe(3);

--- a/apps/web/tests/worker/api/articles/by-feed.test.ts
+++ b/apps/web/tests/worker/api/articles/by-feed.test.ts
@@ -10,62 +10,62 @@ beforeEach(async () => {
 describe("GET /api/articles/by-feed/:feedId", () => {
   it("returns 200 with articles for a known feedId", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-feed/openai-blog");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ articles: { feed_id: string }[]; next_cursor: string | null }>();
-    expect(Array.isArray(body.articles)).toBe(true);
-    expect(body.articles.length).toBe(2);
+    expect.soft(Array.isArray(body.articles)).toBe(true);
+    expect.soft(body.articles.length).toBe(2);
     for (const article of body.articles) {
-      expect(article.feed_id).toBe("openai-blog");
+      expect.soft(article.feed_id).toBe("openai-blog");
     }
-    expect(body.next_cursor).toBeNull();
+    expect.soft(body.next_cursor).toBeNull();
   });
 
   it("returns 200 with empty array when feedId has no articles", async () => {
     // 存在しない feed_id を指定 → 0 件で 200
     const res = await SELF.fetch("https://example.com/api/articles/by-feed/nonexistent-feed-xyz");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ articles: unknown[]; next_cursor: string | null }>();
-    expect(body.articles).toEqual([]);
-    expect(body.next_cursor).toBeNull();
+    expect.soft(body.articles).toEqual([]);
+    expect.soft(body.next_cursor).toBeNull();
   });
 
   it("returns 400 when feedId is empty", async () => {
     // Hono のルートでは /by-feed/ は別セグメントとして扱われないため
     // 空文字チェックは URL decode 後に行う
     const res = await SELF.fetch("https://example.com/api/articles/by-feed/%20");
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toMatch(/feedId/);
+    expect.soft(body.error).toMatch(/feedId/);
   });
 
   it("returns 400 when limit=0", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-feed/openai-blog?limit=0");
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toMatch(/limit/);
+    expect.soft(body.error).toMatch(/limit/);
   });
 
   it("returns 400 when limit=51", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-feed/openai-blog?limit=51");
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toMatch(/limit/);
+    expect.soft(body.error).toMatch(/limit/);
   });
 
   it("returns 400 when limit is non-numeric", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-feed/openai-blog?limit=abc");
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toMatch(/limit/);
+    expect.soft(body.error).toMatch(/limit/);
   });
 
   it("returns 400 when cursor is malformed", async () => {
     const res = await SELF.fetch(
       "https://example.com/api/articles/by-feed/openai-blog?cursor=not-valid-base64!!!",
     );
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toMatch(/cursor/);
+    expect.soft(body.error).toMatch(/cursor/);
   });
 
   it("returns articles in published_at DESC, id DESC order", async () => {
@@ -86,15 +86,15 @@ describe("GET /api/articles/by-feed/:feedId", () => {
     ]);
     // o-ai-2 も SAME_AT (2024-04-03) なので tie → id DESC が効く
     const res = await SELF.fetch("https://example.com/api/articles/by-feed/openai-blog");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ articles: { published_at: string; id: number }[] }>();
     const dates = body.articles.map((a) => a.published_at);
     const sorted = dates.toSorted((a, b) => b.localeCompare(a));
-    expect(dates).toEqual(sorted);
+    expect.soft(dates).toEqual(sorted);
     // 同一 published_at 内は id DESC
     const sameAt = body.articles.filter((a) => a.published_at === SAME_AT);
     if (sameAt.length >= 2) {
-      expect(sameAt[0].id).toBeGreaterThan(sameAt[1].id);
+      expect.soft(sameAt[0].id).toBeGreaterThan(sameAt[1].id);
     }
   });
 
@@ -127,7 +127,7 @@ describe("GET /api/articles/by-feed/:feedId", () => {
 
     // 1 ページ目: limit=2
     const res1 = await SELF.fetch("https://example.com/api/articles/by-feed/openai-blog?limit=2");
-    expect(res1.status).toBe(200);
+    expect.soft(res1.status).toBe(200);
     const body1 = await res1.json<{
       articles: { guid: string }[];
       next_cursor: string | null;
@@ -139,34 +139,34 @@ describe("GET /api/articles/by-feed/:feedId", () => {
     const res2 = await SELF.fetch(
       `https://example.com/api/articles/by-feed/openai-blog?limit=2&cursor=${body1.next_cursor}`,
     );
-    expect(res2.status).toBe(200);
+    expect.soft(res2.status).toBe(200);
     const body2 = await res2.json<{
       articles: { guid: string }[];
       next_cursor: string | null;
     }>();
-    expect(body2.articles.length).toBe(2);
-    expect(body2.next_cursor).toBeNull();
+    expect.soft(body2.articles.length).toBe(2);
+    expect.soft(body2.next_cursor).toBeNull();
 
     // 2 ページ合わせて全 guid が揃う
     const allGuids = [...body1.articles.map((a) => a.guid), ...body2.articles.map((a) => a.guid)];
-    expect(allGuids).toContain("o-ai-1");
-    expect(allGuids).toContain("o-ai-2");
-    expect(allGuids).toContain("o-page-1");
-    expect(allGuids).toContain("o-page-2");
+    expect.soft(allGuids).toContain("o-ai-1");
+    expect.soft(allGuids).toContain("o-ai-2");
+    expect.soft(allGuids).toContain("o-page-1");
+    expect.soft(allGuids).toContain("o-page-2");
   });
 
   it("does not mix articles from different feed_id", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-feed/google-research");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ articles: { feed_id: string }[] }>();
     for (const article of body.articles) {
-      expect(article.feed_id).toBe("google-research");
+      expect.soft(article.feed_id).toBe("google-research");
     }
   });
 
   it("returns Cache-Control: public, max-age=300", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-feed/openai-blog");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Cache-Control")).toBe("public, max-age=300");
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Cache-Control")).toBe("public, max-age=300");
   });
 });

--- a/apps/web/tests/worker/api/articles/by-feed.test.ts
+++ b/apps/web/tests/worker/api/articles/by-feed.test.ts
@@ -12,7 +12,7 @@ describe("GET /api/articles/by-feed/:feedId", () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-feed/openai-blog");
     expect.soft(res.status).toBe(200);
     const body = await res.json<{ articles: { feed_id: string }[]; next_cursor: string | null }>();
-    expect.soft(Array.isArray(body.articles)).toBe(true);
+    expect(Array.isArray(body.articles)).toBe(true);
     expect.soft(body.articles.length).toBe(2);
     for (const article of body.articles) {
       expect.soft(article.feed_id).toBe("openai-blog");
@@ -144,7 +144,7 @@ describe("GET /api/articles/by-feed/:feedId", () => {
       articles: { guid: string }[];
       next_cursor: string | null;
     }>();
-    expect.soft(body2.articles.length).toBe(2);
+    expect(body2.articles.length).toBe(2);
     expect.soft(body2.next_cursor).toBeNull();
 
     // 2 ページ合わせて全 guid が揃う

--- a/apps/web/tests/worker/api/articles/calendar.test.ts
+++ b/apps/web/tests/worker/api/articles/calendar.test.ts
@@ -11,12 +11,12 @@ describe("GET /api/articles/calendar", () => {
   it("returns 200 with empty items when no articles in range", async () => {
     // beforeEach の記事は 2024-04 のため、days=30 (今から 30 日以内) では 0 件
     const res = await SELF.fetch("https://example.com/api/articles/calendar?days=30");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ days: number; items: unknown[] }>();
-    expect(body.days).toBe(30);
-    expect(Array.isArray(body.items)).toBe(true);
+    expect.soft(body.days).toBe(30);
+    expect.soft(Array.isArray(body.items)).toBe(true);
     // 2024-04 の記事は今から 30 日以内に含まれないので空
-    expect(body.items.length).toBe(0);
+    expect.soft(body.items.length).toBe(0);
   });
 
   it("returns correct daily counts after inserting recent articles", async () => {
@@ -64,14 +64,14 @@ describe("GET /api/articles/calendar", () => {
     ]);
 
     const res = await SELF.fetch("https://example.com/api/articles/calendar?days=7");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ days: number; items: { date: string; count: number }[] }>();
-    expect(body.days).toBe(7);
+    expect.soft(body.days).toBe(7);
 
     const todayItem = body.items.find((i) => i.date === todayStr);
     const yesterdayItem = body.items.find((i) => i.date === yesterdayStr);
-    expect(todayItem?.count).toBe(2);
-    expect(yesterdayItem?.count).toBe(1);
+    expect.soft(todayItem?.count).toBe(2);
+    expect.soft(yesterdayItem?.count).toBe(1);
   });
 
   it("items are sorted by date ASC", async () => {
@@ -107,11 +107,11 @@ describe("GET /api/articles/calendar", () => {
     ]);
 
     const res = await SELF.fetch("https://example.com/api/articles/calendar?days=7");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ items: { date: string; count: number }[] }>();
     const dates = body.items.map((i) => i.date);
     const sorted = dates.toSorted((a, b) => a.localeCompare(b));
-    expect(dates).toEqual(sorted);
+    expect.soft(dates).toEqual(sorted);
   });
 
   it("filters by lang=ja", async () => {
@@ -144,14 +144,14 @@ describe("GET /api/articles/calendar", () => {
     ]);
 
     const res = await SELF.fetch("https://example.com/api/articles/calendar?days=7&lang=ja");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ items: { date: string; count: number }[] }>();
     const todayItem = body.items.find((i) => i.date === todayStr);
     // ja のみ: 1 件
-    expect(todayItem?.count).toBe(1);
+    expect.soft(todayItem?.count).toBe(1);
     // en の記事は含まれないので total count は 1
     const totalCount = body.items.reduce((s, i) => s + i.count, 0);
-    expect(totalCount).toBe(1);
+    expect.soft(totalCount).toBe(1);
   });
 
   it("filters by category=ai", async () => {
@@ -184,46 +184,46 @@ describe("GET /api/articles/calendar", () => {
     ]);
 
     const res = await SELF.fetch("https://example.com/api/articles/calendar?days=7&category=ai");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ items: { date: string; count: number }[] }>();
     const todayItem = body.items.find((i) => i.date === todayStr);
     // ai のみ: 1 件
-    expect(todayItem?.count).toBe(1);
+    expect.soft(todayItem?.count).toBe(1);
     const totalCount = body.items.reduce((s, i) => s + i.count, 0);
-    expect(totalCount).toBe(1);
+    expect.soft(totalCount).toBe(1);
   });
 
   it("returns 400 for days=10 (not in allowed values)", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/calendar?days=10");
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toContain("days");
+    expect.soft(body.error).toContain("days");
   });
 
   it("returns 400 for lang=fr (invalid)", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/calendar?lang=fr");
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toContain("lang");
+    expect.soft(body.error).toContain("lang");
   });
 
   it("returns 400 for category=invalid", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/calendar?category=invalid");
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toContain("category");
+    expect.soft(body.error).toContain("category");
   });
 
   it("returns Cache-Control: public, max-age=600", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/calendar?days=30");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Cache-Control")).toBe("public, max-age=600");
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Cache-Control")).toBe("public, max-age=600");
   });
 
   it("uses default days=30 when days is not specified", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/calendar");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ days: number; items: unknown[] }>();
-    expect(body.days).toBe(30);
+    expect.soft(body.days).toBe(30);
   });
 });

--- a/apps/web/tests/worker/api/articles/random.test.ts
+++ b/apps/web/tests/worker/api/articles/random.test.ts
@@ -9,43 +9,43 @@ beforeEach(async () => {
 describe("GET /api/articles/random", () => {
   it("returns 200 with articles array using default n=10", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/random");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Cache-Control")).toBe("no-store");
     const body = await res.json<{ articles: unknown[] }>();
-    expect(Array.isArray(body.articles)).toBe(true);
+    expect.soft(Array.isArray(body.articles)).toBe(true);
     // DB に 3 件しかないので 3 件以下
-    expect(body.articles.length).toBeLessThanOrEqual(3);
+    expect.soft(body.articles.length).toBeLessThanOrEqual(3);
   });
 
   it("returns n=5 articles when n=5 is specified and enough records exist", async () => {
     // DB には 3 件しかないため n=2 で 2 件返ることを確認
     const res = await SELF.fetch("https://example.com/api/articles/random?n=2");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ articles: unknown[] }>();
-    expect(body.articles.length).toBe(2);
+    expect.soft(body.articles.length).toBe(2);
   });
 
   it("returns only ai category articles when category=ai", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/random?category=ai");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ articles: { category: string }[] }>();
     expect(body.articles.length).toBeGreaterThan(0);
     for (const article of body.articles) {
-      expect(article.category).toBe("ai");
+      expect.soft(article.category).toBe("ai");
     }
   });
 
   it("returns 400 when n=0", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/random?n=0");
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toBe("n must be 1-50");
+    expect.soft(body.error).toBe("n must be 1-50");
   });
 
   it("returns 400 when n=100", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/random?n=100");
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toBe("n must be 1-50");
+    expect.soft(body.error).toBe("n must be 1-50");
   });
 });

--- a/apps/web/tests/worker/api/articles/random.test.ts
+++ b/apps/web/tests/worker/api/articles/random.test.ts
@@ -12,7 +12,7 @@ describe("GET /api/articles/random", () => {
     expect.soft(res.status).toBe(200);
     expect.soft(res.headers.get("Cache-Control")).toBe("no-store");
     const body = await res.json<{ articles: unknown[] }>();
-    expect.soft(Array.isArray(body.articles)).toBe(true);
+    expect(Array.isArray(body.articles)).toBe(true);
     // DB に 3 件しかないので 3 件以下
     expect.soft(body.articles.length).toBeLessThanOrEqual(3);
   });

--- a/apps/web/tests/worker/api/articles/search.test.ts
+++ b/apps/web/tests/worker/api/articles/search.test.ts
@@ -14,131 +14,131 @@ describe("GET /api/articles/search", () => {
 
   it("returns 400 when q is missing", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/search");
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toBe("missing q");
+    expect.soft(body.error).toBe("missing q");
   });
 
   it("returns 400 when q is empty string", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/search?q=");
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toBe("missing q");
+    expect.soft(body.error).toBe("missing q");
   });
 
   it("returns 400 when q has more than 5 tokens", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/search?q=a+b+c+d+e+f");
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toMatch(/token/);
+    expect.soft(body.error).toMatch(/token/);
   });
 
   it("returns 400 when a token exceeds 50 characters", async () => {
     const longToken = "a".repeat(51);
     const res = await SELF.fetch(`https://example.com/api/articles/search?q=${longToken}`);
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toMatch(/token/);
+    expect.soft(body.error).toMatch(/token/);
   });
 
   it("returns 400 when limit=0", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/search?q=ai&limit=0");
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toMatch(/limit/);
+    expect.soft(body.error).toMatch(/limit/);
   });
 
   it("returns 400 when limit=101", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/search?q=ai&limit=101");
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toMatch(/limit/);
+    expect.soft(body.error).toMatch(/limit/);
   });
 
   it("returns 400 when cursor is malformed", async () => {
     const res = await SELF.fetch(
       "https://example.com/api/articles/search?q=ai&cursor=not-valid-base64!!!",
     );
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toMatch(/cursor/);
+    expect.soft(body.error).toMatch(/cursor/);
   });
 
   it("returns 200 with query/tokens/articles/next_cursor fields", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/search?q=article");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{
       query: string;
       tokens: string[];
       articles: unknown[];
       next_cursor: string | null;
     }>();
-    expect(body.query).toBe("article");
-    expect(body.tokens).toEqual(["article"]);
-    expect(Array.isArray(body.articles)).toBe(true);
-    expect("next_cursor" in body).toBe(true);
+    expect.soft(body.query).toBe("article");
+    expect.soft(body.tokens).toEqual(["article"]);
+    expect.soft(Array.isArray(body.articles)).toBe(true);
+    expect.soft("next_cursor" in body).toBe(true);
   });
 
   it("matches articles whose title contains the keyword (case-insensitive)", async () => {
     // "bigtech" は g-bt-1 の title に含まれる
     const res = await SELF.fetch("https://example.com/api/articles/search?q=bigtech");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ articles: { guid: string }[] }>();
-    expect(body.articles.some((a) => a.guid === "g-bt-1")).toBe(true);
+    expect.soft(body.articles.some((a) => a.guid === "g-bt-1")).toBe(true);
     // ai 記事は含まれない
-    expect(body.articles.every((a) => a.guid !== "o-ai-1")).toBe(true);
+    expect.soft(body.articles.every((a) => a.guid !== "o-ai-1")).toBe(true);
   });
 
   it("matches articles whose summary contains the keyword", async () => {
     // "gpt" は o-ai-1 の summary に含まれる
     const res = await SELF.fetch("https://example.com/api/articles/search?q=gpt");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ articles: { guid: string }[] }>();
-    expect(body.articles.some((a) => a.guid === "o-ai-1")).toBe(true);
+    expect.soft(body.articles.some((a) => a.guid === "o-ai-1")).toBe(true);
     // g-bt-1 や o-ai-2 は含まれない
-    expect(body.articles.every((a) => a.guid !== "g-bt-1")).toBe(true);
-    expect(body.articles.every((a) => a.guid !== "o-ai-2")).toBe(true);
+    expect.soft(body.articles.every((a) => a.guid !== "g-bt-1")).toBe(true);
+    expect.soft(body.articles.every((a) => a.guid !== "o-ai-2")).toBe(true);
   });
 
   it("is case-insensitive (uppercase keyword matches lowercase content)", async () => {
     // "DALL-E" → lowercase "dall-e" で o-ai-2 の summary "Discusses DALL-E" にマッチ
     const res = await SELF.fetch("https://example.com/api/articles/search?q=DALL-E");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ articles: { guid: string }[] }>();
-    expect(body.articles.some((a) => a.guid === "o-ai-2")).toBe(true);
+    expect.soft(body.articles.some((a) => a.guid === "o-ai-2")).toBe(true);
   });
 
   it("applies AND logic: both tokens must match", async () => {
     // "ai" は全 ai 記事に, "gpt" は o-ai-1 にのみマッチ → AND で o-ai-1 のみ
     const res = await SELF.fetch("https://example.com/api/articles/search?q=ai+gpt");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ articles: { guid: string }[] }>();
-    expect(body.articles.some((a) => a.guid === "o-ai-1")).toBe(true);
+    expect.soft(body.articles.some((a) => a.guid === "o-ai-1")).toBe(true);
     // o-ai-2 は "gpt" を含まない
-    expect(body.articles.every((a) => a.guid !== "o-ai-2")).toBe(true);
+    expect.soft(body.articles.every((a) => a.guid !== "o-ai-2")).toBe(true);
   });
 
   it("returns empty articles when no articles match", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/search?q=xxxxxxxxnotexist");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ articles: unknown[] }>();
-    expect(body.articles).toEqual([]);
+    expect.soft(body.articles).toEqual([]);
   });
 
   it("returns results in published_at DESC, id DESC order", async () => {
     // "article" は全 3 件の title に含まれる
     const res = await SELF.fetch("https://example.com/api/articles/search?q=article");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ articles: { published_at: string }[] }>();
     const dates = body.articles.map((a) => a.published_at);
     const sorted = dates.toSorted((a, b) => b.localeCompare(a));
-    expect(dates).toEqual(sorted);
+    expect.soft(dates).toEqual(sorted);
   });
 
   it("paginates with cursor: first page + second page covers all articles", async () => {
     // "article" が全 3 件にマッチ。limit=2 でページネーション確認
     const res1 = await SELF.fetch("https://example.com/api/articles/search?q=article&limit=2");
-    expect(res1.status).toBe(200);
+    expect.soft(res1.status).toBe(200);
     const body1 = await res1.json<{
       articles: { guid: string }[];
       next_cursor: string | null;
@@ -149,29 +149,29 @@ describe("GET /api/articles/search", () => {
     const res2 = await SELF.fetch(
       `https://example.com/api/articles/search?q=article&limit=2&cursor=${body1.next_cursor}`,
     );
-    expect(res2.status).toBe(200);
+    expect.soft(res2.status).toBe(200);
     const body2 = await res2.json<{
       articles: { guid: string }[];
       next_cursor: string | null;
     }>();
-    expect(body2.articles.length).toBe(1);
-    expect(body2.next_cursor).toBeNull();
+    expect.soft(body2.articles.length).toBe(1);
+    expect.soft(body2.next_cursor).toBeNull();
 
     const allGuids = [...body1.articles.map((a) => a.guid), ...body2.articles.map((a) => a.guid)];
-    expect(allGuids).toContain("g-bt-1");
-    expect(allGuids).toContain("o-ai-1");
-    expect(allGuids).toContain("o-ai-2");
+    expect.soft(allGuids).toContain("g-bt-1");
+    expect.soft(allGuids).toContain("o-ai-1");
+    expect.soft(allGuids).toContain("o-ai-2");
   });
 
   it("returns Cache-Control: public, max-age=120", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/search?q=ai");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Cache-Control")).toBe("public, max-age=120");
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Cache-Control")).toBe("public, max-age=120");
   });
 
   it("returns Content-Type: application/json", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/search?q=ai");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Content-Type")).toMatch(/application\/json/);
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Content-Type")).toMatch(/application\/json/);
   });
 });

--- a/apps/web/tests/worker/api/articles/search.test.ts
+++ b/apps/web/tests/worker/api/articles/search.test.ts
@@ -75,7 +75,7 @@ describe("GET /api/articles/search", () => {
     }>();
     expect.soft(body.query).toBe("article");
     expect.soft(body.tokens).toEqual(["article"]);
-    expect.soft(Array.isArray(body.articles)).toBe(true);
+    expect(Array.isArray(body.articles)).toBe(true);
     expect.soft("next_cursor" in body).toBe(true);
   });
 
@@ -154,7 +154,7 @@ describe("GET /api/articles/search", () => {
       articles: { guid: string }[];
       next_cursor: string | null;
     }>();
-    expect.soft(body2.articles.length).toBe(1);
+    expect(body2.articles.length).toBe(1);
     expect.soft(body2.next_cursor).toBeNull();
 
     const allGuids = [...body1.articles.map((a) => a.guid), ...body2.articles.map((a) => a.guid)];


### PR DESCRIPTION
## Summary

Closes part of #334 (Wave 1: worker articles endpoints).

Convert 7 worker test files in `tests/worker/api/articles/` to use `expect.soft(...)` where multiple independent observations (status / cache header / body shape) are checked in one test. Sequential dependent assertions remain plain `expect(...)`.

This aligns with the soft assertion guidance added in `.claude/rules/20-testing-overview.md` (PR #332).

## Affected files

- `tests/worker/api/articles/by-author.test.ts`
- `tests/worker/api/articles/by-feed.test.ts`
- `tests/worker/api/articles/by-category.test.ts`
- `tests/worker/api/articles/by-day.test.ts`
- `tests/worker/api/articles/search.test.ts`
- `tests/worker/api/articles/random.test.ts`
- `tests/worker/api/articles/calendar.test.ts`

## Test plan

- [x] pnpm test pass (articles テスト 126 pass, 全体 544 pass on branch basis)
- [x] typecheck pass
- [x] lint: 0 errors
- [ ] CI pass

## Followups (separate PRs)

- Wave 2: 残りの worker test (collector, syndication 等)
- Wave 3: tests/client/** の hook / component テスト

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated coding standards and testing guidelines with refined helper organization policies and soft assertion recommendations.

* **Tests**
  * Refactored test assertions across API endpoint tests to improve failure reporting and allow multiple validation checks per test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->