### PR TITLE
test(client): adopt soft assertions for independent observations (Wave 3)

### DIFF
--- a/apps/web/tests/client/BookmarkButton.test.tsx
+++ b/apps/web/tests/client/BookmarkButton.test.tsx
@@ -27,8 +27,8 @@ describe("BookmarkButton", () => {
     const btn = screen.getByRole("button");
     await user.click(btn);
     // ブックマーク追加後は aria-pressed=true になる
-    expect(btn.getAttribute("aria-pressed")).toBe("true");
-    expect(btn.textContent).toContain("★");
+    expect.soft(btn.getAttribute("aria-pressed")).toBe("true");
+    expect.soft(btn.textContent).toContain("★");
   });
 
   it("toggles back to false when clicked twice", async () => {
@@ -37,8 +37,8 @@ describe("BookmarkButton", () => {
     const btn = screen.getByRole("button");
     await user.click(btn);
     await user.click(btn);
-    expect(btn.getAttribute("aria-pressed")).toBe("false");
-    expect(btn.textContent).toContain("☆");
+    expect.soft(btn.getAttribute("aria-pressed")).toBe("false");
+    expect.soft(btn.textContent).toContain("☆");
   });
 
   it("aria-label reflects current state", async () => {

--- a/apps/web/tests/client/CalendarHeatmap.test.tsx
+++ b/apps/web/tests/client/CalendarHeatmap.test.tsx
@@ -85,8 +85,8 @@ describe("CalendarHeatmap", () => {
     const cells = container.querySelectorAll("[data-level][aria-label]");
     expect(cells.length).toBeGreaterThan(0);
     const labels = Array.from(cells).map((c) => c.getAttribute("aria-label") ?? "");
-    expect(labels.some((l) => l.includes("5件"))).toBe(true);
-    expect(labels.some((l) => l.includes("月") && l.includes("日"))).toBe(true);
+    expect.soft(labels.some((l) => l.includes("5件"))).toBe(true);
+    expect.soft(labels.some((l) => l.includes("月") && l.includes("日"))).toBe(true);
   });
 
   it("count=0 のセルは data-level=0 が付与される", async () => {

--- a/apps/web/tests/client/CategoriesOverview.test.tsx
+++ b/apps/web/tests/client/CategoriesOverview.test.tsx
@@ -71,9 +71,9 @@ describe("CategoriesOverview", () => {
       expect(screen.getByText("Big Tech")).toBeTruthy();
     });
 
-    expect(screen.getByText("AI")).toBeTruthy();
-    expect(screen.getByText("日本企業")).toBeTruthy();
-    expect(screen.getByText("Zenn")).toBeTruthy();
+    expect.soft(screen.getByText("AI")).toBeTruthy();
+    expect.soft(screen.getByText("日本企業")).toBeTruthy();
+    expect.soft(screen.getByText("Zenn")).toBeTruthy();
   });
 
   it("feeds_count と articles_30d を表示する", async () => {
@@ -93,8 +93,8 @@ describe("CategoriesOverview", () => {
 
     // bigtech: feeds_count=5, articles_30d=120
     const statValues = screen.getAllByText("5");
-    expect(statValues.length).toBeGreaterThan(0);
-    expect(screen.getByText("120")).toBeTruthy();
+    expect.soft(statValues.length).toBeGreaterThan(0);
+    expect.soft(screen.getByText("120")).toBeTruthy();
   });
 
   it("last_published_at が null の場合は「—」を表示する", async () => {

--- a/apps/web/tests/client/EmptyState.test.tsx
+++ b/apps/web/tests/client/EmptyState.test.tsx
@@ -8,18 +8,18 @@ describe("EmptyState", () => {
     render(
       <EmptyState icon="🔍" title="記事が見つかりません" body="別のキーワードで検索してください" />,
     );
-    expect(screen.getByText("🔍")).toBeTruthy();
-    expect(screen.getByText("記事が見つかりません")).toBeTruthy();
-    expect(screen.getByText("別のキーワードで検索してください")).toBeTruthy();
+    expect.soft(screen.getByText("🔍")).toBeTruthy();
+    expect.soft(screen.getByText("記事が見つかりません")).toBeTruthy();
+    expect.soft(screen.getByText("別のキーワードで検索してください")).toBeTruthy();
   });
 
   it("renders with different props correctly", () => {
     render(
       <EmptyState icon="📭" title="ブックマークなし" body="記事をブックマークに追加してください" />,
     );
-    expect(screen.getByText("📭")).toBeTruthy();
-    expect(screen.getByText("ブックマークなし")).toBeTruthy();
-    expect(screen.getByText("記事をブックマークに追加してください")).toBeTruthy();
+    expect.soft(screen.getByText("📭")).toBeTruthy();
+    expect.soft(screen.getByText("ブックマークなし")).toBeTruthy();
+    expect.soft(screen.getByText("記事をブックマークに追加してください")).toBeTruthy();
   });
 
   it("icon is displayed as a block element with large text", () => {

--- a/apps/web/tests/client/FeedDetail.test.tsx
+++ b/apps/web/tests/client/FeedDetail.test.tsx
@@ -97,8 +97,8 @@ describe("FeedDetail", () => {
       expect(screen.getByText("Test Feed")).toBeTruthy();
     });
 
-    expect(screen.getByText("https://example.com/feed")).toBeTruthy();
-    expect(screen.getByText("42")).toBeTruthy();
+    expect.soft(screen.getByText("https://example.com/feed")).toBeTruthy();
+    expect.soft(screen.getByText("42")).toBeTruthy();
   });
 
   it("記事 5 件の場合に 5 枚のカードが表示される", async () => {
@@ -324,14 +324,14 @@ describe("FeedDetail", () => {
     });
 
     // feed meta と articles で各 2 回ずつ、計 4 回 fetch
-    expect(fetchMock).toHaveBeenCalledTimes(4);
-    expect(fetchMock).toHaveBeenNthCalledWith(1, "/api/feeds/test-feed?recent=20");
-    expect(fetchMock).toHaveBeenNthCalledWith(
+    expect.soft(fetchMock).toHaveBeenCalledTimes(4);
+    expect.soft(fetchMock).toHaveBeenNthCalledWith(1, "/api/feeds/test-feed?recent=20");
+    expect.soft(fetchMock).toHaveBeenNthCalledWith(
       2,
       expect.stringContaining("/api/articles/by-feed/test-feed"),
     );
-    expect(fetchMock).toHaveBeenNthCalledWith(3, "/api/feeds/other-feed?recent=20");
-    expect(fetchMock).toHaveBeenNthCalledWith(
+    expect.soft(fetchMock).toHaveBeenNthCalledWith(3, "/api/feeds/other-feed?recent=20");
+    expect.soft(fetchMock).toHaveBeenNthCalledWith(
       4,
       expect.stringContaining("/api/articles/by-feed/other-feed"),
     );

--- a/apps/web/tests/client/FeedDetail.test.tsx
+++ b/apps/web/tests/client/FeedDetail.test.tsx
@@ -324,14 +324,14 @@ describe("FeedDetail", () => {
     });
 
     // feed meta と articles で各 2 回ずつ、計 4 回 fetch
-    expect.soft(fetchMock).toHaveBeenCalledTimes(4);
-    expect.soft(fetchMock).toHaveBeenNthCalledWith(1, "/api/feeds/test-feed?recent=20");
-    expect.soft(fetchMock).toHaveBeenNthCalledWith(
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(fetchMock).toHaveBeenNthCalledWith(1, "/api/feeds/test-feed?recent=20");
+    expect(fetchMock).toHaveBeenNthCalledWith(
       2,
       expect.stringContaining("/api/articles/by-feed/test-feed"),
     );
-    expect.soft(fetchMock).toHaveBeenNthCalledWith(3, "/api/feeds/other-feed?recent=20");
-    expect.soft(fetchMock).toHaveBeenNthCalledWith(
+    expect(fetchMock).toHaveBeenNthCalledWith(3, "/api/feeds/other-feed?recent=20");
+    expect(fetchMock).toHaveBeenNthCalledWith(
       4,
       expect.stringContaining("/api/articles/by-feed/other-feed"),
     );

--- a/apps/web/tests/client/FilterBar.test.tsx
+++ b/apps/web/tests/client/FilterBar.test.tsx
@@ -30,9 +30,9 @@ describe("FilterBar", () => {
 
   it("each select has an accessible aria-label", () => {
     render(<FilterBar {...defaultProps} />);
-    expect(screen.getByRole("combobox", { name: "カテゴリ" })).toBeTruthy();
-    expect(screen.getByRole("combobox", { name: "言語" })).toBeTruthy();
-    expect(screen.getByRole("combobox", { name: "フィード" })).toBeTruthy();
+    expect.soft(screen.getByRole("combobox", { name: "カテゴリ" })).toBeTruthy();
+    expect.soft(screen.getByRole("combobox", { name: "言語" })).toBeTruthy();
+    expect.soft(screen.getByRole("combobox", { name: "フィード" })).toBeTruthy();
   });
 
   it("calls onCategoryChange when a category is selected", async () => {
@@ -61,8 +61,8 @@ describe("FilterBar", () => {
     const user = userEvent.setup();
     render(<FilterBar {...defaultProps} category="ai" onClear={onClear} />);
     const clearBtn = screen.getByText(/解除/);
-    expect(clearBtn).toBeTruthy();
+    expect.soft(clearBtn).toBeTruthy();
     await user.click(clearBtn);
-    expect(onClear).toHaveBeenCalled();
+    expect.soft(onClear).toHaveBeenCalled();
   });
 });

--- a/apps/web/tests/client/FilterBar.test.tsx
+++ b/apps/web/tests/client/FilterBar.test.tsx
@@ -63,6 +63,6 @@ describe("FilterBar", () => {
     const clearBtn = screen.getByText(/解除/);
     expect.soft(clearBtn).toBeTruthy();
     await user.click(clearBtn);
-    expect.soft(onClear).toHaveBeenCalled();
+    expect(onClear).toHaveBeenCalled();
   });
 });

--- a/apps/web/tests/client/Header.test.tsx
+++ b/apps/web/tests/client/Header.test.tsx
@@ -31,9 +31,9 @@ describe("Header", () => {
 
   it("renders 3 theme toggle buttons", () => {
     render(<Header />);
-    expect(screen.getByRole("button", { name: "ライトモード" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "OS設定に追従" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "ダークモード" })).toBeTruthy();
+    expect.soft(screen.getByRole("button", { name: "ライトモード" })).toBeTruthy();
+    expect.soft(screen.getByRole("button", { name: "OS設定に追従" })).toBeTruthy();
+    expect.soft(screen.getByRole("button", { name: "ダークモード" })).toBeTruthy();
   });
 
   it("system button is aria-pressed=true when theme is system", () => {

--- a/apps/web/tests/client/HelpModal.test.tsx
+++ b/apps/web/tests/client/HelpModal.test.tsx
@@ -12,16 +12,16 @@ describe("HelpModal", () => {
 
   it("renders the dialog with shortcut table when open=true", () => {
     render(<HelpModal open={true} onClose={vi.fn<() => void>()} />);
-    expect(screen.getByRole("dialog")).toBeTruthy();
-    expect(screen.getByText("キーボードショートカット")).toBeTruthy();
+    expect.soft(screen.getByRole("dialog")).toBeTruthy();
+    expect.soft(screen.getByText("キーボードショートカット")).toBeTruthy();
   });
 
   it("shows shortcut rows in the table", () => {
     render(<HelpModal open={true} onClose={vi.fn<() => void>()} />);
     // HelpModal に定義されているショートカット説明が表示されているか確認
-    expect(screen.getByText("次の記事に移動")).toBeTruthy();
-    expect(screen.getByText("前の記事に移動")).toBeTruthy();
-    expect(screen.getByText("検索ボックスにフォーカス")).toBeTruthy();
+    expect.soft(screen.getByText("次の記事に移動")).toBeTruthy();
+    expect.soft(screen.getByText("前の記事に移動")).toBeTruthy();
+    expect.soft(screen.getByText("検索ボックスにフォーカス")).toBeTruthy();
   });
 
   it("calls onClose when close button is clicked", async () => {

--- a/apps/web/tests/client/ReportsList.test.tsx
+++ b/apps/web/tests/client/ReportsList.test.tsx
@@ -53,8 +53,8 @@ describe("ReportsList", () => {
     });
 
     // 日次・週次ラベルが表示される
-    expect(screen.getAllByText("日次").length).toBeGreaterThanOrEqual(1);
-    expect(screen.getAllByText("週次").length).toBeGreaterThanOrEqual(1);
+    expect.soft(screen.getAllByText("日次").length).toBeGreaterThanOrEqual(1);
+    expect.soft(screen.getAllByText("週次").length).toBeGreaterThanOrEqual(1);
   });
 
   it("レポートが 0 件のとき '...ありません' が表示される", async () => {
@@ -105,8 +105,10 @@ describe("ReportsList", () => {
 
     // 「日次」クリック後: aria-pressed が切り替わる
     await user.click(screen.getByRole("button", { name: "日次" }));
-    expect(screen.getByRole("button", { name: "日次" }).getAttribute("aria-pressed")).toBe("true");
-    expect(screen.getByRole("button", { name: "すべて" }).getAttribute("aria-pressed")).toBe(
+    expect.soft(screen.getByRole("button", { name: "日次" }).getAttribute("aria-pressed")).toBe(
+      "true",
+    );
+    expect.soft(screen.getByRole("button", { name: "すべて" }).getAttribute("aria-pressed")).toBe(
       "false",
     );
   });

--- a/apps/web/tests/client/ReportsList.test.tsx
+++ b/apps/web/tests/client/ReportsList.test.tsx
@@ -105,12 +105,12 @@ describe("ReportsList", () => {
 
     // 「日次」クリック後: aria-pressed が切り替わる
     await user.click(screen.getByRole("button", { name: "日次" }));
-    expect.soft(screen.getByRole("button", { name: "日次" }).getAttribute("aria-pressed")).toBe(
-      "true",
-    );
-    expect.soft(screen.getByRole("button", { name: "すべて" }).getAttribute("aria-pressed")).toBe(
-      "false",
-    );
+    expect
+      .soft(screen.getByRole("button", { name: "日次" }).getAttribute("aria-pressed"))
+      .toBe("true");
+    expect
+      .soft(screen.getByRole("button", { name: "すべて" }).getAttribute("aria-pressed"))
+      .toBe("false");
   });
 
   it("kind フィルタ chip をクリックすると fetch URL が変わる", async () => {

--- a/apps/web/tests/client/SearchInput.test.tsx
+++ b/apps/web/tests/client/SearchInput.test.tsx
@@ -64,8 +64,8 @@ describe("SearchInput", () => {
     const ref = createRef<HTMLInputElement>();
     render(<SearchInput value="test" onChange={vi.fn<(q: string) => void>()} ref={ref} />);
     expect(ref.current).toBeTruthy();
-    expect(ref.current?.tagName).toBe("INPUT");
-    expect(ref.current?.value).toBe("test");
+    expect.soft(ref.current?.tagName).toBe("INPUT");
+    expect.soft(ref.current?.value).toBe("test");
   });
 
   it("has aria-label for screen readers", () => {

--- a/apps/web/tests/client/SearchSuggestions.test.tsx
+++ b/apps/web/tests/client/SearchSuggestions.test.tsx
@@ -42,9 +42,9 @@ describe("SearchSuggestions", () => {
         visible={true}
       />,
     );
-    expect(screen.getByText("React")).toBeTruthy();
-    expect(screen.getByText("TypeScript")).toBeTruthy();
-    expect(screen.getByText("Cloudflare")).toBeTruthy();
+    expect.soft(screen.getByText("React")).toBeTruthy();
+    expect.soft(screen.getByText("TypeScript")).toBeTruthy();
+    expect.soft(screen.getByText("Cloudflare")).toBeTruthy();
   });
 
   it("calls onPick when a suggestion item is clicked via mousedown", () => {

--- a/apps/web/tests/client/ShareButtons.test.tsx
+++ b/apps/web/tests/client/ShareButtons.test.tsx
@@ -11,34 +11,34 @@ describe("ShareButtons", () => {
     render(<ShareButtons url={TEST_URL} title={TEST_TITLE} />);
     const xLink = screen.getByRole("link", { name: /X \(Twitter\)/i });
     const href = xLink.getAttribute("href") ?? "";
-    expect(href).toContain("twitter.com/intent/tweet");
-    expect(href).toContain(encodeURIComponent(TEST_URL));
-    expect(href).toContain(encodeURIComponent(TEST_TITLE));
+    expect.soft(href).toContain("twitter.com/intent/tweet");
+    expect.soft(href).toContain(encodeURIComponent(TEST_URL));
+    expect.soft(href).toContain(encodeURIComponent(TEST_TITLE));
   });
 
   it("Hatena anchor href encodes url and title", () => {
     render(<ShareButtons url={TEST_URL} title={TEST_TITLE} />);
     const hatenaLink = screen.getByRole("link", { name: /はてなブックマーク/i });
     const href = hatenaLink.getAttribute("href") ?? "";
-    expect(href).toContain("b.hatena.ne.jp/add");
-    expect(href).toContain(encodeURIComponent(TEST_URL));
-    expect(href).toContain(encodeURIComponent(TEST_TITLE));
+    expect.soft(href).toContain("b.hatena.ne.jp/add");
+    expect.soft(href).toContain(encodeURIComponent(TEST_URL));
+    expect.soft(href).toContain(encodeURIComponent(TEST_TITLE));
   });
 
   it("X and Hatena links open in new tab with noopener", () => {
     render(<ShareButtons url={TEST_URL} title={TEST_TITLE} />);
     for (const label of [/X \(Twitter\)/i, /はてなブックマーク/i]) {
       const link = screen.getByRole("link", { name: label });
-      expect(link.getAttribute("target")).toBe("_blank");
-      expect(link.getAttribute("rel")).toContain("noopener");
+      expect.soft(link.getAttribute("target")).toBe("_blank");
+      expect.soft(link.getAttribute("rel")).toContain("noopener");
     }
   });
 
   it("all interactive elements have aria-label", () => {
     render(<ShareButtons url={TEST_URL} title={TEST_TITLE} />);
-    expect(screen.getByRole("link", { name: /X \(Twitter\)/i })).toBeTruthy();
-    expect(screen.getByRole("link", { name: /はてなブックマーク/i })).toBeTruthy();
-    expect(screen.getByRole("button", { name: /URLをコピー/i })).toBeTruthy();
+    expect.soft(screen.getByRole("link", { name: /X \(Twitter\)/i })).toBeTruthy();
+    expect.soft(screen.getByRole("link", { name: /はてなブックマーク/i })).toBeTruthy();
+    expect.soft(screen.getByRole("button", { name: /URLをコピー/i })).toBeTruthy();
   });
 
   it("copy button click succeeds and shows copied state via aria-label", async () => {

--- a/apps/web/tests/client/ShortcutsHelp.test.tsx
+++ b/apps/web/tests/client/ShortcutsHelp.test.tsx
@@ -12,20 +12,20 @@ describe("ShortcutsHelp", () => {
 
   it("renders the modal when open is true", () => {
     render(<ShortcutsHelp open={true} onClose={vi.fn<() => void>()} />);
-    expect(screen.getByRole("dialog")).toBeTruthy();
-    expect(screen.getByText("キーボードショートカット")).toBeTruthy();
+    expect.soft(screen.getByRole("dialog")).toBeTruthy();
+    expect.soft(screen.getByText("キーボードショートカット")).toBeTruthy();
   });
 
   it("shows all shortcut rows", () => {
     render(<ShortcutsHelp open={true} onClose={vi.fn<() => void>()} />);
     // j/k, Enter, b, /, ?, g g, G, Esc の各ショートカット説明を確認
-    expect(screen.getByText("次の記事に移動")).toBeTruthy();
-    expect(screen.getByText("前の記事に移動")).toBeTruthy();
-    expect(screen.getByText("選択中の記事を新規タブで開く")).toBeTruthy();
-    expect(screen.getByText("選択中の記事をブックマーク切り替え")).toBeTruthy();
-    expect(screen.getByText("検索ボックスにフォーカス")).toBeTruthy();
-    expect(screen.getByText("このヘルプを開く / 閉じる")).toBeTruthy();
-    expect(screen.getByText("ヘルプを閉じる / 選択解除")).toBeTruthy();
+    expect.soft(screen.getByText("次の記事に移動")).toBeTruthy();
+    expect.soft(screen.getByText("前の記事に移動")).toBeTruthy();
+    expect.soft(screen.getByText("選択中の記事を新規タブで開く")).toBeTruthy();
+    expect.soft(screen.getByText("選択中の記事をブックマーク切り替え")).toBeTruthy();
+    expect.soft(screen.getByText("検索ボックスにフォーカス")).toBeTruthy();
+    expect.soft(screen.getByText("このヘルプを開く / 閉じる")).toBeTruthy();
+    expect.soft(screen.getByText("ヘルプを閉じる / 選択解除")).toBeTruthy();
   });
 
   it("calls onClose when close button is clicked", async () => {

--- a/apps/web/tests/client/StaleFeedsWarning.test.tsx
+++ b/apps/web/tests/client/StaleFeedsWarning.test.tsx
@@ -28,8 +28,8 @@ describe("StaleFeedsWarning", () => {
   it("renders feed name for each stale feed", () => {
     const feeds = [makeStale("f1", "Tech Blog"), makeStale("f2", "Dev Blog")];
     render(<StaleFeedsWarning staleFeeds={feeds} />);
-    expect(screen.getByText("Tech Blog")).toBeTruthy();
-    expect(screen.getByText("Dev Blog")).toBeTruthy();
+    expect.soft(screen.getByText("Tech Blog")).toBeTruthy();
+    expect.soft(screen.getByText("Dev Blog")).toBeTruthy();
   });
 
   it("shows 'error' label for feeds with error status", () => {
@@ -62,7 +62,7 @@ describe("StaleFeedsWarning", () => {
   it("uses details/summary pattern (collapsible)", () => {
     const feeds = [makeStale("f1", "Feed A")];
     const { container } = render(<StaleFeedsWarning staleFeeds={feeds} />);
-    expect(container.querySelector("details")).toBeTruthy();
-    expect(container.querySelector("summary")).toBeTruthy();
+    expect.soft(container.querySelector("details")).toBeTruthy();
+    expect.soft(container.querySelector("summary")).toBeTruthy();
   });
 });

--- a/apps/web/tests/client/StatsChart.test.tsx
+++ b/apps/web/tests/client/StatsChart.test.tsx
@@ -31,8 +31,8 @@ describe("StatsChart", () => {
     const data = makeTrendData(30);
     render(<StatsChart data={data} categories={CATEGORIES} />);
     const svg = screen.getByRole("img");
-    expect(svg).toBeTruthy();
-    expect(svg.tagName.toLowerCase()).toBe("svg");
+    expect.soft(svg).toBeTruthy();
+    expect.soft(svg.tagName.toLowerCase()).toBe("svg");
   });
 
   it("renders legend items for each category", () => {
@@ -67,7 +67,7 @@ describe("StatsChart", () => {
     const { container } = render(<StatsChart data={singleData} categories={CATEGORIES} />);
     const titles = container.querySelectorAll("title");
     const titleTexts = Array.from(titles).map((t) => t.textContent ?? "");
-    expect(titleTexts.some((t) => t.includes("bigtech") && t.includes("5"))).toBe(true);
-    expect(titleTexts.some((t) => t.includes("ai") && t.includes("3"))).toBe(true);
+    expect.soft(titleTexts.some((t) => t.includes("bigtech") && t.includes("5"))).toBe(true);
+    expect.soft(titleTexts.some((t) => t.includes("ai") && t.includes("3"))).toBe(true);
   });
 });

--- a/apps/web/tests/client/StatsDashboard.test.tsx
+++ b/apps/web/tests/client/StatsDashboard.test.tsx
@@ -118,8 +118,8 @@ describe("StatsDashboard", () => {
     mockFetchSuccess();
     render(<StatsDashboard />);
     await screen.findByText("Alice");
-    expect(screen.getByText("Bob")).toBeTruthy();
-    expect(screen.getByText("Judy")).toBeTruthy();
+    expect.soft(screen.getByText("Bob")).toBeTruthy();
+    expect.soft(screen.getByText("Judy")).toBeTruthy();
   });
 
   it("top_authors のバーに aria-label が設定される", async () => {
@@ -134,15 +134,15 @@ describe("StatsDashboard", () => {
     mockFetchSuccess();
     render(<StatsDashboard />);
     await screen.findByText("Feed A");
-    expect(screen.getByText("Feed B")).toBeTruthy();
-    expect(screen.getByText("Feed C")).toBeTruthy();
+    expect.soft(screen.getByText("Feed B")).toBeTruthy();
+    expect.soft(screen.getByText("Feed C")).toBeTruthy();
   });
 
   it("by_lang_30d の ja と en バーが表示される", async () => {
     mockFetchSuccess();
     render(<StatsDashboard />);
     await screen.findByText("ja");
-    expect(screen.getByText("en")).toBeTruthy();
+    expect.soft(screen.getByText("en")).toBeTruthy();
   });
 
   it("by_lang バーの aria-label に件数が含まれる", async () => {
@@ -150,18 +150,18 @@ describe("StatsDashboard", () => {
     render(<StatsDashboard />);
     // ja: 500件 のバー
     const jaBar = await screen.findByRole("img", { name: /ja.*500/ });
-    expect(jaBar).toBeTruthy();
+    expect.soft(jaBar).toBeTruthy();
     const enBar = screen.getByRole("img", { name: /en.*300/ });
-    expect(enBar).toBeTruthy();
+    expect.soft(enBar).toBeTruthy();
   });
 
   it("by_category が表示される", async () => {
     mockFetchSuccess();
     render(<StatsDashboard />);
     await screen.findByText("bigtech");
-    expect(screen.getByText("ai")).toBeTruthy();
-    expect(screen.getByText("jp")).toBeTruthy();
-    expect(screen.getByText("zenn")).toBeTruthy();
+    expect.soft(screen.getByText("ai")).toBeTruthy();
+    expect.soft(screen.getByText("jp")).toBeTruthy();
+    expect.soft(screen.getByText("zenn")).toBeTruthy();
   });
 
   it("活動カレンダーセクションが描画される", async () => {

--- a/apps/web/tests/client/ThemeToggle.test.tsx
+++ b/apps/web/tests/client/ThemeToggle.test.tsx
@@ -20,15 +20,15 @@ describe("ThemeToggle", () => {
 
   it("light button has aria-pressed=true when theme is light", () => {
     render(<ThemeToggle theme="light" onSetTheme={mockSetTheme} />);
-    expect.soft(
-      screen.getByRole("button", { name: "ライトモード" }).getAttribute("aria-pressed"),
-    ).toBe("true");
-    expect.soft(
-      screen.getByRole("button", { name: "OS設定に追従" }).getAttribute("aria-pressed"),
-    ).toBe("false");
-    expect.soft(
-      screen.getByRole("button", { name: "ダークモード" }).getAttribute("aria-pressed"),
-    ).toBe("false");
+    expect
+      .soft(screen.getByRole("button", { name: "ライトモード" }).getAttribute("aria-pressed"))
+      .toBe("true");
+    expect
+      .soft(screen.getByRole("button", { name: "OS設定に追従" }).getAttribute("aria-pressed"))
+      .toBe("false");
+    expect
+      .soft(screen.getByRole("button", { name: "ダークモード" }).getAttribute("aria-pressed"))
+      .toBe("false");
   });
 
   it("system button has aria-pressed=true when theme is system", () => {

--- a/apps/web/tests/client/ThemeToggle.test.tsx
+++ b/apps/web/tests/client/ThemeToggle.test.tsx
@@ -13,22 +13,22 @@ describe("ThemeToggle", () => {
 
   it("renders 3 buttons (light, system, dark)", () => {
     render(<ThemeToggle theme="system" onSetTheme={mockSetTheme} />);
-    expect(screen.getByRole("button", { name: "ライトモード" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "OS設定に追従" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "ダークモード" })).toBeTruthy();
+    expect.soft(screen.getByRole("button", { name: "ライトモード" })).toBeTruthy();
+    expect.soft(screen.getByRole("button", { name: "OS設定に追従" })).toBeTruthy();
+    expect.soft(screen.getByRole("button", { name: "ダークモード" })).toBeTruthy();
   });
 
   it("light button has aria-pressed=true when theme is light", () => {
     render(<ThemeToggle theme="light" onSetTheme={mockSetTheme} />);
-    expect(screen.getByRole("button", { name: "ライトモード" }).getAttribute("aria-pressed")).toBe(
-      "true",
-    );
-    expect(screen.getByRole("button", { name: "OS設定に追従" }).getAttribute("aria-pressed")).toBe(
-      "false",
-    );
-    expect(screen.getByRole("button", { name: "ダークモード" }).getAttribute("aria-pressed")).toBe(
-      "false",
-    );
+    expect.soft(
+      screen.getByRole("button", { name: "ライトモード" }).getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect.soft(
+      screen.getByRole("button", { name: "OS設定に追従" }).getAttribute("aria-pressed"),
+    ).toBe("false");
+    expect.soft(
+      screen.getByRole("button", { name: "ダークモード" }).getAttribute("aria-pressed"),
+    ).toBe("false");
   });
 
   it("system button has aria-pressed=true when theme is system", () => {

--- a/apps/web/tests/client/useArticlesCalendar.test.tsx
+++ b/apps/web/tests/client/useArticlesCalendar.test.tsx
@@ -30,10 +30,10 @@ describe("useArticlesCalendar", () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(result.current.items).toHaveLength(2);
-    expect(result.current.items[0]?.date).toBe("2026-04-28");
-    expect(result.current.items[0]?.count).toBe(5);
-    expect(result.current.error).toBeNull();
+    expect.soft(result.current.items).toHaveLength(2);
+    expect.soft(result.current.items[0]?.date).toBe("2026-04-28");
+    expect.soft(result.current.items[0]?.count).toBe(5);
+    expect.soft(result.current.error).toBeNull();
   });
 
   it("fetch エラー時に error が設定されアイテムは空", async () => {
@@ -45,8 +45,8 @@ describe("useArticlesCalendar", () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(result.current.error).toContain("500");
-    expect(result.current.items).toEqual([]);
+    expect.soft(result.current.error).toContain("500");
+    expect.soft(result.current.items).toEqual([]);
   });
 
   it("空のレスポンスの場合 items が空配列", async () => {
@@ -64,8 +64,8 @@ describe("useArticlesCalendar", () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(result.current.items).toEqual([]);
-    expect(result.current.error).toBeNull();
+    expect.soft(result.current.items).toEqual([]);
+    expect.soft(result.current.error).toBeNull();
   });
 
   it("days が変わると再 fetch が発火する", async () => {
@@ -102,7 +102,7 @@ describe("useArticlesCalendar", () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(result.current.error).toBe("Network error");
-    expect(result.current.items).toEqual([]);
+    expect.soft(result.current.error).toBe("Network error");
+    expect.soft(result.current.items).toEqual([]);
   });
 });

--- a/apps/web/tests/client/useAuthorArticles.test.tsx
+++ b/apps/web/tests/client/useAuthorArticles.test.tsx
@@ -43,9 +43,9 @@ describe("useAuthorArticles", () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(result.current.articles).toHaveLength(2);
-    expect(result.current.error).toBeNull();
-    expect(result.current.hasMore).toBe(false);
+    expect.soft(result.current.articles).toHaveLength(2);
+    expect.soft(result.current.error).toBeNull();
+    expect.soft(result.current.hasMore).toBe(false);
   });
 
   it("fetch エラー時に error が設定され記事は空", async () => {
@@ -57,8 +57,8 @@ describe("useAuthorArticles", () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(result.current.error).toContain("500");
-    expect(result.current.articles).toEqual([]);
+    expect.soft(result.current.error).toContain("500");
+    expect.soft(result.current.articles).toEqual([]);
   });
 
   it("author が変わると再 fetch が発火する", async () => {
@@ -101,8 +101,8 @@ describe("useAuthorArticles", () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(result.current.articles).toHaveLength(2);
-    expect(result.current.hasMore).toBe(true);
+    expect.soft(result.current.articles).toHaveLength(2);
+    expect.soft(result.current.hasMore).toBe(true);
 
     await act(async () => {
       await result.current.loadMore();
@@ -112,7 +112,7 @@ describe("useAuthorArticles", () => {
       expect(result.current.articles).toHaveLength(3);
     });
 
-    expect(result.current.hasMore).toBe(false);
+    expect.soft(result.current.hasMore).toBe(false);
   });
 
   it("author が空文字の場合は fetch が発火しない", async () => {

--- a/apps/web/tests/client/useBookmarks.test.tsx
+++ b/apps/web/tests/client/useBookmarks.test.tsx
@@ -45,8 +45,8 @@ describe("useBookmarks", () => {
     const stored = localStorage.getItem(STORAGE_KEY);
     expect(stored).not.toBeNull();
     const parsed: unknown = JSON.parse(stored!);
-    expect(Array.isArray(parsed)).toBe(true);
-    expect((parsed as string[]).includes("guid-xyz")).toBe(true);
+    expect.soft(Array.isArray(parsed)).toBe(true);
+    expect.soft((parsed as string[]).includes("guid-xyz")).toBe(true);
   });
 
   it("isBookmarked returns false for unknown guid", () => {
@@ -64,18 +64,18 @@ describe("useBookmarks", () => {
     act(() => {
       result.current.clear();
     });
-    expect(result.current.bookmarks.size).toBe(0);
-    expect(result.current.isBookmarked("guid-1")).toBe(false);
-    expect(result.current.isBookmarked("guid-2")).toBe(false);
+    expect.soft(result.current.bookmarks.size).toBe(0);
+    expect.soft(result.current.isBookmarked("guid-1")).toBe(false);
+    expect.soft(result.current.isBookmarked("guid-2")).toBe(false);
   });
 
   it("returns the same Set reference when raw is unchanged", () => {
     // raw が変わっていなければ getSnapshot が同じ参照を返すことを確認する
     localStorage.setItem(STORAGE_KEY, JSON.stringify(["guid-a", "guid-b"]));
     const { result } = renderHook(() => useBookmarks());
-    expect(result.current.isBookmarked("guid-a")).toBe(true);
-    expect(result.current.isBookmarked("guid-b")).toBe(true);
-    expect(result.current.isBookmarked("guid-c")).toBe(false);
+    expect.soft(result.current.isBookmarked("guid-a")).toBe(true);
+    expect.soft(result.current.isBookmarked("guid-b")).toBe(true);
+    expect.soft(result.current.isBookmarked("guid-c")).toBe(false);
   });
 
   it("syncs via StorageEvent (cross-tab simulation)", () => {

--- a/apps/web/tests/client/useCategories.test.tsx
+++ b/apps/web/tests/client/useCategories.test.tsx
@@ -47,9 +47,9 @@ describe("useCategories", () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(result.current.categories).toHaveLength(2);
-    expect(result.current.categories?.[0].id).toBe("bigtech");
-    expect(result.current.error).toBeNull();
+    expect.soft(result.current.categories).toHaveLength(2);
+    expect.soft(result.current.categories?.[0].id).toBe("bigtech");
+    expect.soft(result.current.error).toBeNull();
   });
 
   it("HTTP エラー時に error を返す", async () => {
@@ -67,8 +67,8 @@ describe("useCategories", () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(result.current.error).toBeTruthy();
-    expect(result.current.categories).toBeNull();
+    expect.soft(result.current.error).toBeTruthy();
+    expect.soft(result.current.categories).toBeNull();
   });
 
   it("初期状態では isLoading が true", () => {
@@ -76,9 +76,9 @@ describe("useCategories", () => {
 
     const { result } = renderHook(() => useCategories());
 
-    expect(result.current.isLoading).toBe(true);
-    expect(result.current.categories).toBeNull();
-    expect(result.current.error).toBeNull();
+    expect.soft(result.current.isLoading).toBe(true);
+    expect.soft(result.current.categories).toBeNull();
+    expect.soft(result.current.error).toBeNull();
   });
 
   it("/api/categories を fetch する", async () => {

--- a/apps/web/tests/client/useFeedArticles.test.tsx
+++ b/apps/web/tests/client/useFeedArticles.test.tsx
@@ -40,8 +40,8 @@ describe("useFeedArticles", () => {
   it("初期状態でローディングが true になる", () => {
     vi.stubGlobal("fetch", vi.fn().mockReturnValue(new Promise(() => {})));
     const { result } = renderHook(() => useFeedArticles("test-feed"));
-    expect(result.current.isLoading).toBe(true);
-    expect(result.current.articles).toEqual([]);
+    expect.soft(result.current.isLoading).toBe(true);
+    expect.soft(result.current.articles).toEqual([]);
   });
 
   it("fetch 成功時に記事が返される", async () => {
@@ -54,8 +54,8 @@ describe("useFeedArticles", () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(result.current.articles).toHaveLength(5);
-    expect(result.current.error).toBeNull();
+    expect.soft(result.current.articles).toHaveLength(5);
+    expect.soft(result.current.error).toBeNull();
   });
 
   it("nextCursor が null のとき hasMore が false になる", async () => {
@@ -117,8 +117,8 @@ describe("useFeedArticles", () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(result.current.articles).toHaveLength(20);
-    expect(result.current.hasMore).toBe(true);
+    expect.soft(result.current.articles).toHaveLength(20);
+    expect.soft(result.current.hasMore).toBe(true);
 
     await act(async () => {
       await result.current.loadMore();
@@ -128,7 +128,7 @@ describe("useFeedArticles", () => {
       expect(result.current.articles).toHaveLength(30);
     });
 
-    expect(result.current.hasMore).toBe(false);
+    expect.soft(result.current.hasMore).toBe(false);
   });
 
   it("loadMore の URL に cursor が含まれる", async () => {
@@ -165,7 +165,7 @@ describe("useFeedArticles", () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(result.current.error).toBeTruthy();
-    expect(result.current.articles).toEqual([]);
+    expect.soft(result.current.error).toBeTruthy();
+    expect.soft(result.current.articles).toEqual([]);
   });
 });

--- a/apps/web/tests/client/useFeedDetail.test.tsx
+++ b/apps/web/tests/client/useFeedDetail.test.tsx
@@ -56,9 +56,9 @@ describe("useFeedDetail", () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(result.current.feed?.id).toBe("feed-1");
-    expect(result.current.articles).toHaveLength(2);
-    expect(result.current.error).toBeNull();
+    expect.soft(result.current.feed?.id).toBe("feed-1");
+    expect.soft(result.current.articles).toHaveLength(2);
+    expect.soft(result.current.error).toBeNull();
   });
 
   it("404 エラー時に feed_not_found が設定される", async () => {
@@ -70,9 +70,9 @@ describe("useFeedDetail", () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(result.current.error).toBe("feed_not_found");
-    expect(result.current.feed).toBeNull();
-    expect(result.current.articles).toEqual([]);
+    expect.soft(result.current.error).toBe("feed_not_found");
+    expect.soft(result.current.feed).toBeNull();
+    expect.soft(result.current.articles).toEqual([]);
   });
 
   it("500 エラー時に HTTP エラーメッセージが設定される", async () => {
@@ -84,8 +84,8 @@ describe("useFeedDetail", () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(result.current.error).toBe("HTTP 500");
-    expect(result.current.feed).toBeNull();
+    expect.soft(result.current.error).toBe("HTTP 500");
+    expect.soft(result.current.feed).toBeNull();
   });
 
   it("feedId が変わると再 fetch が発火する", async () => {
@@ -122,8 +122,8 @@ describe("useFeedDetail", () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(result.current.error).toBe("Network failed");
-    expect(result.current.feed).toBeNull();
-    expect(result.current.articles).toEqual([]);
+    expect.soft(result.current.error).toBe("Network failed");
+    expect.soft(result.current.feed).toBeNull();
+    expect.soft(result.current.articles).toEqual([]);
   });
 });

--- a/apps/web/tests/client/useFeeds.test.tsx
+++ b/apps/web/tests/client/useFeeds.test.tsx
@@ -39,9 +39,9 @@ describe("useFeeds", () => {
       expect(result.current.loading).toBe(false);
     });
 
-    expect(result.current.feeds).toHaveLength(2);
-    expect(result.current.feeds[0]?.id).toBe("feed-1");
-    expect(result.current.error).toBeNull();
+    expect.soft(result.current.feeds).toHaveLength(2);
+    expect.soft(result.current.feeds[0]?.id).toBe("feed-1");
+    expect.soft(result.current.error).toBeNull();
   });
 
   it("fetch エラー時に error が設定されフィードは空", async () => {
@@ -53,8 +53,8 @@ describe("useFeeds", () => {
       expect(result.current.loading).toBe(false);
     });
 
-    expect(result.current.error).toContain("500");
-    expect(result.current.feeds).toEqual([]);
+    expect.soft(result.current.error).toContain("500");
+    expect.soft(result.current.feeds).toEqual([]);
   });
 
   it("空のフィード一覧が返された場合、feeds は空配列", async () => {
@@ -66,8 +66,8 @@ describe("useFeeds", () => {
       expect(result.current.loading).toBe(false);
     });
 
-    expect(result.current.feeds).toEqual([]);
-    expect(result.current.error).toBeNull();
+    expect.soft(result.current.feeds).toEqual([]);
+    expect.soft(result.current.error).toBeNull();
   });
 
   it("fetch 中は loading が true", async () => {
@@ -96,7 +96,7 @@ describe("useFeeds", () => {
       expect(result.current.loading).toBe(false);
     });
 
-    expect(result.current.error).toBe("Network Error");
-    expect(result.current.feeds).toEqual([]);
+    expect.soft(result.current.error).toBe("Network Error");
+    expect.soft(result.current.feeds).toEqual([]);
   });
 });

--- a/apps/web/tests/client/useFilterHandlers.test.tsx
+++ b/apps/web/tests/client/useFilterHandlers.test.tsx
@@ -191,11 +191,11 @@ describe("useFilterHandlers", () => {
       result.current.handleClear();
     });
 
-    expect.soft(setters.setFeedId).toHaveBeenCalledWith("");
-    expect.soft(setters.setDateFrom).toHaveBeenCalledWith("");
-    expect.soft(setters.setDateTo).toHaveBeenCalledWith("");
-    expect.soft(setters.setUnreadOnly).toHaveBeenCalledWith(false);
-    expect.soft(setters.setStarredOnly).toHaveBeenCalledWith(false);
+    expect(setters.setFeedId).toHaveBeenCalledWith("");
+    expect(setters.setDateFrom).toHaveBeenCalledWith("");
+    expect(setters.setDateTo).toHaveBeenCalledWith("");
+    expect(setters.setUnreadOnly).toHaveBeenCalledWith(false);
+    expect(setters.setStarredOnly).toHaveBeenCalledWith(false);
   });
 
   it("handleBookmarkedOnlyToggle が setUrlFilters で bookmarksOnly を反転させる", () => {
@@ -237,8 +237,8 @@ describe("useFilterHandlers", () => {
       });
     });
 
-    expect.soft(setters.setFeedId).toHaveBeenCalledWith("preset-feed");
-    expect.soft(setters.setUnreadOnly).toHaveBeenCalledWith(true);
-    expect.soft(setters.setStarredOnly).toHaveBeenCalledWith(false);
+    expect(setters.setFeedId).toHaveBeenCalledWith("preset-feed");
+    expect(setters.setUnreadOnly).toHaveBeenCalledWith(true);
+    expect(setters.setStarredOnly).toHaveBeenCalledWith(false);
   });
 });

--- a/apps/web/tests/client/useFilterHandlers.test.tsx
+++ b/apps/web/tests/client/useFilterHandlers.test.tsx
@@ -191,11 +191,11 @@ describe("useFilterHandlers", () => {
       result.current.handleClear();
     });
 
-    expect(setters.setFeedId).toHaveBeenCalledWith("");
-    expect(setters.setDateFrom).toHaveBeenCalledWith("");
-    expect(setters.setDateTo).toHaveBeenCalledWith("");
-    expect(setters.setUnreadOnly).toHaveBeenCalledWith(false);
-    expect(setters.setStarredOnly).toHaveBeenCalledWith(false);
+    expect.soft(setters.setFeedId).toHaveBeenCalledWith("");
+    expect.soft(setters.setDateFrom).toHaveBeenCalledWith("");
+    expect.soft(setters.setDateTo).toHaveBeenCalledWith("");
+    expect.soft(setters.setUnreadOnly).toHaveBeenCalledWith(false);
+    expect.soft(setters.setStarredOnly).toHaveBeenCalledWith(false);
   });
 
   it("handleBookmarkedOnlyToggle が setUrlFilters で bookmarksOnly を反転させる", () => {
@@ -237,8 +237,8 @@ describe("useFilterHandlers", () => {
       });
     });
 
-    expect(setters.setFeedId).toHaveBeenCalledWith("preset-feed");
-    expect(setters.setUnreadOnly).toHaveBeenCalledWith(true);
-    expect(setters.setStarredOnly).toHaveBeenCalledWith(false);
+    expect.soft(setters.setFeedId).toHaveBeenCalledWith("preset-feed");
+    expect.soft(setters.setUnreadOnly).toHaveBeenCalledWith(true);
+    expect.soft(setters.setStarredOnly).toHaveBeenCalledWith(false);
   });
 });

--- a/apps/web/tests/client/usePresets.test.tsx
+++ b/apps/web/tests/client/usePresets.test.tsx
@@ -78,8 +78,8 @@ describe("usePresets (mock)", () => {
       result.current.addPreset("ai + ja", { category: "ai", lang: "ja" });
     });
     expect(result.current.presets).toHaveLength(1);
-    expect(result.current.presets[0].name).toBe("ai + ja");
-    expect(result.current.presets[0].filters.category).toBe("ai");
+    expect.soft(result.current.presets[0].name).toBe("ai + ja");
+    expect.soft(result.current.presets[0].filters.category).toBe("ai");
   });
 
   it("removes a preset from the list", () => {
@@ -112,8 +112,8 @@ describe("usePresets (mock)", () => {
     act(() => {
       result.current.addPreset("one-too-many", { q: "overflow" });
     });
-    expect(alertMock).toHaveBeenCalled();
-    expect(result.current.presets).toHaveLength(50);
+    expect.soft(alertMock).toHaveBeenCalled();
+    expect.soft(result.current.presets).toHaveLength(50);
 
     // @ts-expect-error -- globalThis.alert を元に戻す
     delete globalThis.alert;

--- a/apps/web/tests/client/usePresets.test.tsx
+++ b/apps/web/tests/client/usePresets.test.tsx
@@ -112,7 +112,7 @@ describe("usePresets (mock)", () => {
     act(() => {
       result.current.addPreset("one-too-many", { q: "overflow" });
     });
-    expect.soft(alertMock).toHaveBeenCalled();
+    expect(alertMock).toHaveBeenCalled();
     expect.soft(result.current.presets).toHaveLength(50);
 
     // @ts-expect-error -- globalThis.alert を元に戻す

--- a/apps/web/tests/client/useReadState.test.tsx
+++ b/apps/web/tests/client/useReadState.test.tsx
@@ -43,15 +43,15 @@ describe("useReadState", () => {
     act(() => {
       result.current.clearAll();
     });
-    expect(result.current.isRead(1)).toBe(false);
-    expect(result.current.isRead(2)).toBe(false);
+    expect.soft(result.current.isRead(1)).toBe(false);
+    expect.soft(result.current.isRead(2)).toBe(false);
   });
 
   it("returns the same Set reference when raw is unchanged", () => {
     // raw が変わっていなければ getSnapshot が同じ参照を返すことを確認する
     localStorage.setItem("tnb-read-articles", JSON.stringify([5, 6]));
     const { result } = renderHook(() => useReadState());
-    expect(result.current.isRead(5)).toBe(true);
-    expect(result.current.isRead(99)).toBe(false);
+    expect.soft(result.current.isRead(5)).toBe(true);
+    expect.soft(result.current.isRead(99)).toBe(false);
   });
 });

--- a/apps/web/tests/client/useRecentSearches.test.tsx
+++ b/apps/web/tests/client/useRecentSearches.test.tsx
@@ -19,8 +19,8 @@ describe("useRecentSearches", () => {
     const stored = localStorage.getItem(STORAGE_KEY);
     expect(stored).not.toBeNull();
     const parsed: unknown = JSON.parse(stored!);
-    expect(Array.isArray(parsed)).toBe(true);
-    expect((parsed as string[]).includes("react")).toBe(true);
+    expect.soft(Array.isArray(parsed)).toBe(true);
+    expect.soft((parsed as string[]).includes("react")).toBe(true);
   });
 
   it("add: 先頭に追加される", () => {
@@ -29,8 +29,8 @@ describe("useRecentSearches", () => {
       result.current.add("typescript");
       result.current.add("react");
     });
-    expect(result.current.items[0]).toBe("react");
-    expect(result.current.items[1]).toBe("typescript");
+    expect.soft(result.current.items[0]).toBe("react");
+    expect.soft(result.current.items[1]).toBe("typescript");
   });
 
   it("add: 空文字は無視される", () => {
@@ -56,9 +56,9 @@ describe("useRecentSearches", () => {
       result.current.add("react");
       result.current.add("typescript");
     });
-    expect(result.current.items[0]).toBe("typescript");
-    expect(result.current.items.filter((v) => v === "typescript").length).toBe(1);
-    expect(result.current.items.length).toBe(2);
+    expect.soft(result.current.items[0]).toBe("typescript");
+    expect.soft(result.current.items.filter((v) => v === "typescript").length).toBe(1);
+    expect.soft(result.current.items.length).toBe(2);
   });
 
   it("add: 11 件以上で 10 件にトリムされる", () => {
@@ -68,11 +68,11 @@ describe("useRecentSearches", () => {
         result.current.add(`query-${i}`);
       }
     });
-    expect(result.current.items.length).toBe(10);
+    expect.soft(result.current.items.length).toBe(10);
     // 最後に追加した query-11 が先頭にある
-    expect(result.current.items[0]).toBe("query-11");
+    expect.soft(result.current.items[0]).toBe("query-11");
     // 最初に追加した query-1 は溢れて消える
-    expect(result.current.items.includes("query-1")).toBe(false);
+    expect.soft(result.current.items.includes("query-1")).toBe(false);
   });
 
   it("remove: 該当が消える", () => {
@@ -84,8 +84,8 @@ describe("useRecentSearches", () => {
     act(() => {
       result.current.remove("typescript");
     });
-    expect(result.current.items.includes("typescript")).toBe(false);
-    expect(result.current.items.includes("react")).toBe(true);
+    expect.soft(result.current.items.includes("typescript")).toBe(false);
+    expect.soft(result.current.items.includes("react")).toBe(true);
   });
 
   it("clear: 全消去される", () => {

--- a/apps/web/tests/client/useReports.test.tsx
+++ b/apps/web/tests/client/useReports.test.tsx
@@ -46,9 +46,9 @@ describe("useReportsList", () => {
       expect(result.current.loading).toBe(false);
     });
 
-    expect(result.current.data).toHaveLength(2);
-    expect(result.current.data[0]?.id).toBe(1);
-    expect(result.current.error).toBeNull();
+    expect.soft(result.current.data).toHaveLength(2);
+    expect.soft(result.current.data[0]?.id).toBe(1);
+    expect.soft(result.current.error).toBeNull();
   });
 
   it("fetch エラー時に error が設定されデータは空", async () => {
@@ -60,8 +60,8 @@ describe("useReportsList", () => {
       expect(result.current.loading).toBe(false);
     });
 
-    expect(result.current.error).toContain("500");
-    expect(result.current.data).toEqual([]);
+    expect.soft(result.current.error).toContain("500");
+    expect.soft(result.current.data).toEqual([]);
   });
 
   it("空のレポート一覧が返された場合、data は空配列", async () => {
@@ -79,8 +79,8 @@ describe("useReportsList", () => {
       expect(result.current.loading).toBe(false);
     });
 
-    expect(result.current.data).toEqual([]);
-    expect(result.current.error).toBeNull();
+    expect.soft(result.current.data).toEqual([]);
+    expect.soft(result.current.error).toBeNull();
   });
 
   it("kind が変わると再 fetch が発火する", async () => {
@@ -127,9 +127,9 @@ describe("useReport", () => {
       expect(result.current.loading).toBe(false);
     });
 
-    expect(result.current.data?.id).toBe(5);
-    expect(result.current.data?.content).toBe("# Daily Report\nContent here.");
-    expect(result.current.error).toBeNull();
+    expect.soft(result.current.data?.id).toBe(5);
+    expect.soft(result.current.data?.content).toBe("# Daily Report\nContent here.");
+    expect.soft(result.current.error).toBeNull();
   });
 
   it("fetch エラー時に error が設定される", async () => {
@@ -141,8 +141,8 @@ describe("useReport", () => {
       expect(result.current.loading).toBe(false);
     });
 
-    expect(result.current.error).toContain("404");
-    expect(result.current.data).toBeNull();
+    expect.soft(result.current.error).toContain("404");
+    expect.soft(result.current.data).toBeNull();
   });
 
   it("id が変わると再 fetch が発火する", async () => {
@@ -176,7 +176,7 @@ describe("useReport", () => {
       expect(result.current.loading).toBe(false);
     });
 
-    expect(result.current.error).toBe("Connection refused");
-    expect(result.current.data).toBeNull();
+    expect.soft(result.current.error).toBe("Connection refused");
+    expect.soft(result.current.data).toBeNull();
   });
 });

--- a/apps/web/tests/client/useStarredState.test.tsx
+++ b/apps/web/tests/client/useStarredState.test.tsx
@@ -43,15 +43,15 @@ describe("useStarredState", () => {
     act(() => {
       result.current.toggleStar(1);
     });
-    expect(result.current.isStarred(1)).toBe(false);
-    expect(result.current.isStarred(2)).toBe(true);
+    expect.soft(result.current.isStarred(1)).toBe(false);
+    expect.soft(result.current.isStarred(2)).toBe(true);
   });
 
   it("returns the same Set reference when raw is unchanged", () => {
     // raw が変わっていなければ getSnapshot が同じ参照を返すことを確認する
     localStorage.setItem("tnb-starred-articles", JSON.stringify([7, 8]));
     const { result } = renderHook(() => useStarredState());
-    expect(result.current.isStarred(7)).toBe(true);
-    expect(result.current.isStarred(99)).toBe(false);
+    expect.soft(result.current.isStarred(7)).toBe(true);
+    expect.soft(result.current.isStarred(99)).toBe(false);
   });
 });

--- a/apps/web/tests/client/useStats.test.tsx
+++ b/apps/web/tests/client/useStats.test.tsx
@@ -41,8 +41,8 @@ describe("useStats", () => {
       expect(result.current.stats).not.toBeNull();
     });
 
-    expect(result.current.stats?.total).toBe(42);
-    expect(result.current.error).toBeNull();
+    expect.soft(result.current.stats?.total).toBe(42);
+    expect.soft(result.current.error).toBeNull();
   });
 
   it("fetch エラー時に error が設定される", async () => {
@@ -66,8 +66,8 @@ describe("useStats", () => {
       expect(result.current.error).toBeTruthy();
     });
 
-    expect(result.current.error).toBe("Network timeout");
-    expect(result.current.stats).toBeNull();
+    expect.soft(result.current.error).toBe("Network timeout");
+    expect.soft(result.current.stats).toBeNull();
   });
 
   it("refreshSignal が変わると再 fetch が発火する", async () => {
@@ -102,7 +102,7 @@ describe("useStats", () => {
       expect(result.current.stats).not.toBeNull();
     });
 
-    expect(result.current.stats?.by_category["ai"]).toBe(99);
-    expect(result.current.stats?.by_category["bigtech"]).toBe(1);
+    expect.soft(result.current.stats?.by_category["ai"]).toBe(99);
+    expect.soft(result.current.stats?.by_category["bigtech"]).toBe(1);
   });
 });

--- a/apps/web/tests/client/useTheme.test.tsx
+++ b/apps/web/tests/client/useTheme.test.tsx
@@ -35,8 +35,8 @@ describe("useTheme", () => {
     act(() => {
       result.current.setTheme("dark");
     });
-    expect(result.current.theme).toBe("dark");
-    expect(result.current.resolvedTheme).toBe("dark");
+    expect.soft(result.current.theme).toBe("dark");
+    expect.soft(result.current.resolvedTheme).toBe("dark");
   });
 
   it("setTheme persists to localStorage", () => {
@@ -73,8 +73,8 @@ describe("useTheme", () => {
     act(() => {
       result.current.setTheme("system");
     });
-    expect(result.current.theme).toBe("system");
-    expect(localStorage.getItem(STORAGE_KEY)).toBe("system");
+    expect.soft(result.current.theme).toBe("system");
+    expect.soft(localStorage.getItem(STORAGE_KEY)).toBe("system");
   });
 
   it("applies data-theme attribute to html element", () => {

--- a/apps/web/tests/client/useToast.test.tsx
+++ b/apps/web/tests/client/useToast.test.tsx
@@ -101,11 +101,11 @@ describe("useToast / ToastContainer", () => {
     const msgs = toasts.map((el) => el.textContent ?? "");
 
     // 最新 3 件のみ残り、最古の「通知1」は消える
-    expect(msgs.some((m) => m.includes("通知1"))).toBe(false);
-    expect(msgs.some((m) => m.includes("通知2"))).toBe(true);
-    expect(msgs.some((m) => m.includes("通知3"))).toBe(true);
-    expect(msgs.some((m) => m.includes("通知4"))).toBe(true);
-    expect(toasts).toHaveLength(3);
+    expect.soft(msgs.some((m) => m.includes("通知1"))).toBe(false);
+    expect.soft(msgs.some((m) => m.includes("通知2"))).toBe(true);
+    expect.soft(msgs.some((m) => m.includes("通知3"))).toBe(true);
+    expect.soft(msgs.some((m) => m.includes("通知4"))).toBe(true);
+    expect.soft(toasts).toHaveLength(3);
   });
 
   it("toast 要素に aria-live='polite' と role='status' が設定されている", () => {
@@ -116,7 +116,7 @@ describe("useToast / ToastContainer", () => {
     });
 
     const toastEl = screen.getByRole("status");
-    expect(toastEl).toBeTruthy();
-    expect(toastEl.getAttribute("aria-live")).toBe("polite");
+    expect.soft(toastEl).toBeTruthy();
+    expect.soft(toastEl.getAttribute("aria-live")).toBe("polite");
   });
 });

--- a/apps/web/tests/client/useUrlState.test.tsx
+++ b/apps/web/tests/client/useUrlState.test.tsx
@@ -71,8 +71,8 @@ describe("useUrlState", () => {
       vi.advanceTimersByTime(300);
     });
 
-    expect(window.location.search).toContain("category=jp");
-    expect(result.current[0].category).toBe("jp");
+    expect.soft(window.location.search).toContain("category=jp");
+    expect.soft(result.current[0].category).toBe("jp");
   });
 
   it("setFilters({ category: '' }) で URL から category が消える", () => {
@@ -87,8 +87,8 @@ describe("useUrlState", () => {
       vi.advanceTimersByTime(300);
     });
 
-    expect(window.location.search).not.toContain("category");
-    expect(result.current[0].category).toBe("");
+    expect.soft(window.location.search).not.toContain("category");
+    expect.soft(result.current[0].category).toBe("");
   });
 
   it("bookmarksOnly: true で URL に bookmarks=only が付く", () => {
@@ -103,8 +103,8 @@ describe("useUrlState", () => {
       vi.advanceTimersByTime(300);
     });
 
-    expect(window.location.search).toContain("bookmarks=only");
-    expect(result.current[0].bookmarksOnly).toBe(true);
+    expect.soft(window.location.search).toContain("bookmarks=only");
+    expect.soft(result.current[0].bookmarksOnly).toBe(true);
   });
 
   it("bookmarksOnly: false で URL から bookmarks が消える", () => {
@@ -120,8 +120,8 @@ describe("useUrlState", () => {
       vi.advanceTimersByTime(300);
     });
 
-    expect(window.location.search).not.toContain("bookmarks");
-    expect(result.current[0].bookmarksOnly).toBe(false);
+    expect.soft(window.location.search).not.toContain("bookmarks");
+    expect.soft(result.current[0].bookmarksOnly).toBe(false);
   });
 
   it("popstate dispatch で state が更新される", () => {
@@ -161,8 +161,8 @@ describe("useUrlState", () => {
     });
 
     // debounce が解消されて最後の値 "ab" が URL に反映される
-    expect(window.location.search).toContain("q=ab");
-    expect(result.current[0].q).toBe("ab");
+    expect.soft(window.location.search).toContain("q=ab");
+    expect.soft(result.current[0].q).toBe("ab");
   });
 
   it("不正な category 値は '' にフォールバックする", () => {


### PR DESCRIPTION
## Summary

- `apps/web/tests/client/**` 45 ファイルを精査し、**独立した観点を複数検証している箇所**に `expect.soft(...)` を適用 (Wave 3)
- Wave 1/2 のレビュー指摘 (guard / prerequisite は plain 維持) を踏襲
- 34 ファイル touched、11 ファイル skipped (soft 化すべき候補なし)

## 変更詳細

| 項目 | 数値 |
|---|---|
| touched ファイル | 34 |
| skipped ファイル | 11 |
| soft assertion 追加件数 | 226 |
| 変更行数 | +234 / -232 |

### touched (34 ファイル)

- `useArticlesCalendar.test.tsx` — items/error の独立観点
- `useAuthorArticles.test.tsx` — articles/error/hasMore
- `useBookmarks.test.tsx` — localStorage persistence, clear(), same-Set-reference
- `useCategories.test.tsx` — categories/error/isLoading 初期状態
- `useFeedArticles.test.tsx` — articles/error/hasMore
- `useFeedDetail.test.tsx` — feed/articles/error (404/500/ネットワーク例外)
- `useFeeds.test.tsx` — feeds/error
- `useFilterHandlers.test.tsx` — handleClear / handleApplyPreset の各 setter
- `usePresets.test.tsx` — preset フィールド, alert/size
- `useReadState.test.tsx` — isRead の複数 ID
- `useRecentSearches.test.tsx` — 順序/重複排除/トリム/remove
- `useReports.test.tsx` — data/error (list + detail)
- `useStarredState.test.tsx` — isStarred の複数 ID
- `useStats.test.tsx` — stats.total/error, by_category 各キー
- `useTheme.test.tsx` — theme/resolvedTheme, theme/localStorage
- `useToast.test.tsx` — aria-live/role=status, 3件上限判定
- `useUrlState.test.tsx` — URL と hook state の対
- `BookmarkButton.test.tsx` — aria-pressed + textContent
- `CalendarHeatmap.test.tsx` — aria-label の日付と件数
- `CategoriesOverview.test.tsx` — 4カテゴリ描画, feeds_count/articles_30d
- `EmptyState.test.tsx` — icon/title/body の3要素
- `FeedDetail.test.tsx` — URL/articles_30d, fetch URL 4件
- `FilterBar.test.tsx` — aria-label 3 combobox, clearBtn/onClear
- `Header.test.tsx` — 3テーマボタン
- `HelpModal.test.tsx` — dialog/タイトル, ショートカット行3件
- `ReportsList.test.tsx` — 日次/週次ラベル, aria-pressed 2ボタン
- `SearchInput.test.tsx` — ref.tagName / ref.value
- `SearchSuggestions.test.tsx` — 3アイテム描画
- `ShareButtons.test.tsx` — href の3要素, target/rel
- `ShortcutsHelp.test.tsx` — dialog/タイトル, 7ショートカット行
- `StaleFeedsWarning.test.tsx` — 2フィード名, details/summary
- `StatsChart.test.tsx` — svg/tagName, title要素内容
- `StatsDashboard.test.tsx` — authors/publishers/lang/category
- `ThemeToggle.test.tsx` — 3ボタン描画, aria-pressed 3ボタン

### skipped (11 ファイル, 変更なし)

- `ArticleCard.test.tsx` — 各テストは単一観点または依存チェーン
- `ArticleList.test.tsx` — 各テストは単一観点
- `AuthorDetail.test.tsx` — 各テストは単一観点
- `FeedDetail.test.tsx` の一部テスト — waitFor内は prerequisite
- `ReportDetail.test.tsx` — 各テストは単一観点
- `PresetBar.test.tsx` — mock 観点のみ
- `ThemeToggle.test.tsx` の一部テスト — 各1件
- `Toast.test.tsx` — 各テストは1件
- `ToastContainer.test.tsx` (= useToast.test.tsx に含む)
- `useArticles.test.tsx` — 各テストは単一観点または依存チェーン
- `useKeyboardNav.test.tsx` — 各テストは単一観点
- `useKeyboardShortcuts.test.tsx` — mock 観点 (spy 呼び出し回数)

## 適用方針

1. **同じ対象の独立した側面** (status / header / body の各キー、複数 UI 要素) → `expect.soft(...)`
2. **guard / prerequisite** (後続コードが依存する前提確認) → plain `expect` のまま
3. **mock 観点** (`spy.toHaveBeenCalled`) → 基本 plain (古典派方針)

## Test plan

- [x] `pnpm --filter @tnb/web test:client` 338 tests passed
- [x] `pnpm --filter @tnb/web build` 成功
- [x] `vp lint` 0 errors (21 warnings は既存)
- [x] `pnpm typecheck` 成功

Closes #368