### PR TITLE
chore(workflows): consolidate recent.mjs calls using comma-separated --category

### DIFF
--- a/.github/workflows/report-daily.yml
+++ b/.github/workflows/report-daily.yml
@@ -53,11 +53,9 @@ jobs:
             - zenn カテゴリは除外 (bigtech / ai / jp の 3 カテゴリを対象にする)
             - lang 指定なし
 
-            Stage 1 では bigtech / ai / jp の 3 カテゴリをそれぞれ取得してマージしてください:
-              node tools/d1-client/recent.mjs --since=today --category=bigtech --target=remote
-              node tools/d1-client/recent.mjs --since=today --category=ai      --target=remote
-              node tools/d1-client/recent.mjs --since=today --category=jp      --target=remote
-            3 つの articles[] を結合し URL de-dup (古い published_at 優先) する。
+            Stage 1 では bigtech / ai / jp の 3 カテゴリを 1 回の呼び出しで取得してください:
+              node tools/d1-client/recent.mjs --since=today --category=bigtech,ai,jp --target=remote --limit=600
+            取得した articles[] を対象に URL de-dup (古い published_at 優先) する。
             以降の Stage はマージ済み articles を対象とする。
 
             Stage 1〜4 を完走したあと、最終的な markdown レポート全文を /tmp/report.md に

--- a/.github/workflows/report-monthly.yml
+++ b/.github/workflows/report-monthly.yml
@@ -47,14 +47,13 @@ jobs:
             tech-news-weekly skill を以下の引数で起動してください:
             - since=month
             - target=remote
-            - limit=500
+            - limit=1000
             - bigtech と ai の 2 カテゴリを対象にする
             - lang 指定なし
 
-            Stage 1 では bigtech / ai の 2 カテゴリをそれぞれ取得してマージしてください:
-              node tools/d1-client/recent.mjs --since=month --category=bigtech --target=remote --limit=500
-              node tools/d1-client/recent.mjs --since=month --category=ai      --target=remote --limit=500
-            2 つの articles[] を結合し URL de-dup (古い published_at 優先) する。
+            Stage 1 では bigtech / ai の 2 カテゴリを 1 回の呼び出しで取得してください:
+              node tools/d1-client/recent.mjs --since=month --category=bigtech,ai --target=remote --limit=1000
+            取得した articles[] を対象に URL de-dup (古い published_at 優先) する。
             以降の Stage はマージ済み articles を対象とする。
 
             Stage 1〜4 を完走したあと、最終的な markdown レポート全文を /tmp/report.md に
@@ -79,7 +78,7 @@ jobs:
             }
 
             注意:
-            - recent.mjs を呼ぶときは --target=remote と --limit=500 を必ず指定してください。
+            - recent.mjs を呼ぶときは --target=remote と --limit=1000 を必ず指定してください。
             - 最終 markdown 出力以外のアシスタント発話は最小限に抑えてください。
             - WebFetch が失敗した記事には (summary based) を末尾に付けてください。
 

--- a/.github/workflows/report-weekly.yml
+++ b/.github/workflows/report-weekly.yml
@@ -49,10 +49,9 @@ jobs:
             - bigtech と ai の 2 カテゴリを対象にする
             - lang 指定なし
 
-            Stage 1 では bigtech / ai の 2 カテゴリをそれぞれ取得してマージしてください:
-              node tools/d1-client/recent.mjs --since=week --category=bigtech --target=remote
-              node tools/d1-client/recent.mjs --since=week --category=ai      --target=remote
-            2 つの articles[] を結合し URL de-dup (古い published_at 優先) する。
+            Stage 1 では bigtech / ai の 2 カテゴリを 1 回の呼び出しで取得してください:
+              node tools/d1-client/recent.mjs --since=week --category=bigtech,ai --target=remote --limit=400
+            取得した articles[] を対象に URL de-dup (古い published_at 優先) する。
             以降の Stage はマージ済み articles を対象とする。
 
             Stage 1〜4 を完走したあと、最終的な markdown レポート全文を /tmp/report.md に


### PR DESCRIPTION
## Summary

PR #337 で `tools/d1-client/recent.mjs` に追加されたカンマ区切り `--category` 対応を、GitHub Actions workflow で活用できていなかった問題を修正する。

- `report-daily.yml`: `bigtech` / `ai` / `jp` を 3 回個別呼び出し → `--category=bigtech,ai,jp --limit=600` で 1 回に統合
- `report-weekly.yml`: `bigtech` / `ai` を 2 回個別呼び出し → `--category=bigtech,ai --limit=400` で 1 回に統合
- `report-monthly.yml`: `bigtech` / `ai` を 2 回個別呼び出し → `--category=bigtech,ai --limit=1000` で 1 回に統合

## 動作互換性が保たれる根拠

`recent.mjs` の `--category` は `category IN ('bigtech','ai',...)` として単一の SQL クエリに展開されるため、複数カテゴリを一括取得した結果は複数回呼び出して `articles[]` を手動結合した場合と等価。

URL による de-dup は `recent.mjs` 内部で処理済みのため、呼び出し側での再 de-dup は不要。

## `--limit` の変化について

`--limit` は「全カテゴリ合算で最大 N 件」を意味する (SQL の `LIMIT` に直接対応)。旧実装はカテゴリごとに独立した `LIMIT` を持つ別クエリだったため、カテゴリ数分の件数を合算した値を新 limit に設定した。

| workflow | 旧 (各カテゴリ) | 新 (合算) | 上限 |
|---|---|---|---|
| daily | 200 × 3 = 600 | 600 | 1000 |
| weekly | 200 × 2 = 400 | 400 | 1000 |
| monthly | 500 × 2 = 1000 | 1000 | 1000 (max) |

`recent.mjs` の SQL は `LIMIT ${Math.max(1, Math.min(limit, 1000))}` でハードキャップされるため、monthly は 1000 が実効上限。

Closes #311