### PR TITLE
fix(seo): sitemap から openapi.json を除外し SWR キャッシュを追加

### DIFF
--- a/apps/web/tests/worker/api/sitemap.test.ts
+++ b/apps/web/tests/worker/api/sitemap.test.ts
@@ -6,7 +6,9 @@ describe("/robots.txt", () => {
     const res = await SELF.fetch("https://example.com/robots.txt");
     expect(res.status).toBe(200);
     expect(res.headers.get("Content-Type")).toContain("text/plain");
-    expect(res.headers.get("Cache-Control")).toBe("public, max-age=3600");
+    expect(res.headers.get("Cache-Control")).toBe(
+      "public, max-age=3600, stale-while-revalidate=86400",
+    );
   });
 
   it("contains User-agent: *", async () => {
@@ -33,7 +35,9 @@ describe("/sitemap.xml", () => {
     const res = await SELF.fetch("https://example.com/sitemap.xml");
     expect(res.status).toBe(200);
     expect(res.headers.get("Content-Type")).toContain("application/xml");
-    expect(res.headers.get("Cache-Control")).toBe("public, max-age=3600");
+    expect(res.headers.get("Cache-Control")).toBe(
+      "public, max-age=3600, stale-while-revalidate=86400",
+    );
   });
 
   it("contains root URL <loc>", async () => {
@@ -51,5 +55,20 @@ describe("/sitemap.xml", () => {
     expect(text).toContain("/?feed_id=google-research");
     expect(text).toContain("<changefreq>daily</changefreq>");
     expect(text).toContain("<priority>0.6</priority>");
+  });
+
+  it("does not include /api/openapi.json (not a content page)", async () => {
+    const res = await SELF.fetch("https://example.com/sitemap.xml");
+    const text = await res.text();
+    // API ドキュメントは HTML コンテンツではないのでクロールバジェット節約のため除外
+    expect(text).not.toContain("/api/openapi.json");
+  });
+
+  it("is well-formed XML with urlset root element", async () => {
+    const res = await SELF.fetch("https://example.com/sitemap.xml");
+    const text = await res.text();
+    expect.soft(text).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect.soft(text).toContain('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">');
+    expect.soft(text).toContain("</urlset>");
   });
 });

--- a/apps/web/worker/api/robots.ts
+++ b/apps/web/worker/api/robots.ts
@@ -14,7 +14,9 @@ app.get("/robots.txt", (c) => {
     `Sitemap: ${origin}/sitemap.xml`,
   ].join("\n");
   c.header("Content-Type", "text/plain; charset=utf-8");
-  c.header("Cache-Control", "public, max-age=3600");
+  // robots.txt の内容は静的なためエッジキャッシュを積極活用する。
+  // stale-while-revalidate でキャッシュ切れ後も裏でリフレッシュしつつ即返せる。
+  c.header("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400");
   return c.body(body);
 });
 

--- a/apps/web/worker/api/sitemap.ts
+++ b/apps/web/worker/api/sitemap.ts
@@ -11,18 +11,14 @@ function escapeXml(input: string): string {
 function buildSitemap(origin: string): string {
   const feeds = loadEnabledFeeds();
 
+  // /api/openapi.json は JSON API ドキュメントであり HTML コンテンツではないため
+  // サイトマップのクロール対象から除外してクロールバジェットを節約する
   const staticUrls = [
     [
       `<url>`,
       `<loc>${escapeXml(origin)}/</loc>`,
       `<changefreq>hourly</changefreq>`,
       `<priority>1.0</priority>`,
-      `</url>`,
-    ].join(""),
-    [
-      `<url>`,
-      `<loc>${escapeXml(origin)}/api/openapi.json</loc>`,
-      `<priority>0.3</priority>`,
       `</url>`,
     ].join(""),
   ];
@@ -51,7 +47,9 @@ app.get("/sitemap.xml", (c) => {
   const origin = `${url.protocol}//${url.host}`;
   const xml = buildSitemap(origin);
   c.header("Content-Type", "application/xml; charset=utf-8");
-  c.header("Cache-Control", "public, max-age=3600");
+  // feeds.yaml は静的なためエッジキャッシュを積極活用する。
+  // stale-while-revalidate でキャッシュ切れ後も裏でリフレッシュしつつ即返せる。
+  c.header("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400");
   return c.body(xml);
 });
 


### PR DESCRIPTION
## 概要
SEO endpoint の監査結果から 2 点の改善を施す。Closes #354

## 変更内容

### 1. `sitemap.xml` から `/api/openapi.json` を除外
- API ドキュメントは HTML コンテンツではないため、検索エンジンのクロール予算を消費させる必要がない
- フィード詳細ページ等の HTML ルートのみ sitemap に残す

### 2. `sitemap.xml` / `robots.txt` の Cache-Control に `stale-while-revalidate=86400` を追加
- どちらも `feeds.yaml` ベースの静的に近いコンテンツ
- SWR で 1 日以内なら古いキャッシュを返しつつ裏で revalidate → エッジキャッシュ効率向上

## テスト
- [x] `pnpm -C apps/web typecheck` pass
- [x] `pnpm -C apps/web test run -- tests/worker/api/sitemap.test.ts` pass
- [x] `pnpm -C apps/web build` pass
- [x] `pnpm format && pnpm lint` clean
- [x] sitemap.test.ts に Cache-Control assertion 更新, openapi.json 除外確認, XML 整形検証を追加

## 影響範囲外
- `spa-shell.ts`: 既に OGP / Twitter Card / canonical / lang は適切。改善余地なし
- robots.txt 内の AI クローラブロックは方針判断が必要なため変更しない