### PR TITLE
test(articles): adopt soft assertions for independent observations

### DIFF
--- a/apps/web/tests/worker/api/articles/archive.test.ts
+++ b/apps/web/tests/worker/api/articles/archive.test.ts
@@ -95,30 +95,30 @@ describe("GET /api/articles/archive", () => {
     ]);
 
     const res = await SELF.fetch("https://example.com/api/articles/archive?year=2024&month=4");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{
       year: number;
       month: number;
       items: { published_at: string }[];
       total: number;
     }>();
-    expect(body.year).toBe(2024);
-    expect(body.month).toBe(4);
-    expect(body.total).toBe(3);
-    expect(body.items.length).toBe(3);
+    expect.soft(body.year).toBe(2024);
+    expect.soft(body.month).toBe(4);
+    expect.soft(body.total).toBe(3);
+    expect.soft(body.items.length).toBe(3);
     for (const item of body.items) {
-      expect(item.published_at >= "2024-04-01T00:00:00.000Z").toBe(true);
-      expect(item.published_at < "2024-05-01T00:00:00.000Z").toBe(true);
+      expect.soft(item.published_at >= "2024-04-01T00:00:00.000Z").toBe(true);
+      expect.soft(item.published_at < "2024-05-01T00:00:00.000Z").toBe(true);
     }
   });
 
   it("returns items in published_at descending order", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/archive?year=2024&month=4");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ items: { published_at: string }[] }>();
     const dates = body.items.map((a) => a.published_at);
     const sorted = dates.toSorted((a, b) => b.localeCompare(a));
-    expect(dates).toEqual(sorted);
+    expect.soft(dates).toEqual(sorted);
   });
 
   it("returns limited items but total reflects full count (total > limit)", async () => {
@@ -139,10 +139,10 @@ describe("GET /api/articles/archive", () => {
     const res = await SELF.fetch(
       "https://example.com/api/articles/archive?year=2024&month=4&limit=10",
     );
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ items: unknown[]; total: number }>();
-    expect(body.items.length).toBe(10);
-    expect(body.total).toBe(15);
+    expect.soft(body.items.length).toBe(10);
+    expect.soft(body.total).toBe(15);
   });
 
   it("correctly handles December to January year wrap (2025-12)", async () => {
@@ -172,38 +172,39 @@ describe("GET /api/articles/archive", () => {
     ]);
 
     const res = await SELF.fetch("https://example.com/api/articles/archive?year=2025&month=12");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ items: { published_at: string }[]; total: number }>();
-    expect(body.total).toBe(1);
+    expect.soft(body.total).toBe(1);
+    // items[0] へのアクセスは length > 0 が前提のため fail-fast で確認
     expect(body.items.length).toBe(1);
-    expect(body.items[0].published_at).toBe("2025-12-15T12:00:00.000Z");
+    expect.soft(body.items[0].published_at).toBe("2025-12-15T12:00:00.000Z");
   });
 
   it("returns Cache-Control: public, max-age=600", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/archive?year=2024&month=4");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Cache-Control")).toBe("public, max-age=600");
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Cache-Control")).toBe("public, max-age=600");
   });
 
   it("returns Content-Type application/json", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/archive?year=2024&month=4");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Content-Type")).toMatch(/application\/json/);
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Content-Type")).toMatch(/application\/json/);
   });
 
   it("filters by year + month + category simultaneously", async () => {
     const res = await SELF.fetch(
       "https://example.com/api/articles/archive?year=2024&month=4&category=ai",
     );
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{
       items: { category: string; published_at: string }[];
       total: number;
     }>();
     // 2024-04 に ai が 2 件 (o-ai-1, o-ai-2)
-    expect(body.total).toBe(2);
+    expect.soft(body.total).toBe(2);
     for (const item of body.items) {
-      expect(item.category).toBe("ai");
+      expect.soft(item.category).toBe("ai");
     }
   });
 });

--- a/apps/web/tests/worker/api/articles/get-by-id.test.ts
+++ b/apps/web/tests/worker/api/articles/get-by-id.test.ts
@@ -15,7 +15,7 @@ describe("GET /api/articles/:id", () => {
     const id = row?.id;
 
     const res = await SELF.fetch(`https://example.com/api/articles/${id}`);
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
 
     const body = await res.json<{
       id: number;
@@ -31,28 +31,28 @@ describe("GET /api/articles/:id", () => {
       category: string;
       lang: string;
     }>();
-    expect(body.id).toBe(id);
-    expect(body.guid).toBe("g-bt-1");
-    expect(body.feed_id).toBe("google-research");
-    expect(body.title).toBe("BigTech Article One");
-    expect(body.url).toBe("https://x.test/g/1");
-    expect(body.category).toBe("bigtech");
-    expect(body.lang).toBe("en");
-    expect(typeof body.fetched_at).toBe("string");
+    expect.soft(body.id).toBe(id);
+    expect.soft(body.guid).toBe("g-bt-1");
+    expect.soft(body.feed_id).toBe("google-research");
+    expect.soft(body.title).toBe("BigTech Article One");
+    expect.soft(body.url).toBe("https://x.test/g/1");
+    expect.soft(body.category).toBe("bigtech");
+    expect.soft(body.lang).toBe("en");
+    expect.soft(typeof body.fetched_at).toBe("string");
   });
 
   it("returns 404 for non-existent id", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/99999999");
-    expect(res.status).toBe(404);
+    expect.soft(res.status).toBe(404);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toBe("not found");
+    expect.soft(body.error).toBe("not found");
   });
 
   it("returns 400 for non-integer id", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/abc");
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toBe("invalid id");
+    expect.soft(body.error).toBe("invalid id");
   });
 
   it("returns 304 when If-None-Match matches ETag", async () => {
@@ -61,7 +61,7 @@ describe("GET /api/articles/:id", () => {
       .first<{ id: number }>();
     const id = row?.id;
 
-    // 1回目のリクエストで ETag を取得
+    // 1回目のリクエストで ETag を取得。etag は後続リクエストの前提のため fail-fast
     const res1 = await SELF.fetch(`https://example.com/api/articles/${id}`);
     expect(res1.status).toBe(200);
     const etag = res1.headers.get("ETag");
@@ -81,8 +81,8 @@ describe("GET /api/articles/:id", () => {
     const id = row?.id;
 
     const res = await SELF.fetch(`https://example.com/api/articles/${id}`);
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const contentType = res.headers.get("Content-Type");
-    expect(contentType).toMatch(/application\/json/);
+    expect.soft(contentType).toMatch(/application\/json/);
   });
 });

--- a/apps/web/tests/worker/api/articles/neighbors.test.ts
+++ b/apps/web/tests/worker/api/articles/neighbors.test.ts
@@ -16,9 +16,9 @@ describe("GET /api/articles/:guid/neighbors", () => {
 
   it("returns 404 for unknown guid", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/unknown-guid-xyz/neighbors");
-    expect(res.status).toBe(404);
+    expect.soft(res.status).toBe(404);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toBe("not found");
+    expect.soft(body.error).toBe("not found");
   });
 
   it("returns prev and next both non-null for a middle article", async () => {
@@ -38,32 +38,35 @@ describe("GET /api/articles/:guid/neighbors", () => {
     ]);
 
     const res = await SELF.fetch("https://example.com/api/articles/o-ai-2/neighbors");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ prev: Article; next: Article }>();
+    // prev/next の null チェックは .guid アクセスの前提のため fail-fast
     expect(body.prev).not.toBeNull();
     expect(body.next).not.toBeNull();
-    expect(body.prev.guid).toBe("o-ai-1");
-    expect(body.next.guid).toBe("o-ai-3");
+    expect.soft(body.prev.guid).toBe("o-ai-1");
+    expect.soft(body.next.guid).toBe("o-ai-3");
   });
 
   it("returns prev=null for the oldest article in feed", async () => {
     // o-ai-1 は openai-blog で最も古い
     const res = await SELF.fetch("https://example.com/api/articles/o-ai-1/neighbors");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ prev: Article | null; next: Article | null }>();
-    expect(body.prev).toBeNull();
+    expect.soft(body.prev).toBeNull();
+    // next not null チェックは next!.guid アクセスの前提のため fail-fast
     expect(body.next).not.toBeNull();
-    expect(body.next!.guid).toBe("o-ai-2");
+    expect.soft(body.next!.guid).toBe("o-ai-2");
   });
 
   it("returns next=null for the newest article in feed", async () => {
     // o-ai-2 は openai-blog で最も新しい
     const res = await SELF.fetch("https://example.com/api/articles/o-ai-2/neighbors");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ prev: Article | null; next: Article | null }>();
-    expect(body.next).toBeNull();
+    expect.soft(body.next).toBeNull();
+    // prev not null チェックは prev!.guid アクセスの前提のため fail-fast
     expect(body.prev).not.toBeNull();
-    expect(body.prev!.guid).toBe("o-ai-1");
+    expect.soft(body.prev!.guid).toBe("o-ai-1");
   });
 
   it("tie-breaks by guid lexicographic order when published_at is identical", async () => {
@@ -107,31 +110,32 @@ describe("GET /api/articles/:guid/neighbors", () => {
     ]);
 
     const res = await SELF.fetch("https://example.com/api/articles/tie-b/neighbors");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ prev: Article; next: Article }>();
-    expect(body.prev.guid).toBe("tie-a");
-    expect(body.next.guid).toBe("tie-c");
+    // prev/next の .guid アクセスは型上 non-null なため直接 soft で検証
+    expect.soft(body.prev.guid).toBe("tie-a");
+    expect.soft(body.next.guid).toBe("tie-c");
   });
 
   it("does not return articles from a different feed", async () => {
     // g-bt-1 は google-research フィード。openai-blog 記事は neighbors に現れない
     const res = await SELF.fetch("https://example.com/api/articles/g-bt-1/neighbors");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ prev: Article | null; next: Article | null }>();
     // google-research には g-bt-1 のみなので両方 null
-    expect(body.prev).toBeNull();
-    expect(body.next).toBeNull();
+    expect.soft(body.prev).toBeNull();
+    expect.soft(body.next).toBeNull();
   });
 
   it("returns Cache-Control: public, max-age=300", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/o-ai-1/neighbors");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Cache-Control")).toBe("public, max-age=300");
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Cache-Control")).toBe("public, max-age=300");
   });
 
   it("returns Content-Type: application/json", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/o-ai-1/neighbors");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Content-Type")).toMatch(/application\/json/);
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Content-Type")).toMatch(/application\/json/);
   });
 });

--- a/apps/web/tests/worker/api/articles/related.test.ts
+++ b/apps/web/tests/worker/api/articles/related.test.ts
@@ -14,23 +14,23 @@ describe("GET /api/articles/:guid/related", () => {
     const res = await SELF.fetch(
       "https://example.com/api/articles/unknown-guid-does-not-exist/related",
     );
-    expect(res.status).toBe(404);
+    expect.soft(res.status).toBe(404);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toBe("not found");
+    expect.soft(body.error).toBe("not found");
   });
 
   it("returns 400 when n=0", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/o-ai-1/related?n=0");
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toBe("n must be 1-20");
+    expect.soft(body.error).toBe("n must be 1-20");
   });
 
   it("returns 400 when n=21", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/o-ai-1/related?n=21");
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toBe("n must be 1-20");
+    expect.soft(body.error).toBe("n must be 1-20");
   });
 
   it("returns same feed articles when enough exist", async () => {
@@ -94,11 +94,11 @@ describe("GET /api/articles/:guid/related", () => {
     ]);
 
     const res = await SELF.fetch("https://example.com/api/articles/o-ai-1/related?n=5");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ items: Article[] }>();
     expect(body.items.length).toBe(5);
     for (const item of body.items) {
-      expect(item.feed_id).toBe("openai-blog");
+      expect.soft(item.feed_id).toBe("openai-blog");
     }
   });
 
@@ -188,25 +188,26 @@ describe("GET /api/articles/:guid/related", () => {
     // g-bt-1 の関連記事を n=5 で取得
     // 同 feed (google-research) には g-bt-2 の 1 件、残り 4 件は meta-engineering から
     const res = await SELF.fetch("https://example.com/api/articles/g-bt-1/related?n=5");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ items: Article[] }>();
+    // items[0] へのアクセスは length > 0 が前提のため fail-fast
     expect(body.items.length).toBe(5);
 
     // 先頭が同 feed
-    expect(body.items[0].feed_id).toBe("google-research");
+    expect.soft(body.items[0].feed_id).toBe("google-research");
     // 残りは meta-engineering (同 category)
     for (const item of body.items.slice(1)) {
-      expect(item.feed_id).toBe("meta-engineering");
-      expect(item.category).toBe("bigtech");
+      expect.soft(item.feed_id).toBe("meta-engineering");
+      expect.soft(item.category).toBe("bigtech");
     }
   });
 
   it("does not include the target article itself in items", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/o-ai-1/related");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ items: Article[] }>();
     for (const item of body.items) {
-      expect(item.guid).not.toBe("o-ai-1");
+      expect.soft(item.guid).not.toBe("o-ai-1");
     }
   });
 
@@ -228,23 +229,24 @@ describe("GET /api/articles/:guid/related", () => {
 
     // o-ai-1 の関連: o-ai-3 (2024-04-04) → o-ai-2 (2024-04-03) の順
     const res = await SELF.fetch("https://example.com/api/articles/o-ai-1/related?n=5");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = await res.json<{ items: Article[] }>();
     const sameFeed = body.items.filter((i) => i.feed_id === "openai-blog");
+    // sameFeed[0/1] アクセスは length >= 2 が前提のため fail-fast
     expect(sameFeed.length).toBeGreaterThanOrEqual(2);
-    expect(sameFeed[0].published_at >= sameFeed[1].published_at).toBe(true);
+    expect.soft(sameFeed[0].published_at >= sameFeed[1].published_at).toBe(true);
   });
 
   it("returns Content-Type application/json", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/o-ai-1/related");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Content-Type")).toMatch(/application\/json/);
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Content-Type")).toMatch(/application\/json/);
   });
 
   it("returns Cache-Control with max-age=300", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/o-ai-1/related");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const cc = res.headers.get("Cache-Control");
-    expect(cc).toContain("max-age=300");
+    expect.soft(cc).toContain("max-age=300");
   });
 });


### PR DESCRIPTION
## Summary

Issue #334 の一部として、`apps/web/tests/worker/api/articles/` 配下の 4 ファイルに `expect.soft()` を導入する。

- `archive.test.ts` — status / body fields / header の独立観点を soft 化
- `get-by-id.test.ts` — status / body fields / header の独立観点を soft 化
- `neighbors.test.ts` — status / body fields / header を soft 化
- `related.test.ts` — status / body fields / header を soft 化

残り 7 ファイル（by-author / by-category / by-day / by-feed / calendar / random / search）はすでに expect.soft が適用済みのため変更なし。

## Fail-fast を残した箇所と理由

| ファイル | 箇所 | 理由 |
|---|---|---|
| archive.test.ts | `expect(body.items.length).toBe(1)` (December wrap) | 直後の `body.items[0]` アクセスが length>0 を前提とするため |
| get-by-id.test.ts | `expect(res1.status).toBe(200)` / `expect(etag).not.toBeNull()` (304テスト) | etag を 2 回目リクエストに使うため前提が崩れると後続が無意味 |
| neighbors.test.ts | `expect(body.prev/next).not.toBeNull()` | 直後の `.guid` アクセスの前提（null の場合 NPE） |
| related.test.ts | `expect(body.items.length).toBe(5)` | 直後の `body.items[0]` アクセスおよびループの前提 |
| related.test.ts | `expect(sameFeed.length).toBeGreaterThanOrEqual(2)` | 直後の `sameFeed[0/1]` アクセスの前提 |

## Test plan

- [x] 変更 4 ファイルのテスト: 39 tests passed
- [x] `pnpm test` (全 worker テスト): 678 tests passed
- [x] `pnpm vp check --fix`: 0 errors

Refs #334