### PR TITLE
fix(collector): respect COLLECTOR_RETRIES=0 and stabilize admin tests

### DIFF
--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -21,6 +21,10 @@ export default defineConfig(async () => {
             // 本番は 1 並列だが、テストでは全 yaml feed を直列に回すと per-feed retry で
             // 25-30s deadline を超えるため 4 並列に上書きする (Medium レート制限テストではない)
             COLLECTOR_CONCURRENCY: "4",
+            // 全 enabled feed (45 件超) × per-feed retry x backoff sleep が 25s deadline に
+            // 張り付き /api/admin/collector/run が CI で 504 flaky になっていたため、
+            // retry を無効化する。リトライ自体の挙動は collector/retry.test.ts が個別に検証する。
+            COLLECTOR_RETRIES: "0",
           },
         },
       }),

--- a/apps/web/worker/collector/index.ts
+++ b/apps/web/worker/collector/index.ts
@@ -425,7 +425,9 @@ export async function collectAll(
 
   const concurrency = Number(env.COLLECTOR_CONCURRENCY ?? "4") || 4;
   const timeoutMs = Number(env.COLLECTOR_TIMEOUT_MS ?? "10000") || 10000;
-  const maxRetries = Number(env.COLLECTOR_RETRIES ?? "2") || 2;
+  // 0 (リトライ無効) を許容するため `|| 2` フォールバックは使わず NaN/負数のみデフォルトに落とす。
+  const maxRetriesRaw = Number(env.COLLECTOR_RETRIES ?? "2");
+  const maxRetries = Number.isFinite(maxRetriesRaw) && maxRetriesRaw >= 0 ? maxRetriesRaw : 2;
   const summaryMax = Number(env.SUMMARY_MAX_LENGTH ?? "500") || 500;
 
   const d1Acc = new D1CostAccumulator();


### PR DESCRIPTION
## Summary
- collector の `Number(env.COLLECTOR_RETRIES ?? \"2\") || 2` で `COLLECTOR_RETRIES=0` が falsy 扱いとなりデフォルト 2 に落ちていたバグを修正 (`Number.isFinite` + `>= 0` で判定)
- `vitest.config.ts` に `COLLECTOR_RETRIES: \"0\"` を追加。retry 無効化により admin.test.ts の所要時間が 60s+ → ~14s に短縮し 504 flaky を解消

## Background
admin.test.ts の `POST /api/admin/collector/run` 等が CI で `expected 504 to be 200` で flaky だった。
原因は 45+ enabled feed × per-feed retry × backoff sleep が 25s handler deadline を超えるため。
さらに `COLLECTOR_RETRIES=0` を vitest config に入れても上記 falsy バグで効かず、リトライが走り続けていた。

## Test plan
- [x] `pnpm test tests/worker/api/admin.test.ts` を 5 回連続実行 → 全 28 テストパス・Duration 14-16s で安定
- [x] `pnpm test` (worker pool 全体 660 テスト) パス
- [x] `pnpm typecheck` パス
- リトライ自体の挙動は `collector/retry.test.ts` が個別検証 (本 PR で影響なし)

Closes #377

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the retry configuration parameter was not being properly recognized, preventing retry logic from being disabled. This resolves CI flakiness that previously caused 504 errors during collection runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->