### PR TITLE
chore(ci): add explicit minimum permissions to 6 workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/cleanup-orphan-previews.yml
+++ b/.github/workflows/cleanup-orphan-previews.yml
@@ -14,6 +14,8 @@ on:
         type: boolean
         default: true
 
+permissions: {}
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
 
+permissions: {}
+
 jobs:
   deploy-preview:
     if: github.event.action != 'closed'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,6 +7,9 @@ on:
     # 毎週月曜 00:00 UTC に実行
     - cron: "0 0 * * 1"
 
+permissions:
+  contents: read
+
 jobs:
   audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-feeds.yml
+++ b/.github/workflows/validate-feeds.yml
@@ -9,6 +9,9 @@ on:
     - cron: "0 0 * * 0"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 概要

GitHub Actions のデフォルト token スコープを最小化するため、`permissions:` ブロックが未設定だった 6 つの workflow にトップレベルの `permissions:` ブロックを追加します。

> **変更前後の挙動**: 権限の明示化のみで、各 workflow の実行ステップ・振る舞いは一切変更していません。

---

## 変更内容と付与理由

| workflow | 追加した permissions | 理由 |
|---|---|---|
| `ci.yml` | `contents: read` | `actions/checkout` のみ。GitHub API 呼び出しなし。build/lint/test のみ実行 |
| `cleanup-orphan-previews.yml` | `permissions: {}` (トップレベル) | job レベルで `pull-requests: read` を設定済み。`gh pr list` で PR 一覧参照。Cloudflare API は外部 secret 経由 |
| `e2e.yml` | `contents: read` | `actions/checkout` + Playwright 実行 + `actions/upload-artifact` のみ |
| `preview.yml` | `permissions: {}` (トップレベル) | 両 job で `pull-requests: write` を設定済み (`peter-evans/create-or-update-comment` によるコメント投稿) |
| `security.yml` | `contents: read` | `pnpm audit` のみ実行。Security Alerts API は使用しない |
| `validate-feeds.yml` | `contents: read` | `node tools/validate-feeds.mjs` のみ実行 |

### `permissions: {}` を使った理由 (`cleanup-orphan-previews.yml`, `preview.yml`)

これら 2 つはすでに **job レベルで最小権限が設定済み**です。トップレベルに `permissions: {}` (全スコープ拒否) を追加することで、job レベルの設定だけが有効になり、デフォルト token スコープが適用されることを防ぎます。

### 触っていない workflow

`deploy.yml`, `report-daily.yml`, `report-weekly.yml`, `report-monthly.yml` は既に `permissions:` 設定済みのため対象外。

---

## テスト

- [x] `actionlint` でエラーなし (6 ファイルすべて)
- [x] 各 workflow の step を再確認し、権限不足になる操作がないことを確認
- [ ] CI で実際の workflow が通ることを確認 (PR のチェックで確認)