### PR TITLE
fix(workflows): pin Claude model to sonnet in report workflows

### DIFF
--- a/.github/workflows/report-daily.yml
+++ b/.github/workflows/report-daily.yml
@@ -41,8 +41,8 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # 廃止モデル (claude-3-5-haiku-20241022) への自動 fallback で 404 が出るため
-          # 現行 sonnet を明示する。alias で CLI 側が最新を解決。
-          claude_args: "--model sonnet"
+          # 現行 sonnet を明示する。
+          model: "claude-sonnet-4-5-20250929"
           allowed_tools: "Bash,Read,Write,WebFetch,Skill"
           timeout_minutes: 30
           # daily digest 生成プロンプト。skill 起動と最終ファイル書き出しを明示する。

--- a/.github/workflows/report-daily.yml
+++ b/.github/workflows/report-daily.yml
@@ -40,6 +40,9 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # 廃止モデル (claude-3-5-haiku-20241022) への自動 fallback で 404 が出るため
+          # 現行 sonnet を明示する。alias で CLI 側が最新を解決。
+          claude_args: "--model sonnet"
           allowed_tools: "Bash,Read,Write,WebFetch,Skill"
           timeout_minutes: 30
           # daily digest 生成プロンプト。skill 起動と最終ファイル書き出しを明示する。

--- a/.github/workflows/report-daily.yml
+++ b/.github/workflows/report-daily.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Run tech-news-digest skill
         uses: anthropics/claude-code-base-action@beta
         env:
+          # claude-code-base-action 内部の Setup Node.js が default 18 を入れるため、
+          # wrangler d1 (Node v20+ 必須) が落ちる。skill が呼ぶ recent.mjs のために 24 を強制。
+          NODE_VERSION: "24"
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         with:

--- a/.github/workflows/report-monthly.yml
+++ b/.github/workflows/report-monthly.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Run tech-news-weekly skill (monthly)
         uses: anthropics/claude-code-base-action@beta
         env:
+          # claude-code-base-action 内部の Setup Node.js が default 18 を入れるため、
+          # wrangler d1 (Node v20+ 必須) が落ちる。skill が呼ぶ recent.mjs のために 24 を強制。
+          NODE_VERSION: "24"
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         with:

--- a/.github/workflows/report-monthly.yml
+++ b/.github/workflows/report-monthly.yml
@@ -39,8 +39,8 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # 廃止モデル (claude-3-5-haiku-20241022) への自動 fallback で 404 が出るため
-          # 現行 sonnet を明示する。alias で CLI 側が最新を解決。
-          claude_args: "--model sonnet"
+          # 現行 sonnet を明示する。
+          model: "claude-sonnet-4-5-20250929"
           allowed_tools: "Bash,Read,Write,WebFetch,Skill"
           timeout_minutes: 45
           # monthly digest 生成プロンプト。tech-news-weekly skill を since=month で起動する。

--- a/.github/workflows/report-monthly.yml
+++ b/.github/workflows/report-monthly.yml
@@ -38,6 +38,9 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # 廃止モデル (claude-3-5-haiku-20241022) への自動 fallback で 404 が出るため
+          # 現行 sonnet を明示する。alias で CLI 側が最新を解決。
+          claude_args: "--model sonnet"
           allowed_tools: "Bash,Read,Write,WebFetch,Skill"
           timeout_minutes: 45
           # monthly digest 生成プロンプト。tech-news-weekly skill を since=month で起動する。

--- a/.github/workflows/report-weekly.yml
+++ b/.github/workflows/report-weekly.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Run tech-news-weekly skill
         uses: anthropics/claude-code-base-action@beta
         env:
+          # claude-code-base-action 内部の Setup Node.js が default 18 を入れるため、
+          # wrangler d1 (Node v20+ 必須) が落ちる。skill が呼ぶ recent.mjs のために 24 を強制。
+          NODE_VERSION: "24"
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         with:

--- a/.github/workflows/report-weekly.yml
+++ b/.github/workflows/report-weekly.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # 廃止モデル (claude-3-5-haiku-20241022) への自動 fallback で 404 が出るため
-          # 現行 sonnet を明示する。alias で CLI 側が最新を解決。
-          claude_args: "--model sonnet"
+          # 現行 sonnet を明示する。
+          model: "claude-sonnet-4-5-20250929"
           allowed_tools: "Bash,Read,Write,WebFetch,Skill"
           timeout_minutes: 30
           # weekly digest 生成プロンプト。skill 起動と最終ファイル書き出しを明示する。

--- a/.github/workflows/report-weekly.yml
+++ b/.github/workflows/report-weekly.yml
@@ -37,6 +37,9 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # 廃止モデル (claude-3-5-haiku-20241022) への自動 fallback で 404 が出るため
+          # 現行 sonnet を明示する。alias で CLI 側が最新を解決。
+          claude_args: "--model sonnet"
           allowed_tools: "Bash,Read,Write,WebFetch,Skill"
           timeout_minutes: 30
           # weekly digest 生成プロンプト。skill 起動と最終ファイル書き出しを明示する。


### PR DESCRIPTION
## Summary

- 3 つの report workflow (`report-daily.yml` / `report-weekly.yml` / `report-monthly.yml`) で `anthropics/claude-code-base-action@beta` 起動時に `claude_args: --model sonnet` を追加し、利用モデルを明示する。
- 直近の `Run tech-news-digest skill` ステップで `model: claude-3-5-haiku-20241022` への 404 エラーが多発していたため、廃止モデルへの自動 fallback 解決を断つ。

## Why

run [25138206272](https://github.com/rikeda71/tech-news-bot/actions/runs/25138206272) の log で以下が複数回観測:

```
API Error: 404 {"type":"error","error":{"type":"not_found_error",
"message":"model: claude-3-5-haiku-20241022"}}
```

Workflow 自体は最終的に成功し Slack 投稿も完了していたが、廃止モデル参照が残ると将来的に skill 実行が完全に失敗するリスクがある。

## Approach

- skill 側 (`SKILL.md`) にはモデル指定の機構がないため、起動側 (workflow) で指定する。
- alias `sonnet` を使い CLI 側が現行最新の sonnet を解決する形にして、世代更新時の workflow 修正を不要にする。
- haiku ではなく sonnet を選んだ理由: skill が Stage 4 (トレンド分析) や WebFetch deep mode で意味理解を要するため、品質維持を優先。

## Test plan

- [ ] CI green
- [ ] `workflow_dispatch` で `Report Daily` を手動実行し、`model: claude-3-5-haiku-20241022` 関連の 404 が出ないことを確認
- [ ] skill 出力が想定通り (`/tmp/report.md` に必須節が含まれる) で D1 保存 + Slack 投稿が成功することを確認