### PR TITLE
fix(workflows): override CLI default haiku to current model

### DIFF
--- a/.github/workflows/report-daily.yml
+++ b/.github/workflows/report-daily.yml
@@ -41,6 +41,9 @@ jobs:
           NODE_VERSION: "24"
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # CLI 内部 (WebFetch URL 要約など) の haiku デフォルトが廃止モデル
+          # claude-3-5-haiku-20241022 になっており 404 で失敗するため、現行版に上書き。
+          ANTHROPIC_DEFAULT_HAIKU_MODEL: "claude-haiku-4-5-20251001"
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # 廃止モデル (claude-3-5-haiku-20241022) への自動 fallback で 404 が出るため

--- a/.github/workflows/report-monthly.yml
+++ b/.github/workflows/report-monthly.yml
@@ -39,6 +39,9 @@ jobs:
           NODE_VERSION: "24"
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # CLI 内部 (WebFetch URL 要約など) の haiku デフォルトが廃止モデル
+          # claude-3-5-haiku-20241022 になっており 404 で失敗するため、現行版に上書き。
+          ANTHROPIC_DEFAULT_HAIKU_MODEL: "claude-haiku-4-5-20251001"
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # 廃止モデル (claude-3-5-haiku-20241022) への自動 fallback で 404 が出るため

--- a/.github/workflows/report-weekly.yml
+++ b/.github/workflows/report-weekly.yml
@@ -38,6 +38,9 @@ jobs:
           NODE_VERSION: "24"
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # CLI 内部 (WebFetch URL 要約など) の haiku デフォルトが廃止モデル
+          # claude-3-5-haiku-20241022 になっており 404 で失敗するため、現行版に上書き。
+          ANTHROPIC_DEFAULT_HAIKU_MODEL: "claude-haiku-4-5-20251001"
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # 廃止モデル (claude-3-5-haiku-20241022) への自動 fallback で 404 が出るため


### PR DESCRIPTION
## Summary
- 3 つの report workflow (daily / weekly / monthly) の \`claude-code-base-action\` 呼び出しに \`ANTHROPIC_DEFAULT_HAIKU_MODEL: claude-haiku-4-5-20251001\` を env 追加
- これにより CLI 内部 (WebFetch URL 要約等) で参照される廃止 haiku の 404 を解消

## Background
Claude Code CLI v2.1.123 (claude-code-base-action 内に pin 済み) が WebFetch の URL summary に廃止モデル \`claude-3-5-haiku-20241022\` をハードコード呼び出ししており、 skill が WebFetch するたびに 404 が出ていた。
\`anthropics/claude-code-base-action\` の action.yml は \`ANTHROPIC_DEFAULT_HAIKU_MODEL\` env を CLI に passthrough しているため、 workflow 側で env をセットすれば現行モデルにオーバーライドできる。
これで Stage 3 deep mode の本文取得が \`(summary based)\` フォールバックに落ちなくなり要約品質が回復する。

## Test plan
- [x] yaml syntax 検証 (\`yaml.safe_load\`) パス
- [ ] \`workflow_dispatch\` で report-daily を手動実行し、 WebFetch が 404 にならず本文ベース要約が出力されることを確認 (マージ後の next dispatch で観測)
- 既存の \`model: claude-sonnet-4-5-20250929\` (会話モデル) はそのまま維持

Closes #376