### PR TITLE
fix(utils): dead code 削除・stripHtml の XML 制御文字除去

### DIFF
--- a/apps/web/tests/worker/utils/xml.test.ts
+++ b/apps/web/tests/worker/utils/xml.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
-import { asArray, parseXml, pickText } from "../../../worker/utils/xml";
+import { asArray, parseXml, pickText, stripHtml } from "../../../worker/utils/xml";
 
 // parseXml が返す型は unknown なので、テスト内では型アサーションで扱う
 type ParsedObj = Record<string, unknown>;
@@ -218,5 +218,72 @@ describe("asArray", () => {
   it("wraps number in an array", () => {
     expect(asArray(0)).toEqual([0]);
     expect(asArray(99)).toEqual([99]);
+  });
+});
+
+describe("stripHtml", () => {
+  it("returns null for null input", () => {
+    expect(stripHtml(null)).toBeNull();
+  });
+
+  it("returns null for undefined input", () => {
+    expect(stripHtml(undefined)).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(stripHtml("")).toBeNull();
+  });
+
+  it("strips basic HTML tags", () => {
+    expect(stripHtml("<p>Hello <b>world</b></p>")).toBe("Hello world");
+  });
+
+  it("strips script tags and their content", () => {
+    expect(stripHtml("<p>text</p><script>alert('xss')</script>")).toBe("text");
+  });
+
+  it("strips style tags and their content", () => {
+    expect(stripHtml("<style>body{color:red}</style><p>text</p>")).toBe("text");
+  });
+
+  it("decodes common HTML entities", () => {
+    // &nbsp; はスペースに変換され trim() で末尾スペースは除去される
+    expect(stripHtml("&amp;&lt;&gt;&quot;&#39;&nbsp;")).toBe("&<>\"'");
+  });
+
+  it("truncates to maxLen and appends ellipsis", () => {
+    expect(stripHtml("Hello world", 5)).toBe("Hello…");
+  });
+
+  it("does not truncate when text is shorter than maxLen", () => {
+    expect(stripHtml("Hi", 10)).toBe("Hi");
+  });
+
+  it("removes XML 1.0 forbidden control characters (U+0000-U+0008)", () => {
+    // NUL, SOH, STX, ETX, EOT, ENQ, ACK, BEL, BS はすべて除去される
+    const withControl = "hello\x00\x01\x02\x03\x04\x05\x06\x07\x08world";
+    expect(stripHtml(withControl)).toBe("helloworld");
+  });
+
+  it("removes XML 1.0 forbidden control characters (U+000B, U+000C)", () => {
+    // VT (vertical tab) と FF (form feed) は XML 1.0 で禁止
+    const withControl = "hello\x0B\x0Cworld";
+    expect(stripHtml(withControl)).toBe("helloworld");
+  });
+
+  it("removes XML 1.0 forbidden control characters (U+000E-U+001F)", () => {
+    // SO through US は XML 1.0 で禁止
+    const withControl = "hello\x0E\x1Fworld";
+    expect(stripHtml(withControl)).toBe("helloworld");
+  });
+
+  it("preserves tab (U+0009), LF (U+000A), CR (U+000D) as whitespace", () => {
+    // tab / LF / CR は XML 1.0 で許可されているホワイトスペース。\s+ で空白に正規化される
+    const withAllowed = "hello\x09\x0A\x0Dworld";
+    expect(stripHtml(withAllowed)).toBe("hello world");
+  });
+
+  it("returns null when input contains only control characters", () => {
+    expect(stripHtml("\x01\x02\x03")).toBeNull();
   });
 });

--- a/apps/web/worker/utils/types.ts
+++ b/apps/web/worker/utils/types.ts
@@ -18,17 +18,3 @@ export function makeOneOf<T extends string>(
   const set = new Set<string>(values);
   return (value): value is T => typeof value === "string" && set.has(value);
 }
-
-/**
- * 要素がすべて string の配列かどうかを確認する type guard。
- * JSON.parse した unknown な配列の型チェックに使う。
- */
-export function isStringArray(value: unknown): value is string[] {
-  return Array.isArray(value) && value.every((v) => typeof v === "string");
-}
-
-/**
- * 非空配列を表す型。
- * 「1 件以上の要素が存在することが保証されている配列」が必要な関数のシグネチャに使う。
- */
-export type NonEmptyArray<T> = [T, ...T[]];

--- a/apps/web/worker/utils/xml.ts
+++ b/apps/web/worker/utils/xml.ts
@@ -16,6 +16,11 @@ export function parseXml(xml: string): unknown {
   return parser.parse(xml);
 }
 
+// XML 1.0 で禁止されている制御文字 (U+0000-U+0008, U+000B, U+000C, U+000E-U+001F)
+// RSS/Atom 本文に含まれていると、XML 出力時に Invalid XML になるため除去する
+// oxlint-disable-next-line no-control-regex -- 意図的に制御文字を対象とした正規表現
+const XML_INVALID_CHARS_RE = /[\x00-\x08\x0B\x0C\x0E-\x1F]/g;
+
 export function stripHtml(input: string | null | undefined, maxLen?: number): string | null {
   if (!input) return null;
   const text = input
@@ -28,6 +33,7 @@ export function stripHtml(input: string | null | undefined, maxLen?: number): st
     .replace(/&gt;/g, ">")
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
+    .replace(XML_INVALID_CHARS_RE, "")
     .replace(/\s+/g, " ")
     .trim();
   if (!text) return null;


### PR DESCRIPTION
## 概要

`apps/web/worker/utils/` 配下の監査で発見した 2 件の問題を修正する。

## 変更内容

### 1. `types.ts` — dead code 削除
- `isStringArray` 関数と `NonEmptyArray<T>` 型をプロジェクト全体で検索した結果、どこからも import されていないことを確認
- YAGNI 原則と `01-typescript.md` の「dead code は速やかに削除」方針に従い削除

### 2. `xml.ts` — `stripHtml` で XML 1.0 禁止制御文字を除去
- XML 1.0 では U+0000–U+0008, U+000B, U+000C, U+000E–U+001F の制御文字が禁止
- RSS/Atom 本文にこれらが含まれると、XML フィード出力時に Invalid XML になる可能性がある
- `stripHtml` の処理パイプラインに除去ステップを追加
- tab (U+0009)・LF (U+000A)・CR (U+000D) は XML 1.0 で許可されているため除去しない

### 3. `tests/worker/utils/xml.test.ts` — `stripHtml` テスト追加
- 14 件のエッジケーステストを追加（null/undefined/空文字・HTML タグ/エンティティ・制御文字・トランケーション）

## 変更しなかった箇所

- `etag.ts`: ETag 生成は決定的（同一入力 → 同一 SHA-256 ハッシュ）。If-None-Match の比較は呼び出し側 (`worker/api/`) で行われており `api/` は変更対象外のため対処なし
- `api/` 配下の `escapeXml` 重複定義: `worker/api/` は変更禁止のため対処なし

## テスト

- [x] `vp test run tests/worker/utils/` — 62 件全パス (types: 9件, xml: 53件→新規14件含む)
- [x] `pnpm -C apps/web build` — ビルド成功
- [x] `tsc --noEmit` — 型エラーなし
- [x] `pnpm lint` — 新規警告・エラーなし (noControlCharactersInRegex は oxlint-disable-next-line で明示的に抑制)