### PR TITLE
test(worker): adopt soft assertions in non-articles worker tests (#334 Wave 2)

### DIFF
--- a/apps/web/tests/worker/api/admin.test.ts
+++ b/apps/web/tests/worker/api/admin.test.ts
@@ -133,8 +133,8 @@ describe("POST /api/admin/collector/run", () => {
     // 同期実行なので応答が返った時点で collector_runs に行が存在するはず
     const runs = await listRuns(env.DB, 10);
     // 最新 run は completed_at が設定されている
+    expect(runs.length).toBeGreaterThan(0);
     const latest = runs[0];
-    expect.soft(runs.length).toBeGreaterThan(0);
     expect.soft(latest.completed_at).toBeTruthy();
   }, 60_000);
 
@@ -157,7 +157,7 @@ describe("POST /api/admin/collector/run", () => {
       results: { feed_id: string }[];
     };
     expect.soft(res.status).toBe(200);
-    expect.soft(body.results).toHaveLength(1);
+    expect(body.results).toHaveLength(1);
     expect.soft(body.results[0].feed_id).toBe(REAL_FEED_ID);
   });
 
@@ -304,7 +304,7 @@ describe("GET /api/admin/runs", () => {
     });
     const body = (await res.json()) as { runs: { id: number; feeds_ok: number }[] };
     expect.soft(res.status).toBe(200);
-    expect.soft(body.runs).toHaveLength(1);
+    expect(body.runs).toHaveLength(1);
     expect.soft(body.runs[0].id).toBe(run_id);
     expect.soft(body.runs[0].feeds_ok).toBe(2);
   });

--- a/apps/web/tests/worker/api/admin.test.ts
+++ b/apps/web/tests/worker/api/admin.test.ts
@@ -29,10 +29,10 @@ describe("POST /api/admin/feeds/:id/enabled", () => {
       headers: { ...AUTH_HEADER, "content-type": "application/json" },
       body: JSON.stringify({ enabled: false }),
     });
-    expect(res.status).toBe(200);
     const body = (await res.json()) as { id: string; enabled: boolean };
-    expect(body.id).toBe("test-feed");
-    expect(body.enabled).toBe(false);
+    expect.soft(res.status).toBe(200);
+    expect.soft(body.id).toBe("test-feed");
+    expect.soft(body.enabled).toBe(false);
   });
 
   it("200: toggles enabled back to true", async () => {
@@ -47,9 +47,9 @@ describe("POST /api/admin/feeds/:id/enabled", () => {
       headers: { ...AUTH_HEADER, "content-type": "application/json" },
       body: JSON.stringify({ enabled: true }),
     });
-    expect(res.status).toBe(200);
     const body = (await res.json()) as { id: string; enabled: boolean };
-    expect(body.enabled).toBe(true);
+    expect.soft(res.status).toBe(200);
+    expect.soft(body.enabled).toBe(true);
   });
 
   it("401: rejects unauthenticated request", async () => {
@@ -104,21 +104,21 @@ describe("POST /api/admin/collector/run", () => {
       method: "POST",
       headers: { ...AUTH_HEADER },
     });
-    expect(res.status).toBe(200);
     const body = (await res.json()) as {
       started_at: string;
       finished_at: string;
       results: { feed_id: string; status: string; new_articles: number }[];
     };
-    expect(typeof body.started_at).toBe("string");
-    expect(typeof body.finished_at).toBe("string");
-    expect(Array.isArray(body.results)).toBe(true);
+    expect.soft(res.status).toBe(200);
+    expect.soft(typeof body.started_at).toBe("string");
+    expect.soft(typeof body.finished_at).toBe("string");
+    expect.soft(Array.isArray(body.results)).toBe(true);
     // 全 enabled feed に対して results が返る (外部 fetch はテスト環境では失敗するが error として返る)
-    expect(body.results.length).toBeGreaterThan(0);
+    expect.soft(body.results.length).toBeGreaterThan(0);
     for (const r of body.results) {
-      expect(typeof r.feed_id).toBe("string");
-      expect(["ok", "error", "not_modified"]).toContain(r.status);
-      expect(typeof r.new_articles).toBe("number");
+      expect.soft(typeof r.feed_id).toBe("string");
+      expect.soft(["ok", "error", "not_modified"]).toContain(r.status);
+      expect.soft(typeof r.new_articles).toBe("number");
     }
   }, 60_000);
 
@@ -132,10 +132,10 @@ describe("POST /api/admin/collector/run", () => {
 
     // 同期実行なので応答が返った時点で collector_runs に行が存在するはず
     const runs = await listRuns(env.DB, 10);
-    expect(runs.length).toBeGreaterThan(0);
     // 最新 run は completed_at が設定されている
     const latest = runs[0];
-    expect(latest.completed_at).toBeTruthy();
+    expect.soft(runs.length).toBeGreaterThan(0);
+    expect.soft(latest.completed_at).toBeTruthy();
   }, 60_000);
 
   it("401: 認証なし → 401", async () => {
@@ -151,14 +151,14 @@ describe("POST /api/admin/collector/run", () => {
       headers: { ...AUTH_HEADER, "content-type": "application/json" },
       body: JSON.stringify({ feed_ids: [REAL_FEED_ID] }),
     });
-    expect(res.status).toBe(200);
     const body = (await res.json()) as {
       started_at: string;
       finished_at: string;
       results: { feed_id: string }[];
     };
-    expect(body.results).toHaveLength(1);
-    expect(body.results[0].feed_id).toBe(REAL_FEED_ID);
+    expect.soft(res.status).toBe(200);
+    expect.soft(body.results).toHaveLength(1);
+    expect.soft(body.results[0].feed_id).toBe(REAL_FEED_ID);
   });
 
   it("400: 不明な feed_id を指定 → 400", async () => {
@@ -167,9 +167,9 @@ describe("POST /api/admin/collector/run", () => {
       headers: { ...AUTH_HEADER, "content-type": "application/json" },
       body: JSON.stringify({ feed_ids: ["unknown-id-xyz"] }),
     });
-    expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
-    expect(body.error).toMatch(/unknown feed_ids/);
+    expect.soft(res.status).toBe(400);
+    expect.soft(body.error).toMatch(/unknown feed_ids/);
   });
 
   it("400: feed_ids が配列でない → 400", async () => {
@@ -178,9 +178,9 @@ describe("POST /api/admin/collector/run", () => {
       headers: { ...AUTH_HEADER, "content-type": "application/json" },
       body: JSON.stringify({ feed_ids: "google-research" }),
     });
-    expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
-    expect(body.error).toBe("feed_ids must be an array of strings");
+    expect.soft(res.status).toBe(400);
+    expect.soft(body.error).toBe("feed_ids must be an array of strings");
   });
 });
 
@@ -206,9 +206,9 @@ describe("POST /api/admin/collect", () => {
       headers: { ...AUTH_HEADER, "content-type": "application/json" },
       body: "{ invalid json",
     });
-    expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
-    expect(body.error).toBe("invalid JSON body");
+    expect.soft(res.status).toBe(400);
+    expect.soft(body.error).toBe("invalid JSON body");
   });
 
   it("404: 存在しない feed_id → 404", async () => {
@@ -217,9 +217,9 @@ describe("POST /api/admin/collect", () => {
       headers: { ...AUTH_HEADER, "content-type": "application/json" },
       body: JSON.stringify({ feed_id: "no-such-feed-xyz" }),
     });
-    expect(res.status).toBe(404);
     const body = (await res.json()) as { error: string };
-    expect(body.error).toMatch(/feed not found/);
+    expect.soft(res.status).toBe(404);
+    expect.soft(body.error).toMatch(/feed not found/);
   });
 
   it("200: body なし (全件) → ok=true と run_id と async=true を返す", async () => {
@@ -227,11 +227,11 @@ describe("POST /api/admin/collect", () => {
       method: "POST",
       headers: { ...AUTH_HEADER },
     });
-    expect(res.status).toBe(200);
     const body = (await res.json()) as { ok: boolean; run_id: number; async: boolean };
-    expect(body.ok).toBe(true);
-    expect(typeof body.run_id).toBe("number");
-    expect(body.async).toBe(true);
+    expect.soft(res.status).toBe(200);
+    expect.soft(body.ok).toBe(true);
+    expect.soft(typeof body.run_id).toBe("number");
+    expect.soft(body.async).toBe(true);
 
     // waitUntil の完了 (completed_at が設定される) を待ち、collector_runs に行が作られていることを確認する。
     // 完了を待つことで次テストの beforeEach(reset) との競合を防ぐ。
@@ -256,11 +256,11 @@ describe("POST /api/admin/collect", () => {
       headers: { ...AUTH_HEADER, "content-type": "application/json" },
       body: JSON.stringify({ feed_id: REAL_FEED_ID }),
     });
-    expect(res.status).toBe(200);
     const body = (await res.json()) as { ok: boolean; run_id: number; async: boolean };
-    expect(body.ok).toBe(true);
-    expect(typeof body.run_id).toBe("number");
-    expect(body.async).toBe(true);
+    expect.soft(res.status).toBe(200);
+    expect.soft(body.ok).toBe(true);
+    expect.soft(typeof body.run_id).toBe("number");
+    expect.soft(body.async).toBe(true);
 
     // waitUntil が完了するまでポーリングして collector_run_feeds を確認する。
     // テスト環境では waitUntil は外部 fetch のタイムアウト後に完了する。
@@ -289,10 +289,10 @@ describe("GET /api/admin/runs", () => {
     const res = await SELF.fetch("https://example.com/api/admin/runs", {
       headers: AUTH_HEADER,
     });
-    expect(res.status).toBe(200);
     const body = (await res.json()) as { runs: unknown[] };
-    expect(Array.isArray(body.runs)).toBe(true);
-    expect(body.runs).toHaveLength(0);
+    expect.soft(res.status).toBe(200);
+    expect.soft(Array.isArray(body.runs)).toBe(true);
+    expect.soft(body.runs).toHaveLength(0);
   });
 
   it("200: returns runs list", async () => {
@@ -302,11 +302,11 @@ describe("GET /api/admin/runs", () => {
     const res = await SELF.fetch("https://example.com/api/admin/runs", {
       headers: AUTH_HEADER,
     });
-    expect(res.status).toBe(200);
     const body = (await res.json()) as { runs: { id: number; feeds_ok: number }[] };
-    expect(body.runs).toHaveLength(1);
-    expect(body.runs[0].id).toBe(run_id);
-    expect(body.runs[0].feeds_ok).toBe(2);
+    expect.soft(res.status).toBe(200);
+    expect.soft(body.runs).toHaveLength(1);
+    expect.soft(body.runs[0].id).toBe(run_id);
+    expect.soft(body.runs[0].feeds_ok).toBe(2);
   });
 
   it("200: clamps limit to max 100", async () => {
@@ -339,22 +339,22 @@ describe("GET /api/admin/runs/:id", () => {
     const res = await SELF.fetch(`https://example.com/api/admin/runs/${run_id}`, {
       headers: AUTH_HEADER,
     });
-    expect(res.status).toBe(200);
-    expect(res.headers.get("cache-control")).toBe("private, max-age=30");
     const body = (await res.json()) as {
       run: { id: number; feeds_ok: number; duration_ms: number | null };
       feeds: { feed_id: string; status: string; error: string | null }[];
     };
-    expect(body.run.id).toBe(run_id);
-    expect(body.run.feeds_ok).toBe(1);
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("cache-control")).toBe("private, max-age=30");
+    expect.soft(body.run.id).toBe(run_id);
+    expect.soft(body.run.feeds_ok).toBe(1);
     // 5s = 5000ms
-    expect(body.run.duration_ms).toBe(5000);
+    expect.soft(body.run.duration_ms).toBe(5000);
     expect(body.feeds).toHaveLength(2);
     const feedA = body.feeds.find((f) => f.feed_id === "feed-a");
-    expect(feedA!.status).toBe("ok");
+    expect.soft(feedA!.status).toBe("ok");
     const feedB = body.feeds.find((f) => f.feed_id === "feed-b");
-    expect(feedB!.status).toBe("failed");
-    expect(feedB!.error).toBe("HTTP 500");
+    expect.soft(feedB!.status).toBe("failed");
+    expect.soft(feedB!.error).toBe("HTTP 500");
   });
 
   it("200: duration_ms is null when run is not yet completed", async () => {
@@ -363,23 +363,23 @@ describe("GET /api/admin/runs/:id", () => {
     const res = await SELF.fetch(`https://example.com/api/admin/runs/${run_id}`, {
       headers: AUTH_HEADER,
     });
-    expect(res.status).toBe(200);
     const body = (await res.json()) as {
       run: { id: number; duration_ms: number | null };
       feeds: unknown[];
     };
-    expect(body.run.id).toBe(run_id);
-    expect(body.run.duration_ms).toBeNull();
-    expect(body.feeds).toHaveLength(0);
+    expect.soft(res.status).toBe(200);
+    expect.soft(body.run.id).toBe(run_id);
+    expect.soft(body.run.duration_ms).toBeNull();
+    expect.soft(body.feeds).toHaveLength(0);
   });
 
   it("404: returns 'run not found' for unknown id", async () => {
     const res = await SELF.fetch("https://example.com/api/admin/runs/99999", {
       headers: AUTH_HEADER,
     });
-    expect(res.status).toBe(404);
     const body = (await res.json()) as { error: string };
-    expect(body.error).toBe("run not found");
+    expect.soft(res.status).toBe(404);
+    expect.soft(body.error).toBe("run not found");
   });
 
   it("401: rejects unauthenticated request", async () => {

--- a/apps/web/tests/worker/api/feeds.test.ts
+++ b/apps/web/tests/worker/api/feeds.test.ts
@@ -104,7 +104,6 @@ beforeEach(async () => {
 describe("GET /api/feeds - basic", () => {
   it("returns feeds array with articles_30d and last_published_at fields", async () => {
     const res = await SELF.fetch("https://example.com/api/feeds");
-    expect(res.status).toBe(200);
     const body = (await res.json()) as {
       feeds: {
         id: string;
@@ -113,12 +112,13 @@ describe("GET /api/feeds - basic", () => {
         enabled: boolean;
       }[];
     };
-    expect(Array.isArray(body.feeds)).toBe(true);
+    expect.soft(res.status).toBe(200);
+    expect.soft(Array.isArray(body.feeds)).toBe(true);
     const openai = body.feeds.find((f) => f.id === "openai-blog");
     expect(openai).toBeDefined();
-    expect(openai!.articles_30d).toBe(2);
-    expect(openai!.last_published_at).not.toBeNull();
-    expect(openai!.enabled).toBe(true);
+    expect.soft(openai!.articles_30d).toBe(2);
+    expect.soft(openai!.last_published_at).not.toBeNull();
+    expect.soft(openai!.enabled).toBe(true);
   });
 
   it("articles_30d counts only articles within 30 days", async () => {
@@ -151,8 +151,8 @@ describe("GET /api/feeds - basic", () => {
     };
     const ca = body.feeds.find((f) => f.id === "cyberagent-blog");
     expect(ca).toBeDefined();
-    expect(ca!.articles_30d).toBe(0);
-    expect(ca!.last_published_at).toBeNull();
+    expect.soft(ca!.articles_30d).toBe(0);
+    expect.soft(ca!.last_published_at).toBeNull();
   });
 
   it("returns feeds sorted by id ASC", async () => {
@@ -166,11 +166,11 @@ describe("GET /api/feeds - basic", () => {
 describe("GET /api/feeds - filter by category", () => {
   it("returns only ai feeds when category=ai", async () => {
     const res = await SELF.fetch("https://example.com/api/feeds?category=ai");
-    expect(res.status).toBe(200);
     const body = (await res.json()) as { feeds: { id: string; category: string }[] };
-    expect(body.feeds.every((f) => f.category === "ai")).toBe(true);
-    expect(body.feeds.some((f) => f.id === "openai-blog")).toBe(true);
-    expect(body.feeds.some((f) => f.id === "google-research")).toBe(false);
+    expect.soft(res.status).toBe(200);
+    expect.soft(body.feeds.every((f) => f.category === "ai")).toBe(true);
+    expect.soft(body.feeds.some((f) => f.id === "openai-blog")).toBe(true);
+    expect.soft(body.feeds.some((f) => f.id === "google-research")).toBe(false);
   });
 
   it("returns 400 for invalid category value", async () => {
@@ -182,10 +182,10 @@ describe("GET /api/feeds - filter by category", () => {
 describe("GET /api/feeds - filter by lang", () => {
   it("returns only ja feeds when lang=ja", async () => {
     const res = await SELF.fetch("https://example.com/api/feeds?lang=ja");
-    expect(res.status).toBe(200);
     const body = (await res.json()) as { feeds: { id: string; lang: string }[] };
-    expect(body.feeds.every((f) => f.lang === "ja")).toBe(true);
-    expect(body.feeds.some((f) => f.id === "openai-blog")).toBe(false);
+    expect.soft(res.status).toBe(200);
+    expect.soft(body.feeds.every((f) => f.lang === "ja")).toBe(true);
+    expect.soft(body.feeds.some((f) => f.id === "openai-blog")).toBe(false);
   });
 
   it("returns 400 for invalid lang value", async () => {
@@ -197,19 +197,19 @@ describe("GET /api/feeds - filter by lang", () => {
 describe("GET /api/feeds - filter by enabled", () => {
   it("returns only disabled feeds when enabled=false", async () => {
     const res = await SELF.fetch("https://example.com/api/feeds?enabled=false");
-    expect(res.status).toBe(200);
     const body = (await res.json()) as { feeds: { id: string; enabled: boolean }[] };
-    expect(body.feeds.every((f) => !f.enabled)).toBe(true);
-    expect(body.feeds.some((f) => f.id === "zenn-ai")).toBe(true);
-    expect(body.feeds.some((f) => f.id === "openai-blog")).toBe(false);
+    expect.soft(res.status).toBe(200);
+    expect.soft(body.feeds.every((f) => !f.enabled)).toBe(true);
+    expect.soft(body.feeds.some((f) => f.id === "zenn-ai")).toBe(true);
+    expect.soft(body.feeds.some((f) => f.id === "openai-blog")).toBe(false);
   });
 
   it("returns only enabled feeds when enabled=true", async () => {
     const res = await SELF.fetch("https://example.com/api/feeds?enabled=true");
-    expect(res.status).toBe(200);
     const body = (await res.json()) as { feeds: { id: string; enabled: boolean }[] };
-    expect(body.feeds.every((f) => f.enabled)).toBe(true);
-    expect(body.feeds.some((f) => f.id === "zenn-ai")).toBe(false);
+    expect.soft(res.status).toBe(200);
+    expect.soft(body.feeds.every((f) => f.enabled)).toBe(true);
+    expect.soft(body.feeds.some((f) => f.id === "zenn-ai")).toBe(false);
   });
 
   it("returns 400 for invalid enabled value", async () => {
@@ -241,17 +241,17 @@ describe("GET /api/feeds/:id", () => {
 
   it("returns 404 for unknown id", async () => {
     const res = await SELF.fetch("https://example.com/api/feeds/no-such-feed");
-    expect(res.status).toBe(404);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toBe("feed not found");
+    expect.soft(res.status).toBe(404);
+    expect.soft(body.error).toBe("feed not found");
   });
 
   it("returns 200 with feed and recent_articles structure", async () => {
     const res = await SELF.fetch("https://example.com/api/feeds/openai-blog");
-    expect(res.status).toBe(200);
     const body = await res.json<{ feed: unknown; recent_articles: unknown[] }>();
-    expect(body.feed).toBeDefined();
-    expect(Array.isArray(body.recent_articles)).toBe(true);
+    expect.soft(res.status).toBe(200);
+    expect.soft(body.feed).toBeDefined();
+    expect.soft(Array.isArray(body.recent_articles)).toBe(true);
   });
 
   it("returns correct feed fields", async () => {
@@ -269,14 +269,14 @@ describe("GET /api/feeds/:id", () => {
       };
       recent_articles: unknown[];
     }>();
-    expect(body.feed.id).toBe("openai-blog");
-    expect(body.feed.name).toBe("OpenAI News");
-    expect(body.feed.category).toBe("ai");
-    expect(body.feed.lang).toBe("en");
-    expect(body.feed.enabled).toBe(true);
+    expect.soft(body.feed.id).toBe("openai-blog");
+    expect.soft(body.feed.name).toBe("OpenAI News");
+    expect.soft(body.feed.category).toBe("ai");
+    expect.soft(body.feed.lang).toBe("en");
+    expect.soft(body.feed.enabled).toBe(true);
     // openai-1 (5d), openai-2 (20d), extra 1-9 (1-9d) = 11件、openai-3 (31d) は窓外
-    expect(body.feed.articles_30d).toBe(11);
-    expect(body.feed.last_published_at).not.toBeNull();
+    expect.soft(body.feed.articles_30d).toBe(11);
+    expect.soft(body.feed.last_published_at).not.toBeNull();
   });
 
   it("returns default 10 recent_articles when recent is not specified", async () => {
@@ -297,37 +297,37 @@ describe("GET /api/feeds/:id", () => {
 
   it("returns empty recent_articles when recent=0", async () => {
     const res = await SELF.fetch("https://example.com/api/feeds/openai-blog?recent=0");
-    expect(res.status).toBe(200);
     const body = await res.json<{ feed: unknown; recent_articles: Article[] }>();
-    expect(body.recent_articles).toEqual([]);
+    expect.soft(res.status).toBe(200);
+    expect.soft(body.recent_articles).toEqual([]);
   });
 
   it("returns 400 when recent=51", async () => {
     const res = await SELF.fetch("https://example.com/api/feeds/openai-blog?recent=51");
-    expect(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toContain("recent must be an integer");
+    expect.soft(res.status).toBe(400);
+    expect.soft(body.error).toContain("recent must be an integer");
   });
 
   it("returns specified number of recent_articles when recent=3", async () => {
     const res = await SELF.fetch("https://example.com/api/feeds/openai-blog?recent=3");
-    expect(res.status).toBe(200);
     const body = await res.json<{ feed: unknown; recent_articles: Article[] }>();
-    expect(body.recent_articles.length).toBe(3);
+    expect.soft(res.status).toBe(200);
+    expect.soft(body.recent_articles.length).toBe(3);
   });
 
   it("returns 0 articles_30d and null last_published_at for feed with no articles", async () => {
     // google-research には 30d 以内の記事が 1 件 (beforeEach で投入済み)
     // 新しいフィードで確認するため zenn-ai を使う
     const res = await SELF.fetch("https://example.com/api/feeds/zenn-ai");
-    expect(res.status).toBe(200);
     const body = await res.json<{
       feed: { articles_30d: number; last_published_at: string | null };
       recent_articles: Article[];
     }>();
-    expect(body.feed.articles_30d).toBe(0);
-    expect(body.feed.last_published_at).toBeNull();
-    expect(body.recent_articles).toEqual([]);
+    expect.soft(res.status).toBe(200);
+    expect.soft(body.feed.articles_30d).toBe(0);
+    expect.soft(body.feed.last_published_at).toBeNull();
+    expect.soft(body.recent_articles).toEqual([]);
   });
 
   it("sets Cache-Control: public, max-age=300", async () => {
@@ -384,16 +384,16 @@ describe("GET /api/feeds/:id/health", () => {
 
   it("returns 404 for feed not in feeds.yaml", async () => {
     const res = await SELF.fetch("https://example.com/api/feeds/no-such-feed/health");
-    expect(res.status).toBe(404);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toBe("feed not found");
+    expect.soft(res.status).toBe(404);
+    expect.soft(body.error).toBe("feed not found");
   });
 
   it("returns 400 for invalid days param", async () => {
     const res = await SELF.fetch("https://example.com/api/feeds/openai-blog/health?days=abc");
-    expect(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toBe("invalid days");
+    expect.soft(res.status).toBe(400);
+    expect.soft(body.error).toBe("invalid days");
   });
 
   it("returns 400 when days exceeds 30", async () => {
@@ -422,21 +422,21 @@ describe("GET /api/feeds/:id/health", () => {
       avg_duration_ms: number | null;
       articles_inserted_total: number;
     }>();
-    expect(body.feed_id).toBe("openai-blog");
-    expect(body.window_days).toBe(7);
-    expect(body.total_runs).toBe(4);
-    expect(body.successful_runs).toBe(3);
-    expect(body.failed_runs).toBe(1);
-    expect(body.success_rate).toBeCloseTo(0.75, 2);
-    expect(body.last_run_at).not.toBeNull();
+    expect.soft(body.feed_id).toBe("openai-blog");
+    expect.soft(body.window_days).toBe(7);
+    expect.soft(body.total_runs).toBe(4);
+    expect.soft(body.successful_runs).toBe(3);
+    expect.soft(body.failed_runs).toBe(1);
+    expect.soft(body.success_rate).toBeCloseTo(0.75, 2);
+    expect.soft(body.last_run_at).not.toBeNull();
     // 最終実行は ok (1日前)
-    expect(body.last_run_status).toBe("success");
+    expect.soft(body.last_run_status).toBe("success");
     // 失敗が存在するので last_error は非 null
     expect(body.last_error).not.toBeNull();
-    expect(body.last_error!.message).toContain("timeout");
-    expect(body.avg_duration_ms).not.toBeNull();
+    expect.soft(body.last_error!.message).toContain("timeout");
+    expect.soft(body.avg_duration_ms).not.toBeNull();
     // 合計記事数: 5+3+10+0=18
-    expect(body.articles_inserted_total).toBe(18);
+    expect.soft(body.articles_inserted_total).toBe(18);
   });
 
   it("returns null last_error when no failures", async () => {
@@ -444,10 +444,10 @@ describe("GET /api/feeds/:id/health", () => {
     // 成功のみのランを別フィードに挿入して確認
     await insertRun("google-research", "ok", { daysAgoN: 1, durationMs: 150, articlesInserted: 2 });
     const res = await SELF.fetch("https://example.com/api/feeds/google-research/health");
-    expect(res.status).toBe(200);
     const body = await res.json<{ last_error: null; last_run_status: string }>();
-    expect(body.last_error).toBeNull();
-    expect(body.last_run_status).toBe("success");
+    expect.soft(res.status).toBe(200);
+    expect.soft(body.last_error).toBeNull();
+    expect.soft(body.last_run_status).toBe("success");
   });
 
   it("returns total_runs=0 when no runs in window", async () => {
@@ -455,15 +455,15 @@ describe("GET /api/feeds/:id/health", () => {
     const res = await SELF.fetch(
       "https://example.com/api/feeds/cyberagent-developers/health?days=7",
     );
-    expect(res.status).toBe(200);
     const body = await res.json<{
       total_runs: number;
       success_rate: number | null;
       last_run_at: string | null;
     }>();
-    expect(body.total_runs).toBe(0);
-    expect(body.success_rate).toBeNull();
-    expect(body.last_run_at).toBeNull();
+    expect.soft(res.status).toBe(200);
+    expect.soft(body.total_runs).toBe(0);
+    expect.soft(body.success_rate).toBeNull();
+    expect.soft(body.last_run_at).toBeNull();
   });
 
   it("uses default days=7 when days param is omitted", async () => {

--- a/apps/web/tests/worker/api/feeds.test.ts
+++ b/apps/web/tests/worker/api/feeds.test.ts
@@ -113,7 +113,7 @@ describe("GET /api/feeds - basic", () => {
       }[];
     };
     expect.soft(res.status).toBe(200);
-    expect.soft(Array.isArray(body.feeds)).toBe(true);
+    expect(Array.isArray(body.feeds)).toBe(true);
     const openai = body.feeds.find((f) => f.id === "openai-blog");
     expect(openai).toBeDefined();
     expect.soft(openai!.articles_30d).toBe(2);

--- a/apps/web/tests/worker/api/health.test.ts
+++ b/apps/web/tests/worker/api/health.test.ts
@@ -27,9 +27,9 @@ const DISABLED_FEED: FeedConfig = {
 describe("/api/health", () => {
   it("returns 200 with ok: true", async () => {
     const res = await SELF.fetch("https://example.com/api/health");
-    expect(res.status).toBe(200);
     const body = (await res.json()) as HealthResponse;
-    expect(body.ok).toBe(true);
+    expect.soft(res.status).toBe(200);
+    expect.soft(body.ok).toBe(true);
   });
 
   it("now is ISO 8601 format", async () => {
@@ -47,15 +47,15 @@ describe("/api/health", () => {
   it("feeds.total and feeds.enabled are 0 when db is empty", async () => {
     const res = await SELF.fetch("https://example.com/api/health");
     const body = (await res.json()) as HealthResponse;
-    expect(body.feeds.total).toBe(0);
-    expect(body.feeds.enabled).toBe(0);
+    expect.soft(body.feeds.total).toBe(0);
+    expect.soft(body.feeds.enabled).toBe(0);
   });
 
   it("articles.total and articles.last_24h are 0 when db is empty", async () => {
     const res = await SELF.fetch("https://example.com/api/health");
     const body = (await res.json()) as HealthResponse;
-    expect(body.articles.total).toBe(0);
-    expect(body.articles.last_24h).toBe(0);
+    expect.soft(body.articles.total).toBe(0);
+    expect.soft(body.articles.last_24h).toBe(0);
   });
 
   it("last_cron_run is null when no runs exist", async () => {
@@ -69,8 +69,8 @@ describe("/api/health", () => {
 
     const res = await SELF.fetch("https://example.com/api/health");
     const body = (await res.json()) as HealthResponse;
-    expect(body.feeds.total).toBe(2);
-    expect(body.feeds.enabled).toBe(1);
+    expect.soft(body.feeds.total).toBe(2);
+    expect.soft(body.feeds.enabled).toBe(1);
   });
 
   it("reflects articles.total and articles.last_24h with fixture data", async () => {
@@ -104,8 +104,8 @@ describe("/api/health", () => {
 
     const res = await SELF.fetch("https://example.com/api/health");
     const body = (await res.json()) as HealthResponse;
-    expect(body.articles.total).toBe(2);
-    expect(body.articles.last_24h).toBe(1);
+    expect.soft(body.articles.total).toBe(2);
+    expect.soft(body.articles.last_24h).toBe(1);
   });
 
   it("last_cron_run returns most recent completed run when 2 runs exist", async () => {
@@ -124,11 +124,11 @@ describe("/api/health", () => {
     const body = (await res.json()) as HealthResponse;
 
     expect(body.last_cron_run).not.toBeNull();
-    expect(body.last_cron_run?.completed_at).toBe(run2CompletedAt);
-    expect(body.last_cron_run?.feeds_total).toBe(41);
-    expect(body.last_cron_run?.feeds_ok).toBe(39);
-    expect(body.last_cron_run?.feeds_failed).toBe(2);
-    expect(body.last_cron_run?.articles_inserted).toBe(15);
+    expect.soft(body.last_cron_run?.completed_at).toBe(run2CompletedAt);
+    expect.soft(body.last_cron_run?.feeds_total).toBe(41);
+    expect.soft(body.last_cron_run?.feeds_ok).toBe(39);
+    expect.soft(body.last_cron_run?.feeds_failed).toBe(2);
+    expect.soft(body.last_cron_run?.articles_inserted).toBe(15);
   });
 
   it("last_cron_run is null when only incomplete runs exist", async () => {
@@ -155,11 +155,11 @@ const ZENN_TRENDING_ID = "zenn-trending";
 describe("GET /api/health/feeds", () => {
   it("returns 200 with an array", async () => {
     const res = await SELF.fetch("https://example.com/api/health/feeds");
-    expect(res.status).toBe(200);
     const body = (await res.json()) as unknown as FeedHealth[];
-    expect(Array.isArray(body)).toBe(true);
+    expect.soft(res.status).toBe(200);
+    expect.soft(Array.isArray(body)).toBe(true);
     // feeds.yaml に定義されたフィード数以上の要素が返る
-    expect(body.length).toBeGreaterThan(0);
+    expect.soft(body.length).toBeGreaterThan(0);
   });
 
   it("returns correct shape for each entry", async () => {
@@ -168,12 +168,12 @@ describe("GET /api/health/feeds", () => {
     // DB 未登録でもゼロ埋めで返る
     const found = body.find((f) => f.feed_id === GOOGLE_DEVELOPERS_ID);
     expect(found).toBeDefined();
-    expect(typeof found?.feed_name).toBe("string");
-    expect(typeof found?.enabled).toBe("boolean");
-    expect(found?.consecutive_failures).toBe(0);
-    expect(found?.articles_last_7d).toBe(0);
-    expect(found?.last_success_at).toBeNull();
-    expect(found?.last_failure_at).toBeNull();
+    expect.soft(typeof found?.feed_name).toBe("string");
+    expect.soft(typeof found?.enabled).toBe("boolean");
+    expect.soft(found?.consecutive_failures).toBe(0);
+    expect.soft(found?.articles_last_7d).toBe(0);
+    expect.soft(found?.last_success_at).toBeNull();
+    expect.soft(found?.last_failure_at).toBeNull();
   });
 
   it("reflects last_success_at after recordFetchSuccess", async () => {
@@ -193,9 +193,9 @@ describe("GET /api/health/feeds", () => {
     const res = await SELF.fetch("https://example.com/api/health/feeds");
     const body = (await res.json()) as unknown as FeedHealth[];
     const found = body.find((f) => f.feed_id === GOOGLE_DEVELOPERS_ID);
-    expect(found?.last_success_at).toBe(successAt);
-    expect(found?.last_failure_at).toBeNull();
-    expect(found?.consecutive_failures).toBe(0);
+    expect.soft(found?.last_success_at).toBe(successAt);
+    expect.soft(found?.last_failure_at).toBeNull();
+    expect.soft(found?.consecutive_failures).toBe(0);
   });
 
   it("reflects last_failure_at and consecutive_failures after recordFetchError", async () => {
@@ -215,9 +215,9 @@ describe("GET /api/health/feeds", () => {
     const res = await SELF.fetch("https://example.com/api/health/feeds");
     const body = (await res.json()) as unknown as FeedHealth[];
     const found = body.find((f) => f.feed_id === GOOGLE_DEVELOPERS_ID);
-    expect(found?.last_failure_at).toBe(failAt);
-    expect(found?.consecutive_failures).toBe(2);
-    expect(found?.last_success_at).toBeNull();
+    expect.soft(found?.last_failure_at).toBe(failAt);
+    expect.soft(found?.consecutive_failures).toBe(2);
+    expect.soft(found?.last_success_at).toBeNull();
   });
 
   it("counts only articles published within the last 7 days", async () => {

--- a/apps/web/tests/worker/api/stats.test.ts
+++ b/apps/web/tests/worker/api/stats.test.ts
@@ -313,7 +313,7 @@ describe("GET /api/stats — top_authors_30d", () => {
       top_authors_30d: { author: string; count: number }[];
     };
     expect.soft(res.status).toBe(200);
-    expect.soft(Array.isArray(body.top_authors_30d)).toBe(true);
+    expect(Array.isArray(body.top_authors_30d)).toBe(true);
     const authorA = body.top_authors_30d.find((a) => a.author === "Author A");
     const authorB = body.top_authors_30d.find((a) => a.author === "Author B");
     expect.soft(authorA?.count).toBe(3);
@@ -426,7 +426,7 @@ describe("GET /api/stats — top_publishers_30d", () => {
       top_publishers_30d: { feed_id: string; feed_name: string; count: number }[];
     };
     expect.soft(res.status).toBe(200);
-    expect.soft(Array.isArray(body.top_publishers_30d)).toBe(true);
+    expect(Array.isArray(body.top_publishers_30d)).toBe(true);
     // beforeEach で google-research=2, openai-blog=1, cyberagent-developers=1
     const google = body.top_publishers_30d.find((p) => p.feed_id === "google-research");
     expect.soft(google?.count).toBe(2);

--- a/apps/web/tests/worker/api/stats.test.ts
+++ b/apps/web/tests/worker/api/stats.test.ts
@@ -102,11 +102,11 @@ beforeEach(async () => {
 describe("GET /api/stats — category_trend_30d", () => {
   it("returns exactly 30 entries", async () => {
     const res = await SELF.fetch("https://example.com/api/stats");
-    expect(res.status).toBe(200);
     const body = (await res.json()) as {
       category_trend_30d: { date: string; ai: number; bigtech: number; jp: number; zenn: number }[];
     };
-    expect(body.category_trend_30d).toHaveLength(30);
+    expect.soft(res.status).toBe(200);
+    expect.soft(body.category_trend_30d).toHaveLength(30);
   });
 
   it("each entry has date, ai, bigtech, jp, zenn fields", async () => {
@@ -115,11 +115,11 @@ describe("GET /api/stats — category_trend_30d", () => {
       category_trend_30d: { date: string; ai: number; bigtech: number; jp: number; zenn: number }[];
     };
     const point = body.category_trend_30d[0];
-    expect(typeof point.date).toBe("string");
-    expect(typeof point.ai).toBe("number");
-    expect(typeof point.bigtech).toBe("number");
-    expect(typeof point.jp).toBe("number");
-    expect(typeof point.zenn).toBe("number");
+    expect.soft(typeof point.date).toBe("string");
+    expect.soft(typeof point.ai).toBe("number");
+    expect.soft(typeof point.bigtech).toBe("number");
+    expect.soft(typeof point.jp).toBe("number");
+    expect.soft(typeof point.zenn).toBe("number");
   });
 
   it("counts match inserted articles for days with data", async () => {
@@ -135,17 +135,17 @@ describe("GET /api/stats — category_trend_30d", () => {
     const d3str = d3.toISOString().slice(0, 10);
     const point3 = body.category_trend_30d.find((p) => p.date === d3str);
     expect(point3).toBeDefined();
-    expect(point3!.bigtech).toBe(2);
-    expect(point3!.ai).toBe(1);
-    expect(point3!.jp).toBe(0);
+    expect.soft(point3!.bigtech).toBe(2);
+    expect.soft(point3!.ai).toBe(1);
+    expect.soft(point3!.jp).toBe(0);
 
     const d1 = new Date(today);
     d1.setUTCDate(today.getUTCDate() - 1);
     const d1str = d1.toISOString().slice(0, 10);
     const point1 = body.category_trend_30d.find((p) => p.date === d1str);
     expect(point1).toBeDefined();
-    expect(point1!.jp).toBe(1);
-    expect(point1!.bigtech).toBe(0);
+    expect.soft(point1!.jp).toBe(1);
+    expect.soft(point1!.bigtech).toBe(0);
   });
 
   it("days with no articles have all counts as 0", async () => {
@@ -159,17 +159,16 @@ describe("GET /api/stats — category_trend_30d", () => {
     const todayStr = today.toISOString().slice(0, 10);
     const todayPoint = body.category_trend_30d.find((p) => p.date === todayStr);
     expect(todayPoint).toBeDefined();
-    expect(todayPoint!.ai).toBe(0);
-    expect(todayPoint!.bigtech).toBe(0);
-    expect(todayPoint!.jp).toBe(0);
-    expect(todayPoint!.zenn).toBe(0);
+    expect.soft(todayPoint!.ai).toBe(0);
+    expect.soft(todayPoint!.bigtech).toBe(0);
+    expect.soft(todayPoint!.jp).toBe(0);
+    expect.soft(todayPoint!.zenn).toBe(0);
   });
 });
 
 describe("GET /api/stats — feed_activity", () => {
   it("returns feed_activity array", async () => {
     const res = await SELF.fetch("https://example.com/api/stats");
-    expect(res.status).toBe(200);
     const body = (await res.json()) as {
       feed_activity: {
         feed_id: string;
@@ -178,7 +177,8 @@ describe("GET /api/stats — feed_activity", () => {
         last_published_at: string | null;
       }[];
     };
-    expect(Array.isArray(body.feed_activity)).toBe(true);
+    expect.soft(res.status).toBe(200);
+    expect.soft(Array.isArray(body.feed_activity)).toBe(true);
   });
 
   it("counts articles per feed correctly", async () => {
@@ -189,9 +189,9 @@ describe("GET /api/stats — feed_activity", () => {
     const google = body.feed_activity.find((f) => f.feed_id === "google-research");
     const openai = body.feed_activity.find((f) => f.feed_id === "openai-blog");
     const cyberagent = body.feed_activity.find((f) => f.feed_id === "cyberagent-developers");
-    expect(google?.articles_30d).toBe(2);
-    expect(openai?.articles_30d).toBe(1);
-    expect(cyberagent?.articles_30d).toBe(1);
+    expect.soft(google?.articles_30d).toBe(2);
+    expect.soft(openai?.articles_30d).toBe(1);
+    expect.soft(cyberagent?.articles_30d).toBe(1);
   });
 
   it("is sorted by articles_30d descending", async () => {
@@ -250,6 +250,7 @@ describe("GET /api/stats — feed_activity", () => {
 
 describe("GET /api/stats — top_authors_30d", () => {
   it("returns top_authors_30d array sorted by count descending", async () => {
+    // TODO: 独立観点が多いため将来 it() 分割を検討
     await insertArticles(env.DB, [
       {
         guid: "author-a1",
@@ -308,19 +309,19 @@ describe("GET /api/stats — top_authors_30d", () => {
       },
     ]);
     const res = await SELF.fetch("https://example.com/api/stats");
-    expect(res.status).toBe(200);
     const body = (await res.json()) as {
       top_authors_30d: { author: string; count: number }[];
     };
-    expect(Array.isArray(body.top_authors_30d)).toBe(true);
+    expect.soft(res.status).toBe(200);
+    expect.soft(Array.isArray(body.top_authors_30d)).toBe(true);
     const authorA = body.top_authors_30d.find((a) => a.author === "Author A");
     const authorB = body.top_authors_30d.find((a) => a.author === "Author B");
-    expect(authorA?.count).toBe(3);
-    expect(authorB?.count).toBe(2);
+    expect.soft(authorA?.count).toBe(3);
+    expect.soft(authorB?.count).toBe(2);
     // 件数降順になっていること
     const counts = body.top_authors_30d.map((a) => a.count);
     for (let i = 1; i < counts.length; i++) {
-      expect(counts[i]).toBeLessThanOrEqual(counts[i - 1]);
+      expect.soft(counts[i]).toBeLessThanOrEqual(counts[i - 1]);
     }
   });
 
@@ -412,26 +413,26 @@ describe("GET /api/stats — top_authors_30d", () => {
       top_authors_30d: { author: string; count: number }[];
     };
     // Zenn の author は除外される
-    expect(body.top_authors_30d.some((a) => a.author === "Zenn Heavy Poster")).toBe(false);
+    expect.soft(body.top_authors_30d.some((a) => a.author === "Zenn Heavy Poster")).toBe(false);
     // bigtech の author は含まれる
-    expect(body.top_authors_30d.some((a) => a.author === "Bigtech Author")).toBe(true);
+    expect.soft(body.top_authors_30d.some((a) => a.author === "Bigtech Author")).toBe(true);
   });
 });
 
 describe("GET /api/stats — top_publishers_30d", () => {
   it("returns top_publishers_30d array sorted by count descending", async () => {
     const res = await SELF.fetch("https://example.com/api/stats");
-    expect(res.status).toBe(200);
     const body = (await res.json()) as {
       top_publishers_30d: { feed_id: string; feed_name: string; count: number }[];
     };
-    expect(Array.isArray(body.top_publishers_30d)).toBe(true);
+    expect.soft(res.status).toBe(200);
+    expect.soft(Array.isArray(body.top_publishers_30d)).toBe(true);
     // beforeEach で google-research=2, openai-blog=1, cyberagent-developers=1
     const google = body.top_publishers_30d.find((p) => p.feed_id === "google-research");
-    expect(google?.count).toBe(2);
+    expect.soft(google?.count).toBe(2);
     const counts = body.top_publishers_30d.map((p) => p.count);
     for (let i = 1; i < counts.length; i++) {
-      expect(counts[i]).toBeLessThanOrEqual(counts[i - 1]);
+      expect.soft(counts[i]).toBeLessThanOrEqual(counts[i - 1]);
     }
   });
 
@@ -481,18 +482,18 @@ describe("GET /api/stats — by_lang_30d", () => {
     // ja のみのシナリオを確認するため en 記事がない新 DB 状態が必要だが、
     // setup.ts の beforeEach がリセットするため、この test では ja=1 en=3 で検証する
     const res = await SELF.fetch("https://example.com/api/stats");
-    expect(res.status).toBe(200);
     const body = (await res.json()) as { by_lang_30d: { ja: number; en: number } };
-    expect(typeof body.by_lang_30d.ja).toBe("number");
-    expect(typeof body.by_lang_30d.en).toBe("number");
+    expect.soft(res.status).toBe(200);
+    expect.soft(typeof body.by_lang_30d.ja).toBe("number");
+    expect.soft(typeof body.by_lang_30d.en).toBe("number");
   });
 
   it("counts ja and en articles correctly", async () => {
     const res = await SELF.fetch("https://example.com/api/stats");
     const body = (await res.json()) as { by_lang_30d: { ja: number; en: number } };
     // beforeEach: en=3 (bt-1, bt-2, ai-1), ja=1 (jp-1)
-    expect(body.by_lang_30d.en).toBe(3);
-    expect(body.by_lang_30d.ja).toBe(1);
+    expect.soft(body.by_lang_30d.en).toBe(3);
+    expect.soft(body.by_lang_30d.ja).toBe(1);
   });
 
   it("articles older than 30 days are not counted in by_lang_30d", async () => {
@@ -512,8 +513,8 @@ describe("GET /api/stats — by_lang_30d", () => {
     const res = await SELF.fetch("https://example.com/api/stats");
     const body = (await res.json()) as { by_lang_30d: { ja: number; en: number } };
     // 31 日前の en 記事は含まれない → en は 3 のまま
-    expect(body.by_lang_30d.en).toBe(3);
-    expect(body.by_lang_30d.ja).toBe(1);
+    expect.soft(body.by_lang_30d.en).toBe(3);
+    expect.soft(body.by_lang_30d.ja).toBe(1);
   });
 
   it("returns en: 0 when no en articles in 30d window", async () => {
@@ -536,7 +537,7 @@ describe("GET /api/stats — by_lang_30d", () => {
     ]);
     const res = await SELF.fetch("https://example.com/api/stats");
     const body = (await res.json()) as { by_lang_30d: { ja: number; en: number } };
-    expect(body.by_lang_30d.ja).toBe(2);
-    expect(body.by_lang_30d.en).toBe(3);
+    expect.soft(body.by_lang_30d.ja).toBe(2);
+    expect.soft(body.by_lang_30d.en).toBe(3);
   });
 });

--- a/apps/web/tests/worker/api/syndication.test.ts
+++ b/apps/web/tests/worker/api/syndication.test.ts
@@ -83,7 +83,7 @@ describe("/feed.json", () => {
     expect.soft(res.status).toBe(200);
     expect.soft(res.headers.get("Content-Type")).toContain("application/feed+json");
     expect.soft(body.version).toBe("https://jsonfeed.org/version/1.1");
-    expect.soft(body.items.map((i) => i.id)).toEqual(["g-bigtech", "g-jp", "g-ai"]);
+    expect(body.items.map((i) => i.id)).toEqual(["g-bigtech", "g-jp", "g-ai"]);
     expect.soft(body.items[2].title).toBe("AI <Article> & friends");
   });
 
@@ -143,8 +143,8 @@ describe("/feeds/:id.xml (per-feed RSS)", () => {
 
   it("returns 304 on If-None-Match match (ETag round-trip)", async () => {
     const res1 = await SELF.fetch("https://example.com/feeds/openai-blog.xml");
+    expect(res1.status).toBe(200);
     const etag = res1.headers.get("ETag")!;
-    expect.soft(res1.status).toBe(200);
     expect.soft(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
 
     const res2 = await SELF.fetch("https://example.com/feeds/openai-blog.xml", {
@@ -347,8 +347,8 @@ describe("/feeds/:id.atom (per-feed Atom)", () => {
 
   it("returns 304 on If-None-Match match (ETag round-trip)", async () => {
     const res1 = await SELF.fetch("https://example.com/feeds/openai-blog.atom");
+    expect(res1.status).toBe(200);
     const etag = res1.headers.get("ETag")!;
-    expect.soft(res1.status).toBe(200);
     expect.soft(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
 
     const res2 = await SELF.fetch("https://example.com/feeds/openai-blog.atom", {
@@ -455,8 +455,8 @@ describe("/feeds/author/:author.xml (author RSS)", () => {
 
   it("returns 304 on If-None-Match match (ETag round-trip)", async () => {
     const res1 = await SELF.fetch("https://example.com/feeds/author/Sam.xml");
+    expect(res1.status).toBe(200);
     const etag = res1.headers.get("ETag")!;
-    expect.soft(res1.status).toBe(200);
 
     const res2 = await SELF.fetch("https://example.com/feeds/author/Sam.xml", {
       headers: { "If-None-Match": etag },
@@ -592,8 +592,8 @@ describe("/feeds/author/:author.atom (author Atom)", () => {
 
   it("returns ETag header and supports 304 round-trip", async () => {
     const res1 = await SELF.fetch("https://example.com/feeds/author/Sam.atom");
+    expect(res1.status).toBe(200);
     const etag = res1.headers.get("ETag")!;
-    expect.soft(res1.status).toBe(200);
     expect.soft(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
 
     const res2 = await SELF.fetch("https://example.com/feeds/author/Sam.atom", {
@@ -647,8 +647,8 @@ describe("/feeds/lang/:lang.xml (lang RSS)", () => {
 
   it("returns ETag header and supports 304 round-trip", async () => {
     const res1 = await SELF.fetch("https://example.com/feeds/lang/ja.xml");
+    expect(res1.status).toBe(200);
     const etag = res1.headers.get("ETag")!;
-    expect.soft(res1.status).toBe(200);
     expect.soft(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
 
     const res2 = await SELF.fetch("https://example.com/feeds/lang/ja.xml", {
@@ -752,8 +752,8 @@ describe("/feeds/lang/:lang.atom (lang Atom)", () => {
 
   it("returns ETag header and supports 304 round-trip", async () => {
     const res1 = await SELF.fetch("https://example.com/feeds/lang/en.atom");
+    expect(res1.status).toBe(200);
     const etag = res1.headers.get("ETag")!;
-    expect.soft(res1.status).toBe(200);
     expect.soft(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
 
     const res2 = await SELF.fetch("https://example.com/feeds/lang/en.atom", {

--- a/apps/web/tests/worker/api/syndication.test.ts
+++ b/apps/web/tests/worker/api/syndication.test.ts
@@ -75,16 +75,16 @@ beforeEach(async () => {
 describe("/feed.json", () => {
   it("returns JSON Feed v1.1 with all items in desc order", async () => {
     const res = await SELF.fetch("https://example.com/feed.json");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Content-Type")).toContain("application/feed+json");
     const body = (await res.json()) as {
       version: string;
       feed_url: string;
       items: { id: string; title: string; url: string }[];
     };
-    expect(body.version).toBe("https://jsonfeed.org/version/1.1");
-    expect(body.items.map((i) => i.id)).toEqual(["g-bigtech", "g-jp", "g-ai"]);
-    expect(body.items[2].title).toBe("AI <Article> & friends");
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Content-Type")).toContain("application/feed+json");
+    expect.soft(body.version).toBe("https://jsonfeed.org/version/1.1");
+    expect.soft(body.items.map((i) => i.id)).toEqual(["g-bigtech", "g-jp", "g-ai"]);
+    expect.soft(body.items[2].title).toBe("AI <Article> & friends");
   });
 
   it("filters by category", async () => {
@@ -103,17 +103,17 @@ describe("/feed.json", () => {
 describe("/feed.xml", () => {
   it("returns RSS 2.0 with escaped XML", async () => {
     const res = await SELF.fetch("https://example.com/feed.xml");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Content-Type")).toContain("application/rss+xml");
     const text = await res.text();
-    expect(text.startsWith("<?xml")).toBe(true);
-    expect(text).toContain('<rss version="2.0"');
-    expect(text).toContain("AI &lt;Article&gt; &amp; friends");
-    expect(text).toContain('<guid isPermaLink="false">g-ai</guid>');
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Content-Type")).toContain("application/rss+xml");
+    expect.soft(text.startsWith("<?xml")).toBe(true);
+    expect.soft(text).toContain('<rss version="2.0"');
+    expect.soft(text).toContain("AI &lt;Article&gt; &amp; friends");
+    expect.soft(text).toContain('<guid isPermaLink="false">g-ai</guid>');
     // 並び順: 最新が先
     const ai = text.indexOf("g-ai");
     const jp = text.indexOf("g-jp");
-    expect(jp).toBeLessThan(ai);
+    expect.soft(jp).toBeLessThan(ai);
   });
 
   it("filters by category", async () => {
@@ -127,13 +127,13 @@ describe("/feed.xml", () => {
 describe("/feeds/:id.xml (per-feed RSS)", () => {
   it("returns 200 with only articles from the specified feed_id", async () => {
     const res = await SELF.fetch("https://example.com/feeds/openai-blog.xml");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Content-Type")).toContain("application/rss+xml");
     const text = await res.text();
-    expect(text).toContain("g-ai");
-    expect(text).not.toContain("g-jp");
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Content-Type")).toContain("application/rss+xml");
+    expect.soft(text).toContain("g-ai");
+    expect.soft(text).not.toContain("g-jp");
     // channel.title には feeds.yaml の name が入る
-    expect(text).toContain("<title>OpenAI News</title>");
+    expect.soft(text).toContain("<title>OpenAI News</title>");
   });
 
   it("returns 404 for unknown feed_id", async () => {
@@ -143,15 +143,15 @@ describe("/feeds/:id.xml (per-feed RSS)", () => {
 
   it("returns 304 on If-None-Match match (ETag round-trip)", async () => {
     const res1 = await SELF.fetch("https://example.com/feeds/openai-blog.xml");
-    expect(res1.status).toBe(200);
     const etag = res1.headers.get("ETag")!;
-    expect(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
+    expect.soft(res1.status).toBe(200);
+    expect.soft(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
 
     const res2 = await SELF.fetch("https://example.com/feeds/openai-blog.xml", {
       headers: { "If-None-Match": etag },
     });
-    expect(res2.status).toBe(304);
-    expect(res2.headers.get("ETag")).toBe(etag);
+    expect.soft(res2.status).toBe(304);
+    expect.soft(res2.headers.get("ETag")).toBe(etag);
   });
 
   // enabled: false のフィードでも feeds.yaml に id が定義されていれば 200 を返すことを確認する。
@@ -193,17 +193,17 @@ describe("/feeds/:id.xml (per-feed RSS)", () => {
 describe("/feeds/:id.json (per-feed JSON Feed)", () => {
   it("returns 200 with JSON Feed v1.1 for the specified feed_id", async () => {
     const res = await SELF.fetch("https://example.com/feeds/cyberagent-developers.json");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Content-Type")).toContain("application/feed+json");
     const body = (await res.json()) as {
       version: string;
       title: string;
       items: { id: string }[];
     };
-    expect(body.version).toBe("https://jsonfeed.org/version/1.1");
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Content-Type")).toContain("application/feed+json");
+    expect.soft(body.version).toBe("https://jsonfeed.org/version/1.1");
     // title には feeds.yaml の name が入る
-    expect(body.title).toBe("CyberAgent Developers Blog");
-    expect(body.items.map((i) => i.id)).toEqual(["g-jp"]);
+    expect.soft(body.title).toBe("CyberAgent Developers Blog");
+    expect.soft(body.items.map((i) => i.id)).toEqual(["g-jp"]);
   });
 
   it("returns 404 for unknown feed_id", async () => {
@@ -215,27 +215,27 @@ describe("/feeds/:id.json (per-feed JSON Feed)", () => {
 describe("/feeds/category/:cat.json", () => {
   it("returns 200 with correct Content-Type for ai category", async () => {
     const res = await SELF.fetch("https://example.com/feeds/category/ai.json");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Content-Type")).toContain("application/feed+json");
     const body = (await res.json()) as {
       version: string;
       title: string;
       items: { id: string }[];
     };
-    expect(body.version).toBe("https://jsonfeed.org/version/1.1");
-    expect(body.title).toBe("Tech News Bot — AI Labs");
-    expect(body.items.map((i) => i.id)).toEqual(["g-ai"]);
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Content-Type")).toContain("application/feed+json");
+    expect.soft(body.version).toBe("https://jsonfeed.org/version/1.1");
+    expect.soft(body.title).toBe("Tech News Bot — AI Labs");
+    expect.soft(body.items.map((i) => i.id)).toEqual(["g-ai"]);
   });
 
   it("returns 200 and only jp articles for jp category", async () => {
     const res = await SELF.fetch("https://example.com/feeds/category/jp.json");
-    expect(res.status).toBe(200);
     const body = (await res.json()) as { title: string; items: { id: string }[] };
-    expect(body.title).toBe("Tech News Bot — 国内エンジニアリング");
-    expect(body.items.map((i) => i.id)).toEqual(["g-jp"]);
+    expect.soft(res.status).toBe(200);
+    expect.soft(body.title).toBe("Tech News Bot — 国内エンジニアリング");
+    expect.soft(body.items.map((i) => i.id)).toEqual(["g-jp"]);
     // 別カテゴリの記事が混入しないこと
-    expect(body.items.find((i) => i.id === "g-ai")).toBeUndefined();
-    expect(body.items.find((i) => i.id === "g-bigtech")).toBeUndefined();
+    expect.soft(body.items.find((i) => i.id === "g-ai")).toBeUndefined();
+    expect.soft(body.items.find((i) => i.id === "g-bigtech")).toBeUndefined();
   });
 
   it("returns 404 for invalid category", async () => {
@@ -246,36 +246,36 @@ describe("/feeds/category/:cat.json", () => {
   it("returns 304 on ETag round-trip", async () => {
     const first = await SELF.fetch("https://example.com/feeds/category/ai.json");
     const etag = first.headers.get("ETag");
-    expect(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
+    expect.soft(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
 
     const second = await SELF.fetch("https://example.com/feeds/category/ai.json", {
       headers: { "If-None-Match": etag! },
     });
-    expect(second.status).toBe(304);
+    expect.soft(second.status).toBe(304);
   });
 });
 
 describe("/feeds/category/:cat.xml", () => {
   it("returns 200 with correct Content-Type for bigtech category", async () => {
     const res = await SELF.fetch("https://example.com/feeds/category/bigtech.xml");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Content-Type")).toContain("application/rss+xml");
     const text = await res.text();
-    expect(text.startsWith("<?xml")).toBe(true);
-    expect(text).toContain('<rss version="2.0"');
-    expect(text).toContain("Tech News Bot — Big Tech");
-    expect(text).toContain("g-bigtech");
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Content-Type")).toContain("application/rss+xml");
+    expect.soft(text.startsWith("<?xml")).toBe(true);
+    expect.soft(text).toContain('<rss version="2.0"');
+    expect.soft(text).toContain("Tech News Bot — Big Tech");
+    expect.soft(text).toContain("g-bigtech");
   });
 
   it("returns 200 and only ai articles for ai category", async () => {
     const res = await SELF.fetch("https://example.com/feeds/category/ai.xml");
-    expect(res.status).toBe(200);
     const text = await res.text();
-    expect(text).toContain("Tech News Bot — AI Labs");
-    expect(text).toContain("g-ai");
+    expect.soft(res.status).toBe(200);
+    expect.soft(text).toContain("Tech News Bot — AI Labs");
+    expect.soft(text).toContain("g-ai");
     // 別カテゴリの記事が混入しないこと
-    expect(text).not.toContain("g-jp");
-    expect(text).not.toContain("g-bigtech");
+    expect.soft(text).not.toContain("g-jp");
+    expect.soft(text).not.toContain("g-bigtech");
   });
 
   it("returns 404 for invalid category", async () => {
@@ -286,58 +286,58 @@ describe("/feeds/category/:cat.xml", () => {
   it("returns 304 on ETag round-trip", async () => {
     const first = await SELF.fetch("https://example.com/feeds/category/jp.xml");
     const etag = first.headers.get("ETag");
-    expect(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
+    expect.soft(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
 
     const second = await SELF.fetch("https://example.com/feeds/category/jp.xml", {
       headers: { "If-None-Match": etag! },
     });
-    expect(second.status).toBe(304);
+    expect.soft(second.status).toBe(304);
   });
 });
 
 describe("/feed.atom", () => {
   it("returns 200 with Atom 1.0 feed and entries in desc order", async () => {
     const res = await SELF.fetch("https://example.com/feed.atom");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Content-Type")).toContain("application/atom+xml");
     const text = await res.text();
-    expect(text.startsWith("<?xml")).toBe(true);
-    expect(text).toContain('<feed xmlns="http://www.w3.org/2005/Atom">');
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Content-Type")).toContain("application/atom+xml");
+    expect.soft(text.startsWith("<?xml")).toBe(true);
+    expect.soft(text).toContain('<feed xmlns="http://www.w3.org/2005/Atom">');
     // XML エスケープが正しく行われること
-    expect(text).toContain("AI &lt;Article&gt; &amp; friends");
+    expect.soft(text).toContain("AI &lt;Article&gt; &amp; friends");
     // 並び順: 最新が先 (bigtech: 2024-04-04 > jp: 2024-04-03 > ai: 2024-04-02)
     const bigtech = text.indexOf("g-bigtech");
     const jp = text.indexOf("g-jp");
     const ai = text.indexOf("g-ai");
-    expect(bigtech).toBeLessThan(jp);
-    expect(jp).toBeLessThan(ai);
+    expect.soft(bigtech).toBeLessThan(jp);
+    expect.soft(jp).toBeLessThan(ai);
     // JSON Feed の version 文字列が混入しないこと
-    expect(text).not.toContain("jsonfeed.org");
+    expect.soft(text).not.toContain("jsonfeed.org");
   });
 
   it("filters by category=ai", async () => {
     const res = await SELF.fetch("https://example.com/feed.atom?category=ai");
-    expect(res.status).toBe(200);
     const text = await res.text();
-    expect(text).toContain("g-ai");
-    expect(text).not.toContain("g-jp");
-    expect(text).not.toContain("g-bigtech");
+    expect.soft(res.status).toBe(200);
+    expect.soft(text).toContain("g-ai");
+    expect.soft(text).not.toContain("g-jp");
+    expect.soft(text).not.toContain("g-bigtech");
   });
 });
 
 describe("/feeds/:id.atom (per-feed Atom)", () => {
   it("returns 200 with only articles from the specified feed_id", async () => {
     const res = await SELF.fetch("https://example.com/feeds/openai-blog.atom");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Content-Type")).toContain("application/atom+xml");
     const text = await res.text();
-    expect(text).toContain('<feed xmlns="http://www.w3.org/2005/Atom">');
-    expect(text).toContain("g-ai");
-    expect(text).not.toContain("g-jp");
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Content-Type")).toContain("application/atom+xml");
+    expect.soft(text).toContain('<feed xmlns="http://www.w3.org/2005/Atom">');
+    expect.soft(text).toContain("g-ai");
+    expect.soft(text).not.toContain("g-jp");
     // title には feeds.yaml の name が入る
-    expect(text).toContain("<title>OpenAI News</title>");
+    expect.soft(text).toContain("<title>OpenAI News</title>");
     // summary が存在する場合 summary 要素が出力される
-    expect(text).toContain('<summary type="html">');
+    expect.soft(text).toContain('<summary type="html">');
   });
 
   it("returns 404 for unknown feed_id", async () => {
@@ -347,48 +347,48 @@ describe("/feeds/:id.atom (per-feed Atom)", () => {
 
   it("returns 304 on If-None-Match match (ETag round-trip)", async () => {
     const res1 = await SELF.fetch("https://example.com/feeds/openai-blog.atom");
-    expect(res1.status).toBe(200);
     const etag = res1.headers.get("ETag")!;
-    expect(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
+    expect.soft(res1.status).toBe(200);
+    expect.soft(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
 
     const res2 = await SELF.fetch("https://example.com/feeds/openai-blog.atom", {
       headers: { "If-None-Match": etag },
     });
-    expect(res2.status).toBe(304);
-    expect(res2.headers.get("ETag")).toBe(etag);
+    expect.soft(res2.status).toBe(304);
+    expect.soft(res2.headers.get("ETag")).toBe(etag);
   });
 
   it("omits summary element when article has no summary", async () => {
     const res = await SELF.fetch("https://example.com/feeds/cyberagent-developers.atom");
-    expect(res.status).toBe(200);
     const text = await res.text();
-    expect(text).toContain("g-jp");
+    expect.soft(res.status).toBe(200);
+    expect.soft(text).toContain("g-jp");
     // summary が null の場合 summary 要素が出力されないこと
-    expect(text).not.toContain("<summary");
+    expect.soft(text).not.toContain("<summary");
   });
 });
 
 describe("/feeds/category/:cat.atom", () => {
   it("returns 200 with correct Content-Type for ai category", async () => {
     const res = await SELF.fetch("https://example.com/feeds/category/ai.atom");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Content-Type")).toContain("application/atom+xml");
     const text = await res.text();
-    expect(text).toContain('<feed xmlns="http://www.w3.org/2005/Atom">');
-    expect(text).toContain("<title>Tech News Bot — AI Labs</title>");
-    expect(text).toContain("g-ai");
-    expect(text).not.toContain("g-jp");
-    expect(text).not.toContain("g-bigtech");
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Content-Type")).toContain("application/atom+xml");
+    expect.soft(text).toContain('<feed xmlns="http://www.w3.org/2005/Atom">');
+    expect.soft(text).toContain("<title>Tech News Bot — AI Labs</title>");
+    expect.soft(text).toContain("g-ai");
+    expect.soft(text).not.toContain("g-jp");
+    expect.soft(text).not.toContain("g-bigtech");
   });
 
   it("returns 200 and only jp articles for jp category", async () => {
     const res = await SELF.fetch("https://example.com/feeds/category/jp.atom");
-    expect(res.status).toBe(200);
     const text = await res.text();
-    expect(text).toContain("Tech News Bot — 国内エンジニアリング");
-    expect(text).toContain("g-jp");
-    expect(text).not.toContain("g-ai");
-    expect(text).not.toContain("g-bigtech");
+    expect.soft(res.status).toBe(200);
+    expect.soft(text).toContain("Tech News Bot — 国内エンジニアリング");
+    expect.soft(text).toContain("g-jp");
+    expect.soft(text).not.toContain("g-ai");
+    expect.soft(text).not.toContain("g-bigtech");
   });
 
   it("returns 404 for invalid category", async () => {
@@ -399,27 +399,27 @@ describe("/feeds/category/:cat.atom", () => {
   it("returns 304 on ETag round-trip", async () => {
     const first = await SELF.fetch("https://example.com/feeds/category/ai.atom");
     const etag = first.headers.get("ETag");
-    expect(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
+    expect.soft(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
 
     const second = await SELF.fetch("https://example.com/feeds/category/ai.atom", {
       headers: { "If-None-Match": etag! },
     });
-    expect(second.status).toBe(304);
+    expect.soft(second.status).toBe(304);
   });
 });
 
 describe("/feeds/author/:author.xml (author RSS)", () => {
   it("returns 200 with application/rss+xml and channel title", async () => {
     const res = await SELF.fetch("https://example.com/feeds/author/Sam.xml");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Content-Type")).toContain("application/rss+xml");
     const text = await res.text();
-    expect(text.startsWith("<?xml")).toBe(true);
-    expect(text).toContain('<rss version="2.0"');
-    expect(text).toContain("<title>Sam - tech-news-bot</title>");
-    expect(text).toContain("g-ai");
-    expect(text).not.toContain("g-jp");
-    expect(text).not.toContain("g-bigtech");
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Content-Type")).toContain("application/rss+xml");
+    expect.soft(text.startsWith("<?xml")).toBe(true);
+    expect.soft(text).toContain('<rss version="2.0"');
+    expect.soft(text).toContain("<title>Sam - tech-news-bot</title>");
+    expect.soft(text).toContain("g-ai");
+    expect.soft(text).not.toContain("g-jp");
+    expect.soft(text).not.toContain("g-bigtech");
   });
 
   it("returns 200 with empty feed for unknown author", async () => {
@@ -455,14 +455,14 @@ describe("/feeds/author/:author.xml (author RSS)", () => {
 
   it("returns 304 on If-None-Match match (ETag round-trip)", async () => {
     const res1 = await SELF.fetch("https://example.com/feeds/author/Sam.xml");
-    expect(res1.status).toBe(200);
     const etag = res1.headers.get("ETag")!;
+    expect.soft(res1.status).toBe(200);
 
     const res2 = await SELF.fetch("https://example.com/feeds/author/Sam.xml", {
       headers: { "If-None-Match": etag },
     });
-    expect(res2.status).toBe(304);
-    expect(res2.headers.get("ETag")).toBe(etag);
+    expect.soft(res2.status).toBe(304);
+    expect.soft(res2.headers.get("ETag")).toBe(etag);
   });
 
   it("returns articles in published_at DESC order", async () => {
@@ -517,16 +517,16 @@ describe("/feeds/author/:author.xml (author RSS)", () => {
 describe("/feeds/author/:author.json (author JSON Feed)", () => {
   it("returns 200 with application/feed+json and items array", async () => {
     const res = await SELF.fetch("https://example.com/feeds/author/Sam.json");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Content-Type")).toContain("application/feed+json");
     const body = (await res.json()) as {
       version: string;
       title: string;
       items: { id: string }[];
     };
-    expect(body.version).toBe("https://jsonfeed.org/version/1.1");
-    expect(body.title).toBe("Sam - tech-news-bot");
-    expect(body.items.map((i) => i.id)).toContain("g-ai");
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Content-Type")).toContain("application/feed+json");
+    expect.soft(body.version).toBe("https://jsonfeed.org/version/1.1");
+    expect.soft(body.title).toBe("Sam - tech-news-bot");
+    expect.soft(body.items.map((i) => i.id)).toContain("g-ai");
   });
 
   it("returns 200 with empty items for unknown author", async () => {
@@ -552,10 +552,10 @@ describe("/feeds/author/:author.json (author JSON Feed)", () => {
       },
     ]);
     const res = await SELF.fetch("https://example.com/feeds/author/Author%20A.json");
-    expect(res.status).toBe(200);
     const body = (await res.json()) as { title: string; items: { id: string }[] };
-    expect(body.title).toBe("Author A - tech-news-bot");
-    expect(body.items.map((i) => i.id)).toContain("g-author-a");
+    expect.soft(res.status).toBe(200);
+    expect.soft(body.title).toBe("Author A - tech-news-bot");
+    expect.soft(body.items.map((i) => i.id)).toContain("g-author-a");
   });
 
   it("returns Cache-Control: public, max-age=600", async () => {
@@ -567,13 +567,13 @@ describe("/feeds/author/:author.json (author JSON Feed)", () => {
 describe("/feeds/author/:author.atom (author Atom)", () => {
   it("returns 200 with application/atom+xml", async () => {
     const res = await SELF.fetch("https://example.com/feeds/author/Sam.atom");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Content-Type")).toContain("application/atom+xml");
     const text = await res.text();
-    expect(text.startsWith("<?xml")).toBe(true);
-    expect(text).toContain('<feed xmlns="http://www.w3.org/2005/Atom">');
-    expect(text).toContain("<title>Sam - tech-news-bot</title>");
-    expect(text).toContain("g-ai");
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Content-Type")).toContain("application/atom+xml");
+    expect.soft(text.startsWith("<?xml")).toBe(true);
+    expect.soft(text).toContain('<feed xmlns="http://www.w3.org/2005/Atom">');
+    expect.soft(text).toContain("<title>Sam - tech-news-bot</title>");
+    expect.soft(text).toContain("g-ai");
   });
 
   it("returns 200 with empty feed for unknown author", async () => {
@@ -592,42 +592,42 @@ describe("/feeds/author/:author.atom (author Atom)", () => {
 
   it("returns ETag header and supports 304 round-trip", async () => {
     const res1 = await SELF.fetch("https://example.com/feeds/author/Sam.atom");
-    expect(res1.status).toBe(200);
     const etag = res1.headers.get("ETag")!;
-    expect(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
+    expect.soft(res1.status).toBe(200);
+    expect.soft(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
 
     const res2 = await SELF.fetch("https://example.com/feeds/author/Sam.atom", {
       headers: { "If-None-Match": etag },
     });
-    expect(res2.status).toBe(304);
+    expect.soft(res2.status).toBe(304);
   });
 });
 
 describe("/feeds/lang/:lang.xml (lang RSS)", () => {
   it("returns 200 with application/rss+xml for ja", async () => {
     const res = await SELF.fetch("https://example.com/feeds/lang/ja.xml");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Content-Type")).toContain("application/rss+xml");
     const text = await res.text();
-    expect(text.startsWith("<?xml")).toBe(true);
-    expect(text).toContain('<rss version="2.0"');
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Content-Type")).toContain("application/rss+xml");
+    expect.soft(text.startsWith("<?xml")).toBe(true);
+    expect.soft(text).toContain('<rss version="2.0"');
     // title に「日本語」を含む
-    expect(text).toContain("日本語");
+    expect.soft(text).toContain("日本語");
     // ja 記事のみ
-    expect(text).toContain("g-jp");
-    expect(text).not.toContain("g-ai");
-    expect(text).not.toContain("g-bigtech");
+    expect.soft(text).toContain("g-jp");
+    expect.soft(text).not.toContain("g-ai");
+    expect.soft(text).not.toContain("g-bigtech");
   });
 
   it("returns 200 with application/rss+xml for en", async () => {
     const res = await SELF.fetch("https://example.com/feeds/lang/en.xml");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Content-Type")).toContain("application/rss+xml");
     const text = await res.text();
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Content-Type")).toContain("application/rss+xml");
     // en 記事のみ
-    expect(text).toContain("g-ai");
-    expect(text).toContain("g-bigtech");
-    expect(text).not.toContain("g-jp");
+    expect.soft(text).toContain("g-ai");
+    expect.soft(text).toContain("g-bigtech");
+    expect.soft(text).not.toContain("g-jp");
   });
 
   it("returns 404 for invalid lang (fr)", async () => {
@@ -647,15 +647,15 @@ describe("/feeds/lang/:lang.xml (lang RSS)", () => {
 
   it("returns ETag header and supports 304 round-trip", async () => {
     const res1 = await SELF.fetch("https://example.com/feeds/lang/ja.xml");
-    expect(res1.status).toBe(200);
     const etag = res1.headers.get("ETag")!;
-    expect(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
+    expect.soft(res1.status).toBe(200);
+    expect.soft(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
 
     const res2 = await SELF.fetch("https://example.com/feeds/lang/ja.xml", {
       headers: { "If-None-Match": etag },
     });
-    expect(res2.status).toBe(304);
-    expect(res2.headers.get("ETag")).toBe(etag);
+    expect.soft(res2.status).toBe(304);
+    expect.soft(res2.headers.get("ETag")).toBe(etag);
   });
 
   it("returns articles in published_at DESC order", async () => {
@@ -686,25 +686,25 @@ describe("/feeds/lang/:lang.json (lang JSON Feed)", () => {
   it("returns 200 with application/feed+json for ja with correct item count", async () => {
     // beforeEach: ja=1 (g-jp), en=2 (g-ai, g-bigtech)
     const res = await SELF.fetch("https://example.com/feeds/lang/ja.json");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Content-Type")).toContain("application/feed+json");
     const body = (await res.json()) as {
       version: string;
       title: string;
       items: { id: string }[];
     };
-    expect(body.version).toBe("https://jsonfeed.org/version/1.1");
-    expect(body.items.length).toBe(1);
-    expect(body.items.map((i) => i.id)).toContain("g-jp");
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Content-Type")).toContain("application/feed+json");
+    expect.soft(body.version).toBe("https://jsonfeed.org/version/1.1");
+    expect.soft(body.items.length).toBe(1);
+    expect.soft(body.items.map((i) => i.id)).toContain("g-jp");
   });
 
   it("returns correct item count for en (2 articles)", async () => {
     const res = await SELF.fetch("https://example.com/feeds/lang/en.json");
-    expect(res.status).toBe(200);
     const body = (await res.json()) as { items: { id: string }[] };
-    expect(body.items.length).toBe(2);
-    expect(body.items.map((i) => i.id)).toContain("g-ai");
-    expect(body.items.map((i) => i.id)).toContain("g-bigtech");
+    expect.soft(res.status).toBe(200);
+    expect.soft(body.items.length).toBe(2);
+    expect.soft(body.items.map((i) => i.id)).toContain("g-ai");
+    expect.soft(body.items.map((i) => i.id)).toContain("g-bigtech");
   });
 
   it("returns 404 for invalid lang", async () => {
@@ -722,22 +722,22 @@ describe("/feeds/lang/:lang.json (lang JSON Feed)", () => {
     const resEn = await SELF.fetch("https://example.com/feeds/lang/en.json");
     const etagJa = resJa.headers.get("ETag");
     const etagEn = resEn.headers.get("ETag");
-    expect(etagJa).not.toBeNull();
-    expect(etagEn).not.toBeNull();
-    expect(etagJa).not.toBe(etagEn);
+    expect.soft(etagJa).not.toBeNull();
+    expect.soft(etagEn).not.toBeNull();
+    expect.soft(etagJa).not.toBe(etagEn);
   });
 });
 
 describe("/feeds/lang/:lang.atom (lang Atom)", () => {
   it("returns 200 with application/atom+xml for ja", async () => {
     const res = await SELF.fetch("https://example.com/feeds/lang/ja.atom");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Content-Type")).toContain("application/atom+xml");
     const text = await res.text();
-    expect(text.startsWith("<?xml")).toBe(true);
-    expect(text).toContain('<feed xmlns="http://www.w3.org/2005/Atom">');
-    expect(text).toContain("g-jp");
-    expect(text).not.toContain("g-ai");
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Content-Type")).toContain("application/atom+xml");
+    expect.soft(text.startsWith("<?xml")).toBe(true);
+    expect.soft(text).toContain('<feed xmlns="http://www.w3.org/2005/Atom">');
+    expect.soft(text).toContain("g-jp");
+    expect.soft(text).not.toContain("g-ai");
   });
 
   it("returns 404 for invalid lang", async () => {
@@ -752,13 +752,13 @@ describe("/feeds/lang/:lang.atom (lang Atom)", () => {
 
   it("returns ETag header and supports 304 round-trip", async () => {
     const res1 = await SELF.fetch("https://example.com/feeds/lang/en.atom");
-    expect(res1.status).toBe(200);
     const etag = res1.headers.get("ETag")!;
-    expect(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
+    expect.soft(res1.status).toBe(200);
+    expect.soft(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
 
     const res2 = await SELF.fetch("https://example.com/feeds/lang/en.atom", {
       headers: { "If-None-Match": etag },
     });
-    expect(res2.status).toBe(304);
+    expect.soft(res2.status).toBe(304);
   });
 });

--- a/apps/web/tests/worker/collector/alert.test.ts
+++ b/apps/web/tests/worker/collector/alert.test.ts
@@ -79,11 +79,11 @@ describe("notifyCollectorFailure", () => {
 
     expect(spy).toHaveBeenCalledTimes(1);
     const [url, init] = spy.mock.calls[0];
-    expect(url).toBe(WEBHOOK_URL);
-    expect(init?.method).toBe("POST");
     const body = JSON.parse(init?.body as string) as { text: string };
-    expect(body.text).toContain("[tech-news-bot]");
-    expect(body.text).toContain("feed-a");
+    expect.soft(url).toBe(WEBHOOK_URL);
+    expect.soft(init?.method).toBe("POST");
+    expect.soft(body.text).toContain("[tech-news-bot]");
+    expect.soft(body.text).toContain("feed-a");
   });
 
   it("includes streak feeds in payload", async () => {
@@ -97,8 +97,8 @@ describe("notifyCollectorFailure", () => {
     });
 
     const body = JSON.parse(spy.mock.calls[0][1]?.body as string) as { text: string };
-    expect(body.text).toContain("feed-b");
-    expect(body.text).toContain("7 consecutive failures");
+    expect.soft(body.text).toContain("feed-b");
+    expect.soft(body.text).toContain("7 consecutive failures");
   });
 
   it("does not throw on non-2xx response", async () => {
@@ -216,15 +216,15 @@ describe("sendAlert", () => {
 
     expect(spy).toHaveBeenCalledTimes(1);
     const [url, init] = spy.mock.calls[0];
-    expect(url).toBe(WEBHOOK_URL);
     const body = JSON.parse(init?.body as string) as {
       text: string;
       blocks: { type: string; text: { type: string; text: string } }[];
     };
-    expect(body.text).toContain("collector alert");
+    expect.soft(url).toBe(WEBHOOK_URL);
+    expect.soft(body.text).toContain("collector alert");
     expect(body.blocks).toHaveLength(1);
-    expect(body.blocks[0].text.type).toBe("mrkdwn");
-    expect(body.blocks[0].text.text).toContain("Failed:");
+    expect.soft(body.blocks[0].text.type).toBe("mrkdwn");
+    expect.soft(body.blocks[0].text.text).toContain("Failed:");
   });
 
   it("does not call webhook when failed feeds < threshold (default 5)", async () => {
@@ -263,9 +263,9 @@ describe("sendAlert", () => {
     };
     const mrkdwn = body.blocks[0].text.text;
     // "feed-5" 〜 "feed-9" は含まれないことを確認 (top 5 = feed-0 〜 feed-4)
-    expect(mrkdwn).toContain("feed-0");
-    expect(mrkdwn).toContain("feed-4");
-    expect(mrkdwn).not.toContain("feed-5");
+    expect.soft(mrkdwn).toContain("feed-0");
+    expect.soft(mrkdwn).toContain("feed-4");
+    expect.soft(mrkdwn).not.toContain("feed-5");
   });
 
   it("does not throw on non-2xx webhook response", async () => {

--- a/apps/web/tests/worker/collector/conditionalGet.test.ts
+++ b/apps/web/tests/worker/collector/conditionalGet.test.ts
@@ -29,16 +29,16 @@ describe("fetchFeed conditional GET", () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(VALID_XML, { status: 200 }));
 
     const result = await fetchFeed(DUMMY_URL, 10000, 0);
-    expect(result.notModified).toBe(false);
-    expect(result.xml).toBe(VALID_XML);
+    expect.soft(result.notModified).toBe(false);
+    expect.soft(result.xml).toBe(VALID_XML);
   });
 
   it("returns notModified=true on 304 and xml is null", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(null, { status: 304 }));
 
     const result = await fetchFeed(DUMMY_URL, 10000, 0);
-    expect(result.notModified).toBe(true);
-    expect(result.xml).toBeNull();
+    expect.soft(result.notModified).toBe(true);
+    expect.soft(result.xml).toBeNull();
   });
 
   it("sends If-None-Match header when etag is provided", async () => {
@@ -75,8 +75,8 @@ describe("fetchFeed conditional GET", () => {
 
     const callArgs = spy.mock.calls[0];
     const headers = callArgs[1]?.headers as Record<string, string>;
-    expect(headers["if-none-match"]).toBeUndefined();
-    expect(headers["if-modified-since"]).toBeUndefined();
+    expect.soft(headers["if-none-match"]).toBeUndefined();
+    expect.soft(headers["if-modified-since"]).toBeUndefined();
   });
 
   it("saves etag from 200 response", async () => {
@@ -88,24 +88,24 @@ describe("fetchFeed conditional GET", () => {
     );
 
     const result = await fetchFeed(DUMMY_URL, 10000, 0);
-    expect(result.etag).toBe('"newetag"');
-    expect(result.lastModified).toBe("Tue, 02 Jan 2024 00:00:00 GMT");
+    expect.soft(result.etag).toBe('"newetag"');
+    expect.soft(result.lastModified).toBe("Tue, 02 Jan 2024 00:00:00 GMT");
   });
 });
 
 describe("loadFeedHeaders / updateFeedHeaders", () => {
   it("returns null headers for a feed with no saved headers", async () => {
     const headers = await loadFeedHeaders(env.DB, "test-feed");
-    expect(headers.last_etag).toBeNull();
-    expect(headers.last_modified).toBeNull();
+    expect.soft(headers.last_etag).toBeNull();
+    expect.soft(headers.last_modified).toBeNull();
   });
 
   it("saves and retrieves etag and last_modified", async () => {
     await updateFeedHeaders(env.DB, "test-feed", '"v1"', "Wed, 03 Jan 2024 00:00:00 GMT");
 
     const headers = await loadFeedHeaders(env.DB, "test-feed");
-    expect(headers.last_etag).toBe('"v1"');
-    expect(headers.last_modified).toBe("Wed, 03 Jan 2024 00:00:00 GMT");
+    expect.soft(headers.last_etag).toBe('"v1"');
+    expect.soft(headers.last_modified).toBe("Wed, 03 Jan 2024 00:00:00 GMT");
   });
 
   it("overwrites existing headers on subsequent update", async () => {
@@ -113,13 +113,13 @@ describe("loadFeedHeaders / updateFeedHeaders", () => {
     await updateFeedHeaders(env.DB, "test-feed", '"v2"', null);
 
     const headers = await loadFeedHeaders(env.DB, "test-feed");
-    expect(headers.last_etag).toBe('"v2"');
-    expect(headers.last_modified).toBeNull();
+    expect.soft(headers.last_etag).toBe('"v2"');
+    expect.soft(headers.last_modified).toBeNull();
   });
 
   it("returns null for unknown feed id", async () => {
     const headers = await loadFeedHeaders(env.DB, "non-existent-feed");
-    expect(headers.last_etag).toBeNull();
-    expect(headers.last_modified).toBeNull();
+    expect.soft(headers.last_etag).toBeNull();
+    expect.soft(headers.last_modified).toBeNull();
   });
 });

--- a/apps/web/tests/worker/collector/d1Disabled.test.ts
+++ b/apps/web/tests/worker/collector/d1Disabled.test.ts
@@ -28,17 +28,17 @@ beforeEach(async () => {
 describe("getEnabledFeedIds + setFeedEnabled (D1 runtime toggle)", () => {
   it("returns all feeds when both are enabled", async () => {
     const ids = await getEnabledFeedIds(env.DB);
-    expect(ids.has("feed-a")).toBe(true);
-    expect(ids.has("feed-b")).toBe(true);
+    expect.soft(ids.has("feed-a")).toBe(true);
+    expect.soft(ids.has("feed-b")).toBe(true);
   });
 
   it("excludes a feed disabled via setFeedEnabled", async () => {
     await setFeedEnabled(env.DB, "feed-b", false);
 
     const ids = await getEnabledFeedIds(env.DB);
-    expect(ids.has("feed-a")).toBe(true);
+    expect.soft(ids.has("feed-a")).toBe(true);
     // feed-b は D1 で disabled にされたため含まれない
-    expect(ids.has("feed-b")).toBe(false);
+    expect.soft(ids.has("feed-b")).toBe(false);
   });
 
   it("re-enables a feed and it appears again in getEnabledFeedIds", async () => {

--- a/apps/web/tests/worker/collector/metrics.test.ts
+++ b/apps/web/tests/worker/collector/metrics.test.ts
@@ -98,9 +98,9 @@ describe("D1CostAccumulator", () => {
     acc.add({ rows_read: 5, rows_written: 1, duration: 2 });
 
     const stats = acc.toStats();
-    expect(stats.rowsRead).toBe(35);
-    expect(stats.rowsWritten).toBe(6);
-    expect(stats.durationTotalMs).toBe(15);
+    expect.soft(stats.rowsRead).toBe(35);
+    expect.soft(stats.rowsWritten).toBe(6);
+    expect.soft(stats.durationTotalMs).toBe(15);
   });
 
   it("treats null/undefined meta as zero", () => {
@@ -109,9 +109,9 @@ describe("D1CostAccumulator", () => {
     acc.add(undefined);
 
     const stats = acc.toStats();
-    expect(stats.rowsRead).toBe(0);
-    expect(stats.rowsWritten).toBe(0);
-    expect(stats.durationTotalMs).toBe(0);
+    expect.soft(stats.rowsRead).toBe(0);
+    expect.soft(stats.rowsWritten).toBe(0);
+    expect.soft(stats.durationTotalMs).toBe(0);
   });
 
   it("treats missing fields in meta as zero", () => {
@@ -119,9 +119,9 @@ describe("D1CostAccumulator", () => {
     acc.add({});
 
     const stats = acc.toStats();
-    expect(stats.rowsRead).toBe(0);
-    expect(stats.rowsWritten).toBe(0);
-    expect(stats.durationTotalMs).toBe(0);
+    expect.soft(stats.rowsRead).toBe(0);
+    expect.soft(stats.rowsWritten).toBe(0);
+    expect.soft(stats.durationTotalMs).toBe(0);
   });
 });
 

--- a/apps/web/tests/worker/collector/retry.test.ts
+++ b/apps/web/tests/worker/collector/retry.test.ts
@@ -68,9 +68,9 @@ describe("fetchFeed retry behavior", () => {
       .mockResolvedValueOnce(new Response(VALID_XML, { status: 200 }));
 
     const result = await fetchFeed(DUMMY_URL, 10000, 2);
-    expect(result.xml).toBe(VALID_XML);
-    expect(result.notModified).toBe(false);
-    expect(spy).toHaveBeenCalledTimes(1);
+    expect.soft(result.xml).toBe(VALID_XML);
+    expect.soft(result.notModified).toBe(false);
+    expect.soft(spy).toHaveBeenCalledTimes(1);
   });
 
   it("retries on 503 and succeeds on 2nd attempt", async () => {

--- a/apps/web/tests/worker/collector/rssParser.test.ts
+++ b/apps/web/tests/worker/collector/rssParser.test.ts
@@ -8,30 +8,30 @@ describe("parseFeed", () => {
     const items = parseFeed(sampleRss, { fallbackPublishedAt: "2024-12-01T00:00:00.000Z" });
     expect(items.length).toBe(3);
     const [first, second, third] = items;
-    expect(first.title).toBe("Hello World");
-    expect(first.url).toBe("https://example.com/posts/hello");
-    expect(first.rawGuid).toBe("post-001");
-    expect(first.author).toBe("Alice");
-    expect(first.summary).toContain("summary");
-    expect(first.publishedAt).toBe(new Date("Mon, 01 Jan 2024 12:00:00 GMT").toISOString());
+    expect.soft(first.title).toBe("Hello World");
+    expect.soft(first.url).toBe("https://example.com/posts/hello");
+    expect.soft(first.rawGuid).toBe("post-001");
+    expect.soft(first.author).toBe("Alice");
+    expect.soft(first.summary).toContain("summary");
+    expect.soft(first.publishedAt).toBe(new Date("Mon, 01 Jan 2024 12:00:00 GMT").toISOString());
 
-    expect(second.rawGuid).toBeNull();
-    expect(second.url).toBe("https://example.com/posts/second");
-    expect(second.summary).toBe("Plain summary text.");
+    expect.soft(second.rawGuid).toBeNull();
+    expect.soft(second.url).toBe("https://example.com/posts/second");
+    expect.soft(second.summary).toBe("Plain summary text.");
 
-    expect(third.url).toBeNull();
-    expect(third.title).toBe("Item with no link");
+    expect.soft(third.url).toBeNull();
+    expect.soft(third.title).toBe("Item with no link");
   });
 
   it("parses an Atom 1.0 feed", () => {
     const items = parseFeed(sampleAtom);
     expect(items.length).toBe(2);
-    expect(items[0].url).toBe("https://example.com/atom/1");
-    expect(items[0].rawGuid).toBe("tag:example.com,2024:atom:1");
-    expect(items[0].author).toBe("Bob");
-    expect(items[0].summary).toContain("Atom summary one");
-    expect(items[1].url).toBe("https://example.com/atom/2");
-    expect(items[1].summary).toContain("Body two");
+    expect.soft(items[0].url).toBe("https://example.com/atom/1");
+    expect.soft(items[0].rawGuid).toBe("tag:example.com,2024:atom:1");
+    expect.soft(items[0].author).toBe("Bob");
+    expect.soft(items[0].summary).toContain("Atom summary one");
+    expect.soft(items[1].url).toBe("https://example.com/atom/2");
+    expect.soft(items[1].summary).toContain("Body two");
   });
 
   it("returns empty when xml has no recognized root", () => {


### PR DESCRIPTION
## Summary

Refs #334 (Wave 2). Wave 1 (#346) covered \`tests/worker/api/articles/*\`. This Wave 2 expands the soft-assertion adoption to remaining \`tests/worker/\` files.

Where multiple independent observations on one response (status / Cache-Control header / body shape) are checked in a single test, switch to \`expect.soft(...)\` per \`.claude/rules/20-testing-overview.md\`. Sequential dependent assertions (e.g., \`toBeDefined()\` followed by index access) remain plain \`expect(...)\` to preserve fail-fast behavior.

## Affected files

- \`tests/worker/api/syndication.test.ts\` — status / Content-Type / body fields for all feed formats (JSON Feed, RSS, Atom, per-feed, category, author, lang)
- \`tests/worker/api/feeds.test.ts\` — status / body fields for list, filter, and `:id/health` endpoints
- \`tests/worker/api/admin.test.ts\` — status / body fields for enable toggle, collector run, and run detail endpoints
- \`tests/worker/api/health.test.ts\` — status / body fields for health and feed-health endpoints
- \`tests/worker/api/stats.test.ts\` — status / count fields for category_trend, feed_activity, top_authors, top_publishers, by_lang
- \`tests/worker/collector/alert.test.ts\` — webhook payload fields (text, blocks)
- \`tests/worker/collector/conditionalGet.test.ts\` — notModified / xml / etag / lastModified pairs
- \`tests/worker/collector/d1Disabled.test.ts\` — enabled feed ID set membership
- \`tests/worker/collector/metrics.test.ts\` — D1CostAccumulator stat fields (rowsRead / rowsWritten / duration)
- \`tests/worker/collector/retry.test.ts\` — fetchFeed result fields on first success
- \`tests/worker/collector/rssParser.test.ts\` — parsed item field values

## Test plan

- [x] \`pnpm test\` pass (616 tests / 45 files)
- [x] \`pnpm -r typecheck\` pass
- [x] \`pnpm check\` pass (no new errors)
- [x] Manual soft-assertion smoke: broke \`res.status\` and \`body.version\` in `/feed.json` test simultaneously, confirmed both failures reported in a single run

## Followups

- Wave 3: \`tests/client/**\` hook / component tests (separate PR)