### PR TITLE
fix(db): D1 DB helpers の型安全性・NULL handling 改善

### DIFF
--- a/apps/web/worker/api/feeds.ts
+++ b/apps/web/worker/api/feeds.ts
@@ -124,7 +124,7 @@ app.get("/:id/health", async (c) => {
     last_run_status: lastRunStatus,
     last_error: lastError,
     avg_duration_ms: health.avg_duration_ms !== null ? Math.round(health.avg_duration_ms) : null,
-    articles_inserted_total: health.articles_inserted_total,
+    articles_inserted_total: health.articles_inserted_total ?? 0,
   });
 });
 

--- a/apps/web/worker/db/health.ts
+++ b/apps/web/worker/db/health.ts
@@ -1,3 +1,5 @@
+import type { HealthArticleStatsDbRow, HealthFeedStatsDbRow } from "./types";
+
 export interface HealthSummary {
   articles_total: number;
   feeds_total: number;
@@ -8,6 +10,7 @@ export interface HealthSummary {
 
 /** D1 batch で 1 round trip に集約して health 統計を返す。 */
 export async function getHealthSummary(db: D1Database): Promise<HealthSummary> {
+  // db.batch() は型パラメータを受け取れないため、取り出し後に Row 型へ変換する
   const [articleStats, feedStats] = await db.batch([
     db.prepare(
       `SELECT COUNT(*) AS articles_total,
@@ -22,21 +25,14 @@ export async function getHealthSummary(db: D1Database): Promise<HealthSummary> {
     ),
   ]);
 
-  const aRow = (articleStats.results[0] ?? {}) as {
-    articles_total: number;
-    latest_published_at: string | null;
-    latest_fetched_at: string | null;
-  };
-  const fRow = (feedStats.results[0] ?? {}) as {
-    feeds_total: number;
-    feeds_enabled: number | null;
-  };
+  const aRow = articleStats.results[0] as HealthArticleStatsDbRow | undefined;
+  const fRow = feedStats.results[0] as HealthFeedStatsDbRow | undefined;
 
   return {
-    articles_total: aRow.articles_total ?? 0,
-    feeds_total: fRow.feeds_total ?? 0,
-    feeds_enabled: fRow.feeds_enabled ?? 0,
-    latest_published_at: aRow.latest_published_at ?? null,
-    latest_fetched_at: aRow.latest_fetched_at ?? null,
+    articles_total: aRow?.articles_total ?? 0,
+    feeds_total: fRow?.feeds_total ?? 0,
+    feeds_enabled: fRow?.feeds_enabled ?? 0,
+    latest_published_at: aRow?.latest_published_at ?? null,
+    latest_fetched_at: aRow?.latest_fetched_at ?? null,
   };
 }

--- a/apps/web/worker/db/retention.ts
+++ b/apps/web/worker/db/retention.ts
@@ -3,7 +3,10 @@ export async function pruneOldArticles(db: D1Database, days: number): Promise<{ 
   if (!Number.isFinite(days) || days <= 0) return { deleted: 0 };
 
   const cutoff = new Date(Date.now() - days * 24 * 3600 * 1000).toISOString();
-  // meta.changes には articles_ad トリガによる FTS 更新も含まれるため、削除前に件数を取得する
+  // articles_ad トリガが DELETE に連動して articles_fts を更新するため、
+  // DELETE 後の meta.changes にはトリガ由来の変更数が混入し実際の削除件数を正確に返せない。
+  // そのため先に COUNT(*) で削除予定件数を取得し、DELETE 後の meta.changes は使わない。
+  // Cron は単一インスタンスで動作するため、COUNT と DELETE の間に競合書き込みは発生しない。
   const counted = await db
     .prepare("SELECT COUNT(*) AS n FROM articles WHERE published_at < ?1")
     .bind(cutoff)

--- a/apps/web/worker/db/types.ts
+++ b/apps/web/worker/db/types.ts
@@ -105,7 +105,8 @@ export interface FeedHealthRunDbRow {
   last_error_at: string | null;
   last_error_message: string | null;
   avg_duration_ms: number | null;
-  articles_inserted_total: number;
+  /** SUM は対象行が 0 件の場合 NULL を返すため nullable */
+  articles_inserted_total: number | null;
 }
 
 /** getFeedsDiagnostics クエリ結果 */
@@ -142,4 +143,18 @@ export interface FeedHealthFeedsDbRow {
   last_failure_at: string | null;
   consecutive_failures: number;
   articles_last_7d: number;
+}
+
+/** getHealthSummary — articles 集計クエリ結果 */
+export interface HealthArticleStatsDbRow {
+  articles_total: number;
+  latest_published_at: string | null;
+  latest_fetched_at: string | null;
+}
+
+/** getHealthSummary — feeds 集計クエリ結果 */
+export interface HealthFeedStatsDbRow {
+  feeds_total: number;
+  /** SUM(CASE WHEN enabled = 1 ...) は行が 0 件の場合 NULL を返す */
+  feeds_enabled: number | null;
 }


### PR DESCRIPTION
## 概要
`apps/web/worker/db/{health,retention,types}.ts` と `worker/api/feeds.ts` の型安全性・NULL handling・コメントを改善する。Closes #350

## 変更内容
- **types.ts**: `getHealthSummary` 用に `HealthArticleStatsDbRow` / `HealthFeedStatsDbRow` を追加。`FeedHealthRunDbRow.articles_inserted_total` を `number | null` に修正（SUM は行が 0 件の場合 NULL を返すため）
- **health.ts**: インライン型アサーション (`as {...}`) パターンを廃止し、`types.ts` の Row 型を使った `as T | undefined` に変更。`db.batch()` が型パラメータを受け取れない理由をコメントで明示
- **retention.ts**: COUNT/DELETE の 2 クエリパターンについて、`articles_ad` トリガで `meta.changes` が信頼できない理由と Cron 単一インスタンス前提でレースコンディションが発生しない旨をコメントに追記
- **feeds.ts (api)**: `articles_inserted_total` に `?? 0` フォールバックを追加（DB 行型が `number | null` になったため）

## テスト
- [x] `pnpm -C apps/web typecheck` — pass
- [x] `pnpm -C apps/web test run` — 45 files / 616 tests pass
- [x] `pnpm -C apps/web build` — pass
- [x] `pnpm format && pnpm lint` — 0 errors