### PR TITLE
fix: comprehensive security hardening (CSP/HSTS/CORS/Access/SHA pin)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,13 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "24"
           cache: "pnpm"
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@4f5aa3e38c781f1b01e78fb9255527cee8a6efa6 # v1
         with:
           node-version: "24"
           cache: true
@@ -33,13 +33,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "24"
           cache: "pnpm"
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@4f5aa3e38c781f1b01e78fb9255527cee8a6efa6 # v1
         with:
           node-version: "24"
           cache: true
@@ -48,7 +48,7 @@ jobs:
       - name: vp build
         run: vp run build
       - name: Upload build artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: web-dist
           path: apps/web/dist/
@@ -59,20 +59,20 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "24"
           cache: "pnpm"
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@4f5aa3e38c781f1b01e78fb9255527cee8a6efa6 # v1
         with:
           node-version: "24"
           cache: true
       - run: pnpm install --frozen-lockfile
       - run: pnpm cf-typegen
       - name: Download build artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: web-dist
           path: apps/web/dist/
@@ -83,13 +83,13 @@ jobs:
   test-client:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "24"
           cache: "pnpm"
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@4f5aa3e38c781f1b01e78fb9255527cee8a6efa6 # v1
         with:
           node-version: "24"
           cache: true

--- a/.github/workflows/cleanup-orphan-previews.yml
+++ b/.github/workflows/cleanup-orphan-previews.yml
@@ -28,7 +28,7 @@ jobs:
       DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: List open PR numbers
         id: prs

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,13 +21,13 @@ jobs:
       group: deploy-prod
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "24"
           cache: "pnpm"
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@4f5aa3e38c781f1b01e78fb9255527cee8a6efa6 # v1
         with:
           node-version: "24"
           cache: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "24"
           cache: "pnpm"
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@4f5aa3e38c781f1b01e78fb9255527cee8a6efa6 # v1
         with:
           node-version: "24"
           cache: true
@@ -37,7 +37,7 @@ jobs:
           CI: "true"
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-report
           path: apps/web/playwright-report/

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -16,13 +16,13 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "24"
           cache: "pnpm"
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@4f5aa3e38c781f1b01e78fb9255527cee8a6efa6 # v1
         with:
           node-version: "24"
           cache: true
@@ -44,7 +44,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       - name: Comment preview URL on PR
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
@@ -66,9 +66,9 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "24"
           cache: "pnpm"
@@ -82,7 +82,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       - name: Comment cleanup on PR
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |

--- a/.github/workflows/report-daily.yml
+++ b/.github/workflows/report-daily.yml
@@ -19,11 +19,11 @@ jobs:
       group: report-daily
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "24"
           cache: "pnpm"
@@ -34,7 +34,7 @@ jobs:
       # cf-typegen は build に依存するため明示的に走らせない (skill は recent.mjs しか使わない)。
 
       - name: Run tech-news-digest skill
-        uses: anthropics/claude-code-base-action@beta
+        uses: anthropics/claude-code-base-action@e8132bc5e637a42c27763fc757faa37e1ee43b34 # beta (pinned 2026-04-30)
         env:
           # claude-code-base-action 内部の Setup Node.js が default 18 を入れるため、
           # wrangler d1 (Node v20+ 必須) が落ちる。skill が呼ぶ recent.mjs のために 24 を強制。

--- a/.github/workflows/report-monthly.yml
+++ b/.github/workflows/report-monthly.yml
@@ -20,11 +20,11 @@ jobs:
       group: report-monthly
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "24"
           cache: "pnpm"
@@ -32,7 +32,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Run tech-news-weekly skill (monthly)
-        uses: anthropics/claude-code-base-action@beta
+        uses: anthropics/claude-code-base-action@e8132bc5e637a42c27763fc757faa37e1ee43b34 # beta (pinned 2026-04-30)
         env:
           # claude-code-base-action 内部の Setup Node.js が default 18 を入れるため、
           # wrangler d1 (Node v20+ 必須) が落ちる。skill が呼ぶ recent.mjs のために 24 を強制。

--- a/.github/workflows/report-weekly.yml
+++ b/.github/workflows/report-weekly.yml
@@ -19,11 +19,11 @@ jobs:
       group: report-weekly
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "24"
           cache: "pnpm"
@@ -31,7 +31,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Run tech-news-weekly skill
-        uses: anthropics/claude-code-base-action@beta
+        uses: anthropics/claude-code-base-action@e8132bc5e637a42c27763fc757faa37e1ee43b34 # beta (pinned 2026-04-30)
         env:
           # claude-code-base-action 内部の Setup Node.js が default 18 を入れるため、
           # wrangler d1 (Node v20+ 必須) が落ちる。skill が呼ぶ recent.mjs のために 24 を強制。

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,9 +14,9 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "24"
           cache: "pnpm"

--- a/.github/workflows/validate-feeds.yml
+++ b/.github/workflows/validate-feeds.yml
@@ -16,9 +16,9 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "24"
           cache: "pnpm"

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist/
 !.env.example
 .dev.vars
 .dev.vars.*
+!.dev.vars.example
 .DS_Store
 *.log
 .vscode/

--- a/apps/web/.dev.vars.example
+++ b/apps/web/.dev.vars.example
@@ -1,0 +1,11 @@
+# ローカル開発で wrangler dev / vp test を動かすときの env 例
+# このファイルをコピーして .dev.vars を作成する (.dev.vars は gitignore 済み)
+
+ADMIN_TOKEN=local-dev-admin-token
+CORS_ALLOWED_ORIGINS=http://localhost:5173
+
+# Cloudflare Access の検証をスキップ (ローカルでは Access が前段にいないため)
+SKIP_ACCESS_JWT=1
+# 本番設定例 (動作確認用):
+# CF_ACCESS_AUD=<audience-tag-from-zero-trust-dashboard>
+# CF_ACCESS_TEAM_DOMAIN=<team>.cloudflareaccess.com

--- a/apps/web/client/components/ArticleCard.tsx
+++ b/apps/web/client/components/ArticleCard.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import { useReadState } from "../hooks/useReadState";
 import { useStarredState } from "../hooks/useStarredState";
 import type { Article, FeedCategory } from "../types/api";
+import { safeHref } from "../utils/safe-href";
 import { BookmarkButton } from "./BookmarkButton";
 import { ShareButtons } from "./ShareButtons";
 
@@ -62,15 +63,6 @@ function formatDate(iso: string): string {
     hour: "2-digit",
     minute: "2-digit",
   });
-}
-
-function safeHref(url: string): string {
-  try {
-    const u = new URL(url);
-    return u.protocol === "https:" || u.protocol === "http:" ? url : "#";
-  } catch {
-    return "#";
-  }
 }
 
 export function ArticleCard({

--- a/apps/web/client/components/ReportDetail.tsx
+++ b/apps/web/client/components/ReportDetail.tsx
@@ -2,6 +2,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { Components } from "react-markdown";
 import { useReport } from "../hooks/useReports";
+import { safeHref } from "../utils/safe-href";
 
 const KIND_LABELS: Record<string, string> = {
   daily: "日次",
@@ -36,10 +37,11 @@ function formatDate(iso: string): string {
   });
 }
 
-// markdown 内のリンクを新タブで開くカスタムレンダラ
+// markdown 内のリンクを新タブで開くカスタムレンダラ。
+// javascript:/data: などの危険な URI を遮断するため safeHref を通す
 const markdownComponents: Components = {
   a: ({ href, children, ...props }) => (
-    <a href={href} target="_blank" rel="noopener noreferrer" {...props}>
+    <a href={safeHref(href)} target="_blank" rel="noopener noreferrer" {...props}>
       {children}
     </a>
   ),

--- a/apps/web/client/components/ShareButtons.tsx
+++ b/apps/web/client/components/ShareButtons.tsx
@@ -36,7 +36,7 @@ export function ShareButtons({ url, title }: Props) {
       <a
         href={xHref}
         target="_blank"
-        rel="noopener"
+        rel="noopener noreferrer"
         className={shareButtonBase}
         aria-label="X (Twitter) でシェア"
       >
@@ -55,7 +55,7 @@ export function ShareButtons({ url, title }: Props) {
       <a
         href={hatenaHref}
         target="_blank"
-        rel="noopener"
+        rel="noopener noreferrer"
         className={shareButtonBase}
         aria-label="はてなブックマークに追加"
       >

--- a/apps/web/client/utils/safe-href.ts
+++ b/apps/web/client/utils/safe-href.ts
@@ -1,0 +1,8 @@
+// javascript:/data:/vbscript: などの危険な URI スキームをブロックし、
+// http: / https: 以外は "#" にフォールバックする
+export function safeHref(url: string | undefined): string {
+  if (!url) return "#";
+  const trimmed = url.trim();
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+  return "#";
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "fast-xml-parser": "^5.7.2",
     "hono": "^4.12.15",
+    "jose": "^6.2.3",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "react-markdown": "^10.1.0",

--- a/apps/web/tests/client/ReportDetail.test.tsx
+++ b/apps/web/tests/client/ReportDetail.test.tsx
@@ -103,4 +103,20 @@ describe("ReportDetail", () => {
 
     expect(screen.getByText("← 一覧に戻る")).toBeTruthy();
   });
+
+  it("markdown 内の javascript: リンクが href='#' にサニタイズされる", async () => {
+    const detail = makeDetail({
+      content: "[危険リンク](javascript:alert(1))",
+    });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeDetailResponse(detail)));
+
+    const { container } = render(<ReportDetailComponent id={1} onBack={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("読み込み中...")).toBeNull();
+    });
+
+    const link = container.querySelector("a[href]");
+    expect(link?.getAttribute("href")).toBe("#");
+  });
 });

--- a/apps/web/tests/client/ShareButtons.test.tsx
+++ b/apps/web/tests/client/ShareButtons.test.tsx
@@ -25,12 +25,13 @@ describe("ShareButtons", () => {
     expect.soft(href).toContain(encodeURIComponent(TEST_TITLE));
   });
 
-  it("X and Hatena links open in new tab with noopener", () => {
+  it("X and Hatena links open in new tab with noopener noreferrer", () => {
     render(<ShareButtons url={TEST_URL} title={TEST_TITLE} />);
     for (const label of [/X \(Twitter\)/i, /はてなブックマーク/i]) {
       const link = screen.getByRole("link", { name: label });
       expect.soft(link.getAttribute("target")).toBe("_blank");
       expect.soft(link.getAttribute("rel")).toContain("noopener");
+      expect.soft(link.getAttribute("rel")).toContain("noreferrer");
     }
   });
 

--- a/apps/web/tests/client/safe-href.test.ts
+++ b/apps/web/tests/client/safe-href.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vite-plus/test";
+import { safeHref } from "../../client/utils/safe-href";
+
+describe("safeHref", () => {
+  it("https: URL をそのまま返す", () => {
+    expect(safeHref("https://example.com")).toBe("https://example.com");
+  });
+
+  it("http: URL をそのまま返す", () => {
+    expect(safeHref("http://example.com")).toBe("http://example.com");
+  });
+
+  it("javascript: URI を '#' にフォールバックする", () => {
+    expect(safeHref("javascript:alert(1)")).toBe("#");
+  });
+
+  it("data: URI を '#' にフォールバックする", () => {
+    expect(safeHref("data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==")).toBe("#");
+  });
+
+  it("vbscript: URI を '#' にフォールバックする", () => {
+    expect(safeHref("vbscript:msgbox()")).toBe("#");
+  });
+
+  it("undefined を '#' にフォールバックする", () => {
+    expect(safeHref(undefined)).toBe("#");
+  });
+
+  it("空文字を '#' にフォールバックする", () => {
+    expect(safeHref("")).toBe("#");
+  });
+
+  it("前後に空白がある https: URL を trim して返す", () => {
+    expect(safeHref("  https://x.com  ")).toBe("https://x.com");
+  });
+
+  it("前後に空白がある http: URL を trim して返す", () => {
+    expect(safeHref("  http://example.com  ")).toBe("http://example.com");
+  });
+
+  it("スキームなし相対 URL を '#' にフォールバックする", () => {
+    expect(safeHref("/foo/bar")).toBe("#");
+  });
+});

--- a/apps/web/tests/worker/api/api.test.ts
+++ b/apps/web/tests/worker/api/api.test.ts
@@ -192,17 +192,51 @@ describe("/api/articles", () => {
     expect(body.articles.map((a) => a.guid)).toEqual(["g-ai"]);
   });
 
-  it("ignores invalid date_from silently (returns all)", async () => {
+  it("rejects invalid date_from with 400", async () => {
     const res = await SELF.fetch("https://example.com/api/articles?date_from=not-a-date");
-    const body = (await res.json()) as { articles: { guid: string }[] };
-    expect(body.articles.length).toBe(3);
+    expect.soft(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect.soft(body.error).toBe("invalid date_from");
   });
 
-  it("ignores invalid date_to silently (returns all)", async () => {
+  it("rejects invalid date_to (out-of-range month) with 400", async () => {
     const res = await SELF.fetch("https://example.com/api/articles?date_to=2024-99-99");
-    // 形式チェックは YYYY-MM-DD 形式なのでパスするが、SQLite が正規化して結果が変わる可能性あり
-    // 不正な日付でもクラッシュせず 200 を返すことを確認
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect.soft(body.error).toBe("invalid date_to");
+  });
+
+  it("date_from: 9999-99-99 (overflowing date) → 400", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles?date_from=9999-99-99");
+    expect.soft(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect.soft(body.error).toBe("invalid date_from");
+  });
+
+  it("date_from: 2024-13-01 (invalid month) → 400", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles?date_from=2024-13-01");
+    expect.soft(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect.soft(body.error).toBe("invalid date_from");
+  });
+
+  it("date_from: 2024-02-30 (Feb 30 does not exist) → 400", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles?date_from=2024-02-30");
+    expect.soft(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect.soft(body.error).toBe("invalid date_from");
+  });
+
+  it("date_from: 2024-02-29 (leap year) → 200", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles?date_from=2024-02-29");
+    expect.soft(res.status).toBe(200);
+  });
+
+  it("date_from and date_to both valid → 200", async () => {
+    const res = await SELF.fetch(
+      "https://example.com/api/articles?date_from=2024-01-01&date_to=2024-12-31",
+    );
+    expect.soft(res.status).toBe(200);
   });
 });
 
@@ -372,6 +406,22 @@ describe("CORS headers on public /api/* endpoints", () => {
     });
     expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
   }, 60000);
+
+  it("does NOT return Access-Control-Allow-Origin for unlisted origin", async () => {
+    // CORS_ALLOWED_ORIGINS に含まれていない origin からのリクエストはヘッダーなし
+    const res = await SELF.fetch("https://example.com/api/articles", {
+      headers: { origin: "https://attacker.example.com" },
+    });
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
+  });
+
+  it("reflects only the matching origin (not wildcard) for allowed origin", async () => {
+    // origin: 関数を使っているため * ではなく origin 文字列を返す
+    const res = await SELF.fetch("https://example.com/api/health", {
+      headers: { origin: allowedOrigin },
+    });
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe(allowedOrigin);
+  });
 });
 
 describe("security headers", () => {
@@ -380,6 +430,56 @@ describe("security headers", () => {
     expect(res.headers.get("X-Frame-Options")).toBe("DENY");
     expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
     expect(res.headers.get("Content-Security-Policy")).toContain("default-src 'self'");
+  });
+
+  it("sets Strict-Transport-Security on /api/health", async () => {
+    const res = await SELF.fetch("https://example.com/api/health");
+    expect
+      .soft(res.headers.get("Strict-Transport-Security"))
+      .toBe("max-age=31536000; includeSubDomains");
+  });
+
+  it("sets Cross-Origin-Opener-Policy: same-origin on /api/health", async () => {
+    const res = await SELF.fetch("https://example.com/api/health");
+    expect.soft(res.headers.get("Cross-Origin-Opener-Policy")).toBe("same-origin");
+  });
+
+  it("sets Cross-Origin-Resource-Policy: same-origin on /api/health (non-syndication)", async () => {
+    const res = await SELF.fetch("https://example.com/api/health");
+    expect.soft(res.headers.get("Cross-Origin-Resource-Policy")).toBe("same-origin");
+  });
+
+  it("sets Cross-Origin-Resource-Policy: cross-origin on /feed.json (syndication)", async () => {
+    const res = await SELF.fetch("https://example.com/feed.json");
+    expect.soft(res.headers.get("Cross-Origin-Resource-Policy")).toBe("cross-origin");
+  });
+
+  it("sets Cross-Origin-Resource-Policy: cross-origin on /feed.xml (syndication)", async () => {
+    const res = await SELF.fetch("https://example.com/feed.xml");
+    expect.soft(res.headers.get("Cross-Origin-Resource-Policy")).toBe("cross-origin");
+  });
+
+  it("sets Cross-Origin-Resource-Policy: cross-origin on /feed.atom (syndication)", async () => {
+    const res = await SELF.fetch("https://example.com/feed.atom");
+    expect.soft(res.headers.get("Cross-Origin-Resource-Policy")).toBe("cross-origin");
+  });
+
+  it("sets Cross-Origin-Resource-Policy: cross-origin on /feeds/openai-blog.xml (per-feed syndication)", async () => {
+    const res = await SELF.fetch("https://example.com/feeds/openai-blog.xml");
+    expect.soft(res.headers.get("Cross-Origin-Resource-Policy")).toBe("cross-origin");
+  });
+
+  it("sets Cross-Origin-Resource-Policy: cross-origin on /feeds.opml", async () => {
+    const res = await SELF.fetch("https://example.com/feeds.opml");
+    expect.soft(res.headers.get("Cross-Origin-Resource-Policy")).toBe("cross-origin");
+  });
+
+  it("sets Strict-Transport-Security and COOP on static asset /assets/index-BYIbkfak.js", async () => {
+    const res = await SELF.fetch("https://example.com/assets/index-BYIbkfak.js");
+    expect
+      .soft(res.headers.get("Strict-Transport-Security"))
+      .toBe("max-age=31536000; includeSubDomains");
+    expect.soft(res.headers.get("Cross-Origin-Opener-Policy")).toBe("same-origin");
   });
 });
 

--- a/apps/web/tests/worker/api/articles/by-author.test.ts
+++ b/apps/web/tests/worker/api/articles/by-author.test.ts
@@ -148,4 +148,12 @@ describe("GET /api/articles/by-author/:author", () => {
     expect.soft(res.status).toBe(200);
     expect.soft(res.headers.get("Cache-Control")).toBe("public, max-age=300");
   });
+
+  it("returns 400 when author exceeds 200 characters", async () => {
+    const longAuthor = encodeURIComponent("a".repeat(201));
+    const res = await SELF.fetch(`https://example.com/api/articles/by-author/${longAuthor}`);
+    expect.soft(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect.soft(body.error).toBe("author too long");
+  });
 });

--- a/apps/web/tests/worker/api/articles/by-feed.test.ts
+++ b/apps/web/tests/worker/api/articles/by-feed.test.ts
@@ -169,4 +169,12 @@ describe("GET /api/articles/by-feed/:feedId", () => {
     expect.soft(res.status).toBe(200);
     expect.soft(res.headers.get("Cache-Control")).toBe("public, max-age=300");
   });
+
+  it("returns 400 when feedId exceeds 200 characters", async () => {
+    const longFeedId = encodeURIComponent("f".repeat(201));
+    const res = await SELF.fetch(`https://example.com/api/articles/by-feed/${longFeedId}`);
+    expect.soft(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect.soft(body.error).toBe("feedId too long");
+  });
 });

--- a/apps/web/tests/worker/collector/url-safety.test.ts
+++ b/apps/web/tests/worker/collector/url-safety.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from "vite-plus/test";
+import { checkUrlSafety } from "../../../worker/collector/url-safety";
+
+describe("checkUrlSafety", () => {
+  describe("allows safe public URLs", () => {
+    it("allows https with a public hostname", () => {
+      const result = checkUrlSafety("https://example.com/feed.xml");
+      expect.soft(result.ok).toBe(true);
+      if (result.ok) {
+        expect.soft(result.url.hostname).toBe("example.com");
+      }
+    });
+
+    it("allows http with a public hostname", () => {
+      const result = checkUrlSafety("http://example.org");
+      expect.soft(result.ok).toBe(true);
+    });
+
+    it("allows arbitrary port on a public hostname", () => {
+      const result = checkUrlSafety("https://example.com:8080/x");
+      expect.soft(result.ok).toBe(true);
+    });
+  });
+
+  describe("blocks non-http/https protocols", () => {
+    it("blocks file:// protocol", () => {
+      const result = checkUrlSafety("file:///etc/passwd");
+      expect.soft(result.ok).toBe(false);
+      if (!result.ok) {
+        expect.soft(result.reason).toContain("protocol not allowed");
+      }
+    });
+
+    it("blocks ftp:// protocol", () => {
+      const result = checkUrlSafety("ftp://example.com/feed.xml");
+      expect.soft(result.ok).toBe(false);
+    });
+
+    it("blocks gopher:// protocol", () => {
+      const result = checkUrlSafety("gopher://example.com/");
+      expect.soft(result.ok).toBe(false);
+    });
+
+    it("rejects invalid URL that cannot be parsed", () => {
+      const result = checkUrlSafety("not-a-url");
+      expect.soft(result.ok).toBe(false);
+      if (!result.ok) {
+        expect.soft(result.reason).toBe("invalid URL");
+      }
+    });
+  });
+
+  describe("blocks localhost and local hostnames", () => {
+    it("blocks localhost", () => {
+      const result = checkUrlSafety("https://localhost/x");
+      expect.soft(result.ok).toBe(false);
+      if (!result.ok) {
+        expect.soft(result.reason).toContain("host blocked");
+      }
+    });
+
+    it("blocks LOCALHOST (case-insensitive)", () => {
+      const result = checkUrlSafety("https://LOCALHOST/x");
+      expect.soft(result.ok).toBe(false);
+    });
+
+    it("blocks subdomains of localhost", () => {
+      const result = checkUrlSafety("https://foo.localhost/x");
+      expect.soft(result.ok).toBe(false);
+    });
+
+    it("blocks .local mDNS hostnames", () => {
+      const result = checkUrlSafety("https://myserver.local/feed");
+      expect.soft(result.ok).toBe(false);
+    });
+
+    it("blocks metadata.google.internal (GCP metadata)", () => {
+      const result = checkUrlSafety("http://metadata.google.internal/computeMetadata/v1/");
+      expect.soft(result.ok).toBe(false);
+      if (!result.ok) {
+        expect.soft(result.reason).toContain("host blocked");
+      }
+    });
+  });
+
+  describe("blocks private IPv4 addresses", () => {
+    it("blocks 127.0.0.1 (loopback)", () => {
+      const result = checkUrlSafety("https://127.0.0.1/x");
+      expect.soft(result.ok).toBe(false);
+      if (!result.ok) {
+        expect.soft(result.reason).toContain("private IPv4");
+      }
+    });
+
+    it("blocks 127.0.0.2 (loopback range)", () => {
+      const result = checkUrlSafety("https://127.0.0.2/x");
+      expect.soft(result.ok).toBe(false);
+    });
+
+    it("blocks 169.254.169.254 (AWS metadata endpoint)", () => {
+      const result = checkUrlSafety("https://169.254.169.254/latest/meta-data/");
+      expect.soft(result.ok).toBe(false);
+      if (!result.ok) {
+        expect.soft(result.reason).toContain("private IPv4");
+      }
+    });
+
+    it("blocks 10.0.0.1 (RFC 1918 class A)", () => {
+      const result = checkUrlSafety("https://10.0.0.1/x");
+      expect.soft(result.ok).toBe(false);
+    });
+
+    it("blocks 10.255.255.255 (RFC 1918 class A upper bound)", () => {
+      const result = checkUrlSafety("https://10.255.255.255/x");
+      expect.soft(result.ok).toBe(false);
+    });
+
+    it("blocks 192.168.1.1 (RFC 1918 class C)", () => {
+      const result = checkUrlSafety("https://192.168.1.1/x");
+      expect.soft(result.ok).toBe(false);
+    });
+
+    it("blocks 172.16.0.1 (RFC 1918 class B lower bound)", () => {
+      const result = checkUrlSafety("https://172.16.0.1/x");
+      expect.soft(result.ok).toBe(false);
+    });
+
+    it("blocks 172.31.255.255 (RFC 1918 class B upper bound)", () => {
+      const result = checkUrlSafety("https://172.31.255.255/x");
+      expect.soft(result.ok).toBe(false);
+    });
+
+    it("allows 172.32.0.1 (just outside RFC 1918 class B)", () => {
+      const result = checkUrlSafety("https://172.32.0.1/x");
+      expect.soft(result.ok).toBe(true);
+    });
+
+    it("blocks 0.0.0.0 (0.0.0.0/8)", () => {
+      const result = checkUrlSafety("https://0.0.0.0/x");
+      expect.soft(result.ok).toBe(false);
+    });
+
+    it("blocks 100.64.0.1 (CGNAT)", () => {
+      const result = checkUrlSafety("https://100.64.0.1/x");
+      expect.soft(result.ok).toBe(false);
+    });
+
+    it("blocks 224.0.0.1 (multicast)", () => {
+      const result = checkUrlSafety("https://224.0.0.1/x");
+      expect.soft(result.ok).toBe(false);
+    });
+
+    it("blocks 240.0.0.1 (reserved)", () => {
+      const result = checkUrlSafety("https://240.0.0.1/x");
+      expect.soft(result.ok).toBe(false);
+    });
+  });
+
+  describe("blocks numeric hostnames (octal/hex disguise)", () => {
+    it("blocks 0177.0.0.1 (octal representation of 127.0.0.1, normalized by URL parser)", () => {
+      // URL クラスが 0177.0.0.1 → 127.0.0.1 に正規化するため private IPv4 としてブロックされる
+      const result = checkUrlSafety("https://0177.0.0.1/x");
+      expect.soft(result.ok).toBe(false);
+    });
+  });
+
+  describe("blocks private IPv6 addresses", () => {
+    it("blocks [::1] (IPv6 loopback)", () => {
+      const result = checkUrlSafety("http://[::1]/x");
+      expect.soft(result.ok).toBe(false);
+      if (!result.ok) {
+        expect.soft(result.reason).toContain("private IPv6");
+      }
+    });
+
+    it("blocks [fe80::1] (link-local)", () => {
+      const result = checkUrlSafety("http://[fe80::1]/x");
+      expect.soft(result.ok).toBe(false);
+    });
+
+    it("blocks [2001:db8::1] (documentation range)", () => {
+      const result = checkUrlSafety("http://[2001:db8::1]/x");
+      expect.soft(result.ok).toBe(false);
+    });
+
+    it("blocks [fc00::1] (unique local)", () => {
+      const result = checkUrlSafety("http://[fc00::1]/x");
+      expect.soft(result.ok).toBe(false);
+    });
+
+    it("blocks [fd00::1] (unique local)", () => {
+      const result = checkUrlSafety("http://[fd00::1]/x");
+      expect.soft(result.ok).toBe(false);
+    });
+
+    it("blocks [ff02::1] (multicast)", () => {
+      const result = checkUrlSafety("http://[ff02::1]/x");
+      expect.soft(result.ok).toBe(false);
+    });
+
+    it("blocks [::ffff:127.0.0.1] (IPv4-mapped loopback)", () => {
+      const result = checkUrlSafety("http://[::ffff:127.0.0.1]/x");
+      expect.soft(result.ok).toBe(false);
+    });
+
+    it("blocks [::ffff:169.254.169.254] (IPv4-mapped AWS metadata)", () => {
+      const result = checkUrlSafety("http://[::ffff:169.254.169.254]/x");
+      expect.soft(result.ok).toBe(false);
+    });
+  });
+});

--- a/apps/web/tests/worker/collector/url-safety.test.ts
+++ b/apps/web/tests/worker/collector/url-safety.test.ts
@@ -81,6 +81,22 @@ describe("checkUrlSafety", () => {
         expect.soft(result.reason).toContain("host blocked");
       }
     });
+
+    it("blocks localhost. with trailing dot (FQDN form)", () => {
+      // 末尾ドットは DNS 上 "localhost" と同義のため bypass を防ぐ
+      const result = checkUrlSafety("https://localhost./x");
+      expect.soft(result.ok).toBe(false);
+    });
+
+    it("blocks metadata.google.internal. with trailing dot", () => {
+      const result = checkUrlSafety("http://metadata.google.internal./latest/");
+      expect.soft(result.ok).toBe(false);
+    });
+
+    it("blocks foo.local. with trailing dot", () => {
+      const result = checkUrlSafety("https://foo.local./x");
+      expect.soft(result.ok).toBe(false);
+    });
   });
 
   describe("blocks private IPv4 addresses", () => {
@@ -153,6 +169,36 @@ describe("checkUrlSafety", () => {
     it("blocks 240.0.0.1 (reserved)", () => {
       const result = checkUrlSafety("https://240.0.0.1/x");
       expect.soft(result.ok).toBe(false);
+    });
+
+    it("blocks 192.0.2.1 (TEST-NET-1, 192.0.2.0/24)", () => {
+      const result = checkUrlSafety("https://192.0.2.1/x");
+      expect.soft(result.ok).toBe(false);
+    });
+
+    it("blocks 198.51.100.1 (TEST-NET-2, 198.51.100.0/24)", () => {
+      const result = checkUrlSafety("https://198.51.100.1/x");
+      expect.soft(result.ok).toBe(false);
+    });
+
+    it("blocks 203.0.113.1 (TEST-NET-3, 203.0.113.0/24)", () => {
+      const result = checkUrlSafety("https://203.0.113.1/x");
+      expect.soft(result.ok).toBe(false);
+    });
+
+    it("allows 192.1.1.1 (just outside 192.0.0.0/24 IETF range)", () => {
+      const result = checkUrlSafety("https://192.1.1.1/x");
+      expect.soft(result.ok).toBe(true);
+    });
+
+    it("allows 198.51.99.1 (just outside TEST-NET-2 /24)", () => {
+      const result = checkUrlSafety("https://198.51.99.1/x");
+      expect.soft(result.ok).toBe(true);
+    });
+
+    it("allows 203.0.112.1 (just outside TEST-NET-3 /24)", () => {
+      const result = checkUrlSafety("https://203.0.112.1/x");
+      expect.soft(result.ok).toBe(true);
     });
   });
 

--- a/apps/web/tests/worker/middleware/access-jwt.test.ts
+++ b/apps/web/tests/worker/middleware/access-jwt.test.ts
@@ -22,6 +22,21 @@ describe("accessJwtMiddleware", () => {
     expect(await res.text()).toBe("ok");
   });
 
+  it("SKIP_ACCESS_JWT=1 でも accessUser が context に set される (Variables 契約維持)", async () => {
+    // 下流 handler が c.var.accessUser を参照しても ReferenceError にならないこと
+    const app = new Hono<{
+      Bindings: { SKIP_ACCESS_JWT?: string };
+      Variables: { accessUser: { email: string | undefined; sub: string | undefined } };
+    }>();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    app.use("*", accessJwtMiddleware as any);
+    app.get("/", (c) => c.json({ user: c.get("accessUser") }));
+    const res = await app.fetch(new Request("https://x.test/"), { SKIP_ACCESS_JWT: "1" });
+    expect(res.status).toBe(200);
+    const body = await res.json<{ user: { email: string | undefined; sub: string | undefined } }>();
+    expect(body.user).toEqual({ email: undefined, sub: undefined });
+  });
+
   it("CF_ACCESS_AUD / TEAM_DOMAIN 未設定で 503", async () => {
     const fetch = makeApp({});
     const res = await fetch(new Request("https://x.test/"));

--- a/apps/web/tests/worker/middleware/access-jwt.test.ts
+++ b/apps/web/tests/worker/middleware/access-jwt.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { Hono } from "hono";
+import { accessJwtMiddleware } from "../../../worker/middleware/access-jwt";
+
+function makeApp(env: Record<string, string | undefined>) {
+  const app = new Hono<{ Bindings: typeof env }>();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  app.use("*", accessJwtMiddleware as any);
+  app.get("/", (c) => c.text("ok"));
+  return (req: Request) => app.fetch(req, env);
+}
+
+describe("accessJwtMiddleware", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("SKIP_ACCESS_JWT=1 のときは next() を呼ぶ", async () => {
+    const fetch = makeApp({ SKIP_ACCESS_JWT: "1" });
+    const res = await fetch(new Request("https://x.test/"));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("ok");
+  });
+
+  it("CF_ACCESS_AUD / TEAM_DOMAIN 未設定で 503", async () => {
+    const fetch = makeApp({});
+    const res = await fetch(new Request("https://x.test/"));
+    expect(res.status).toBe(503);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toBe("service unavailable");
+  });
+
+  it("CF_ACCESS_AUD のみ設定で TEAM_DOMAIN 未設定のとき 503", async () => {
+    const fetch = makeApp({ CF_ACCESS_AUD: "test-aud" });
+    const res = await fetch(new Request("https://x.test/"));
+    expect(res.status).toBe(503);
+  });
+
+  it("ヘッダー欠落で 401", async () => {
+    const fetch = makeApp({
+      CF_ACCESS_AUD: "test-aud",
+      CF_ACCESS_TEAM_DOMAIN: "test.cloudflareaccess.com",
+    });
+    const res = await fetch(new Request("https://x.test/"));
+    expect(res.status).toBe(401);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toBe("unauthorized");
+  });
+
+  it("不正な JWT で 401", async () => {
+    // jose の jwtVerify は JWKS fetch に行くため、実 fetch を stub する
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("{}", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    );
+    const fetch = makeApp({
+      CF_ACCESS_AUD: "test-aud",
+      CF_ACCESS_TEAM_DOMAIN: "test.cloudflareaccess.com",
+    });
+    const res = await fetch(
+      new Request("https://x.test/", {
+        headers: { "cf-access-jwt-assertion": "invalid.jwt.token" },
+      }),
+    );
+    expect(res.status).toBe(401);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toBe("unauthorized");
+  });
+});

--- a/apps/web/tests/worker/utils/auth.test.ts
+++ b/apps/web/tests/worker/utils/auth.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vite-plus/test";
+import { isValidAdminToken, timingSafeEqual } from "../../../worker/utils/auth";
+import type { Env } from "../../../worker/types";
+
+// テスト用の最小限 Env スタブ (認証に関係するフィールドのみ)
+function makeEnv(overrides: Partial<Pick<Env, "ADMIN_TOKEN" | "ADMIN_TOKEN_NEXT">> = {}): Env {
+  return {
+    DB: {} as D1Database,
+    ASSETS: {} as Fetcher,
+    COLLECTOR_CONCURRENCY: "4",
+    COLLECTOR_TIMEOUT_MS: "500",
+    COLLECTOR_RETRIES: "2",
+    SUMMARY_MAX_LENGTH: "200",
+    RETENTION_DAYS: "90",
+    CORS_ALLOWED_ORIGINS: "",
+    ...overrides,
+  };
+}
+
+describe("timingSafeEqual", () => {
+  it("同じ文字列は true を返す", () => {
+    expect(timingSafeEqual("abc", "abc")).toBe(true);
+  });
+
+  it("異なる文字列は false を返す", () => {
+    expect(timingSafeEqual("abc", "xyz")).toBe(false);
+  });
+
+  it("長さが異なる場合は false を返す", () => {
+    expect(timingSafeEqual("abc", "abcd")).toBe(false);
+    expect(timingSafeEqual("abcd", "abc")).toBe(false);
+  });
+
+  it("空文字同士は true を返す", () => {
+    expect(timingSafeEqual("", "")).toBe(true);
+  });
+
+  it("片方が空文字の場合は false を返す", () => {
+    expect(timingSafeEqual("abc", "")).toBe(false);
+    expect(timingSafeEqual("", "abc")).toBe(false);
+  });
+});
+
+describe("isValidAdminToken", () => {
+  it("現行 ADMIN_TOKEN と一致する場合は true を返す", () => {
+    const env = makeEnv({ ADMIN_TOKEN: "current-token" });
+    expect(isValidAdminToken("current-token", env)).toBe(true);
+  });
+
+  it("ADMIN_TOKEN_NEXT と一致する場合は true を返す (ローテーション対応)", () => {
+    const env = makeEnv({ ADMIN_TOKEN: "current-token", ADMIN_TOKEN_NEXT: "next-token" });
+    expect(isValidAdminToken("next-token", env)).toBe(true);
+  });
+
+  it("どちらにも一致しない場合は false を返す", () => {
+    const env = makeEnv({ ADMIN_TOKEN: "current-token", ADMIN_TOKEN_NEXT: "next-token" });
+    expect(isValidAdminToken("wrong-token", env)).toBe(false);
+  });
+
+  it("ADMIN_TOKEN が未設定の場合は false を返す", () => {
+    const env = makeEnv();
+    expect(isValidAdminToken("any-token", env)).toBe(false);
+  });
+
+  it("ADMIN_TOKEN_NEXT が未設定でも現行 token が一致すれば true を返す", () => {
+    const env = makeEnv({ ADMIN_TOKEN: "current-token" });
+    expect(isValidAdminToken("current-token", env)).toBe(true);
+  });
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -25,6 +25,8 @@ export default defineConfig(async () => {
             // 張り付き /api/admin/collector/run が CI で 504 flaky になっていたため、
             // retry を無効化する。リトライ自体の挙動は collector/retry.test.ts が個別に検証する。
             COLLECTOR_RETRIES: "0",
+            // テスト環境では Cloudflare Access が前段にいないため JWT 検証をスキップ
+            SKIP_ACCESS_JWT: "1",
           },
         },
       }),

--- a/apps/web/worker/api/admin.ts
+++ b/apps/web/worker/api/admin.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
-import type { MiddlewareHandler } from "hono";
 import type { Env } from "../types";
+import { adminAuthMiddleware } from "../utils/auth";
 import { collectAll, collectFeeds, validateFeedUrl } from "../collector";
 import { loadAllFeeds } from "../feed-config";
 import { getFeedsDiagnostics, setFeedEnabled } from "../db/feeds";
@@ -13,47 +13,9 @@ import type {
   AdminFeedsDiagnosticsResponse,
   AdminRunDetailResponse,
   AdminRunListResponse,
-  ErrorResponse,
 } from "./types";
 
 const app = new Hono<{ Bindings: Env }>();
-
-function timingSafeEqual(a: string, b: string): boolean {
-  if (a.length !== b.length) return false;
-  let diff = 0;
-  for (let i = 0; i < a.length; i++) {
-    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
-  }
-  return diff === 0;
-}
-
-// 現行 token または次世代 token のいずれかに一致すれば認証 OK。
-// ローテーション期間中は両方を受け入れ、完了後に ADMIN_TOKEN_NEXT を削除する。
-function isValidAdminToken(
-  provided: string,
-  current: string | undefined,
-  next: string | undefined,
-): boolean {
-  if (current && timingSafeEqual(provided, current)) return true;
-  if (next && timingSafeEqual(provided, next)) return true;
-  return false;
-}
-
-// すべての admin ルートに適用する認証 middleware。
-// ADMIN_TOKEN 未設定なら 503、token 不正なら 401 を返す。
-const adminAuthMiddleware: MiddlewareHandler<{ Bindings: Env }> = async (c, next) => {
-  const current = c.env.ADMIN_TOKEN;
-  const nextToken = c.env.ADMIN_TOKEN_NEXT;
-  if (!current) {
-    return c.json<ErrorResponse>({ error: "ADMIN_TOKEN is not configured" }, 503);
-  }
-  const auth = c.req.header("authorization") ?? "";
-  const token = auth.replace(/^Bearer\s+/i, "");
-  if (!token || !isValidAdminToken(token, current, nextToken)) {
-    return c.json<ErrorResponse>({ error: "unauthorized" }, 401);
-  }
-  return await next();
-};
 
 app.use("*", adminAuthMiddleware);
 

--- a/apps/web/worker/api/articles.ts
+++ b/apps/web/worker/api/articles.ts
@@ -44,13 +44,39 @@ const app = new Hono<{ Bindings: Env }>();
 const VALID_CATEGORIES = ["bigtech", "ai", "jp", "zenn"] as const satisfies readonly FeedCategory[];
 const VALID_LANGS = ["ja", "en"] as const satisfies readonly FeedLang[];
 const VALID_FEED_IDS = new Set(loadAllFeeds().map((f) => f.id));
+const VALID_CALENDAR_DAYS = [7, 30, 90, 365] as const;
+// URL パラメータの長さ上限。意図せず長い文字列が D1 クエリに流れ込むのを防ぐ
+const MAX_PARAM_LENGTH = 200;
 
 const isCategory = makeOneOf<FeedCategory>(VALID_CATEGORIES);
 const isLang = makeOneOf<FeedLang>(VALID_LANGS);
 
-const ISO_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
-// YYYY-MM-DD または YYYY-MM-DDTHH:MM:SS 形式を受け付ける
-const DATE_RANGE_RE = /^\d{4}-\d{2}-\d{2}/;
+// ISO 8601 の日時部分 (時刻まで)。decodeCursor の publishedAt 検証と
+// since/until の ISO 形式チェック (時刻部分以降は内部で 10 文字に切り詰めて検証) に共用する。
+const ISO_DATETIME_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
+// YYYY-MM-DD 形式のみ受け付ける (末尾 anchor で `9999-99-99foo` のような余剰文字を排除)
+const DATE_RANGE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+// 実日付として妥当か検証する。Date が内部で繰り上げる (9999-99-99 → 3000-03-09 等) ことを
+// 再フォーマットして入力文字列と比較することで検出する。
+function isValidDate(s: string): boolean {
+  const t = Date.parse(`${s}T00:00:00Z`);
+  if (Number.isNaN(t)) return false;
+  const d = new Date(t);
+  const y = d.getUTCFullYear().toString().padStart(4, "0");
+  const m = (d.getUTCMonth() + 1).toString().padStart(2, "0");
+  const day = d.getUTCDate().toString().padStart(2, "0");
+  return `${y}-${m}-${day}` === s;
+}
+
+function isValidDateRange(s: string | undefined): boolean {
+  if (!s) return true; // 未指定は OK
+  // YYYY-MM-DD 形式: 実日付として妥当かチェック
+  if (DATE_RANGE_RE.test(s)) return isValidDate(s);
+  // YYYY-MM-DDTHH:MM:SS... 形式: 先頭の日付部分のみ抽出して検証
+  if (ISO_DATETIME_RE.test(s)) return isValidDate(s.slice(0, 10));
+  return false;
+}
 
 function decodeCursor(input: string | undefined): Cursor | null {
   if (!input) return null;
@@ -61,7 +87,7 @@ function decodeCursor(input: string | undefined): Cursor | null {
       parsed &&
       typeof parsed === "object" &&
       typeof parsed.publishedAt === "string" &&
-      ISO_RE.test(parsed.publishedAt) &&
+      ISO_DATETIME_RE.test(parsed.publishedAt) &&
       typeof parsed.id === "number" &&
       Number.isInteger(parsed.id) &&
       parsed.id >= 0
@@ -117,7 +143,12 @@ app.get("/", async (c) => {
   const langRaw = req.query("lang");
   const feedIdRaw = req.query("feed_id") ?? undefined;
   const feedId = feedIdRaw && VALID_FEED_IDS.has(feedIdRaw) ? feedIdRaw : undefined;
-  const q = req.query("q") ?? undefined;
+  const qRaw = req.query("q") ?? undefined;
+  // 過度に長いクエリが FTS5 に渡るのを防ぐ
+  if (qRaw && qRaw.length > 100) {
+    return c.json({ error: "query too long" }, 400);
+  }
+  const q = qRaw;
   const limitRaw = req.query("limit");
   const cursorRaw = req.query("cursor");
 
@@ -128,9 +159,15 @@ app.get("/", async (c) => {
 
   const dateFromRaw = req.query("date_from") ?? undefined;
   const dateToRaw = req.query("date_to") ?? undefined;
-  // 不正な値は silently drop する既存パターンに合わせる
-  const dateFrom = dateFromRaw && DATE_RANGE_RE.test(dateFromRaw) ? dateFromRaw : undefined;
-  const dateTo = dateToRaw && DATE_RANGE_RE.test(dateToRaw) ? dateToRaw : undefined;
+  // 不正な日付文字列は 400 を返す (silently drop しない)
+  if (!isValidDateRange(dateFromRaw)) {
+    return c.json({ error: "invalid date_from" }, 400);
+  }
+  if (!isValidDateRange(dateToRaw)) {
+    return c.json({ error: "invalid date_to" }, 400);
+  }
+  const dateFrom = dateFromRaw;
+  const dateTo = dateToRaw;
 
   const etag = await computeArticlesEtag(c.env.DB, FEEDS_VERSION, {
     category,
@@ -186,6 +223,7 @@ app.get("/by-author/:author", async (c) => {
   const authorRaw = c.req.param("author");
   const author = decodeURIComponent(authorRaw);
   if (!author) return c.json({ error: "author must not be empty" }, 400);
+  if (author.length > MAX_PARAM_LENGTH) return c.json({ error: "author too long" }, 400);
 
   const parsed = parseListQuery(c);
   if (!parsed.ok) return parsed.response;
@@ -204,6 +242,7 @@ app.get("/by-feed/:feedId", async (c) => {
   const feedIdRaw = c.req.param("feedId");
   const feedId = decodeURIComponent(feedIdRaw).trim();
   if (!feedId) return c.json({ error: "feedId must not be empty" }, 400);
+  if (feedId.length > MAX_PARAM_LENGTH) return c.json({ error: "feedId too long" }, 400);
 
   const parsed = parseListQuery(c);
   if (!parsed.ok) return parsed.response;
@@ -237,8 +276,6 @@ app.get("/by-category/:cat", async (c) => {
     { "Cache-Control": "public, max-age=300" },
   );
 });
-
-const VALID_CALENDAR_DAYS = [7, 30, 90, 365] as const;
 
 app.get("/calendar", async (c) => {
   const daysRaw = c.req.query("days") ?? "30";

--- a/apps/web/worker/api/reports.ts
+++ b/apps/web/worker/api/reports.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
-import type { Context } from "hono";
 import type { Env } from "../types";
+import { adminAuthMiddleware } from "../utils/auth";
 import { getReport, listReports, upsertReport } from "../db/reports";
 import type { ReportInput, ReportKind } from "../db/reports";
 import type {
@@ -11,46 +11,16 @@ import type {
 
 const app = new Hono<{ Bindings: Env }>();
 
+// すべての reports admin ルートに認証を適用する。
+// 個別ハンドラでの authGuard 呼び出しを廃し、ハンドラ追加時の認証漏れを防ぐ。
+app.use("*", adminAuthMiddleware);
+
 const VALID_KINDS = new Set<ReportKind>(["daily", "weekly", "monthly"]);
 const VALID_CATEGORIES = new Set(["bigtech", "ai", "jp", "zenn"]);
 const VALID_LANGS = new Set(["ja", "en"]);
 // content が極端に長くなるのを防ぐ (D1 の row size と Worker の CPU 時間を意識)。
 // 1MB は markdown レポートとしては十分すぎる量。
 const MAX_CONTENT_BYTES = 1_000_000;
-
-function timingSafeEqual(a: string, b: string): boolean {
-  if (a.length !== b.length) return false;
-  let diff = 0;
-  for (let i = 0; i < a.length; i++) {
-    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
-  }
-  return diff === 0;
-}
-
-function isValidAdminToken(
-  provided: string,
-  current: string | undefined,
-  next: string | undefined,
-): boolean {
-  if (current && timingSafeEqual(provided, current)) return true;
-  if (next && timingSafeEqual(provided, next)) return true;
-  return false;
-}
-
-// admin token を検証して、失敗時に Response を返す。成功時は null を返す。
-function authGuard(c: Context<{ Bindings: Env }>): Response | null {
-  const current = c.env.ADMIN_TOKEN;
-  const next = c.env.ADMIN_TOKEN_NEXT;
-  if (!current) {
-    return c.json({ error: "ADMIN_TOKEN is not configured" }, 503);
-  }
-  const auth = c.req.header("authorization") ?? "";
-  const token = auth.replace(/^Bearer\s+/i, "");
-  if (!token || !isValidAdminToken(token, current, next)) {
-    return c.json({ error: "unauthorized" }, 401);
-  }
-  return null;
-}
 
 // Date.toISOString() の strict round-trip だと "2026-04-29T00:00:00Z" のような
 // ms 抜きの ISO 8601 (LLM が頻繁に出力する形式) が弾かれる。
@@ -149,8 +119,6 @@ app.post("/", async (c) => {
   if (c.env.READONLY === "1") {
     return c.json({ error: "read-only mode" }, 403);
   }
-  const denied = authGuard(c);
-  if (denied) return denied;
 
   const rawBody = await c.req.text().catch(() => "");
   if (rawBody.trim() === "") {
@@ -176,9 +144,6 @@ app.post("/", async (c) => {
 });
 
 app.get("/", async (c) => {
-  const denied = authGuard(c);
-  if (denied) return denied;
-
   const kindParam = c.req.query("kind");
   let kind: ReportKind | undefined;
   if (kindParam !== undefined) {
@@ -196,9 +161,6 @@ app.get("/", async (c) => {
 });
 
 app.get("/:id", async (c) => {
-  const denied = authGuard(c);
-  if (denied) return denied;
-
   const idParam = Number(c.req.param("id"));
   if (!Number.isFinite(idParam) || idParam <= 0) {
     return c.json({ error: "invalid id" }, 400);

--- a/apps/web/worker/api/router.ts
+++ b/apps/web/worker/api/router.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import type { Context, Next } from "hono";
 import type { Env } from "../types";
+import { type AccessUser, accessJwtMiddleware } from "../middleware/access-jwt";
 import articles from "./articles";
 import categories from "./categories";
 import feeds from "./feeds";
@@ -13,7 +14,7 @@ import publicReports from "./reports-public";
 import docs from "./docs";
 import { catalogHandler } from "./catalog";
 
-const api = new Hono<{ Bindings: Env }>();
+const api = new Hono<{ Bindings: Env; Variables: { accessUser: AccessUser } }>();
 
 api.use("*", async (c, next) => {
   c.header("Cache-Control", "no-store");
@@ -22,9 +23,19 @@ api.use("*", async (c, next) => {
 
 // /api/admin/* は server-to-server 専用のため CORS を付けない。
 // それ以外の公開エンドポイントは wrangler.toml の CORS_ALLOWED_ORIGINS で制御する。
+// CORS_ALLOWED_ORIGINS が未設定または空文字列の場合は明示設定漏れを早期検知するため
+// どの origin にもマッチさせず、ブラウザの cross-origin リクエストを拒否する。
 function allowedOriginsCors(c: Context<{ Bindings: Env }>, next: Next) {
-  const origins = (c.env.CORS_ALLOWED_ORIGINS ?? "*").split(",").map((o) => o.trim());
-  return cors({ origin: origins })(c, next);
+  const allowedOrigins = (c.env.CORS_ALLOWED_ORIGINS ?? "")
+    .split(",")
+    .map((o) => o.trim())
+    .filter(Boolean);
+  return cors({
+    origin: (origin) => {
+      if (allowedOrigins.length === 0) return null;
+      return allowedOrigins.includes(origin) ? origin : null;
+    },
+  })(c, next);
 }
 
 const PUBLIC_PATHS = [
@@ -47,6 +58,10 @@ api.route("/categories", categories);
 api.route("/feeds", feeds);
 api.route("/health", health);
 api.route("/stats", stats);
+// /admin/* には Cloudflare Access の JWT 検証を前段に挟む。
+// SKIP_ACCESS_JWT="1" のときは bypass する (移行期 / ローカル開発)。
+// admin.ts / reports.ts 内の Bearer ADMIN_TOKEN 検証は廃止せず並行運用する。
+api.use("/admin/*", accessJwtMiddleware);
 // /admin/reports は別ハンドラに分離 (admin の中で /reports をルーティングしない設計)。
 // Hono は path matching が前方一致でなく完全一致なので衝突しない。
 api.route("/admin/reports", reports);

--- a/apps/web/worker/collector/index.ts
+++ b/apps/web/worker/collector/index.ts
@@ -2,6 +2,7 @@ import type { Env, FeedConfig } from "../types";
 import { loadEnabledFeeds } from "../feed-config";
 import { parseFeed } from "./rssParser";
 import { parseXml, pickText, asArray } from "../utils/xml";
+import { checkUrlSafety } from "./url-safety";
 import { buildGuids } from "./deduplicator";
 import { D1CostAccumulator, writeCollectorEvent, writeD1CostEvent } from "./metrics";
 import { maybeAlert, sendAlert } from "./alert";
@@ -341,8 +342,15 @@ export type ValidateFeedResult =
  * URL を fetch + parse して RSS/Atom として有効かどうかを検証する。
  * feeds.yaml に追記する前の事前確認用。DB アクセスは行わない。
  * タイムアウトは 10s (admin endpoint 側で 12s でラップする)。
+ * SSRF 対策として内部 IP / 特殊用途ホストへのアクセスは事前にブロックする。
  */
 export async function validateFeedUrl(url: string): Promise<ValidateFeedResult> {
+  // fetch より前に SSRF チェックを行い、内部 IP やプライベートホストを拒否する
+  const safety = checkUrlSafety(url);
+  if (!safety.ok) {
+    return { ok: false, error: `unsafe URL: ${safety.reason}` };
+  }
+
   let result: Awaited<ReturnType<typeof fetchFeed>>;
   try {
     // retry なし (検証用なので 1 回で判断する)

--- a/apps/web/worker/collector/url-safety.ts
+++ b/apps/web/worker/collector/url-safety.ts
@@ -1,0 +1,134 @@
+/**
+ * SSRF 対策: URL が外部アクセスとして安全かどうかを検査するヘルパー。
+ * admin endpoint の /api/admin/feeds/validate から利用される。
+ * collector の isSafeUrl (プロトコル prefix チェックのみ) より厳密に、
+ * 内部 IP アドレス・特殊用途ホスト名・危険なプロトコルをブロックする。
+ */
+
+export type UrlSafetyResult = { ok: true; url: URL } | { ok: false; reason: string };
+
+export function checkUrlSafety(input: string): UrlSafetyResult {
+  let parsed: URL;
+  try {
+    parsed = new URL(input);
+  } catch {
+    return { ok: false, reason: "invalid URL" };
+  }
+
+  // http / https 以外のプロトコル (file:, gopher:, dict:, ftp: 等) はブロック
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return { ok: false, reason: `protocol not allowed: ${parsed.protocol}` };
+  }
+
+  // URL.hostname は IPv6 リテラルの場合 "[::1]" のようにブラケット付きで返る
+  const host = parsed.hostname.toLowerCase();
+
+  // localhost / .localhost / .local / metadata.google.internal などのホスト名
+  if (
+    host === "localhost" ||
+    host.endsWith(".localhost") ||
+    host.endsWith(".local") ||
+    host === "metadata.google.internal"
+  ) {
+    return { ok: false, reason: `host blocked: ${host}` };
+  }
+
+  // IPv6 リテラル ([::1], [::1%eth0] 形式)
+  if (host.startsWith("[") && host.endsWith("]")) {
+    // zoneid (%eth0 等) を取り除いてから検査する
+    const ipv6 = host.slice(1, -1).split("%")[0];
+    if (ipv6 === undefined || isPrivateIPv6(ipv6)) {
+      return { ok: false, reason: `private IPv6: ${host}` };
+    }
+    return { ok: true, url: parsed };
+  }
+
+  // IPv4 リテラル (dotted-decimal 形式)
+  if (/^\d+\.\d+\.\d+\.\d+$/.test(host)) {
+    if (isPrivateIPv4(host)) {
+      return { ok: false, reason: `private IPv4: ${host}` };
+    }
+    return { ok: true, url: parsed };
+  }
+
+  // 数字で始まる hostname (octal / hex / short-form の IPv4 擬装を拒否)
+  // 例: 0177.0.0.1 (= 127.0.0.1 の octal 表記)
+  if (/^\d/.test(host)) {
+    return { ok: false, reason: `numeric hostname not allowed: ${host}` };
+  }
+
+  return { ok: true, url: parsed };
+}
+
+/**
+ * RFC 1918 / RFC 5735 などで定義されたプライベート・特殊用途 IPv4 かどうかを判定する。
+ * dotted-decimal 形式 ("a.b.c.d") のみ受け付ける。
+ */
+function isPrivateIPv4(ip: string): boolean {
+  const parts = ip.split(".").map(Number);
+  if (parts.length !== 4 || parts.some((n) => Number.isNaN(n) || n < 0 || n > 255)) return false;
+
+  const [a, b] = parts;
+  if (a === undefined || b === undefined) return false;
+
+  if (a === 0) return true; // 0.0.0.0/8
+  if (a === 10) return true; // 10.0.0.0/8
+  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64.0.0/10 CGNAT
+  if (a === 127) return true; // 127.0.0.0/8 loopback
+  if (a === 169 && b === 254) return true; // 169.254.0.0/16 link-local (AWS/GCP metadata)
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
+  if (a === 192 && b === 0) return true; // 192.0.0.0/24 + 192.0.2.0/24 (TEST-NET-1)
+  if (a === 192 && b === 168) return true; // 192.168.0.0/16
+  if (a === 198 && (b === 18 || b === 19)) return true; // 198.18.0.0/15 benchmark
+  if (a === 198 && b === 51) return true; // 198.51.100.0/24 (TEST-NET-2)
+  if (a === 203 && b === 0) return true; // 203.0.113.0/24 (TEST-NET-3)
+  if (a >= 224) return true; // 224.0.0.0/4 multicast + 240.0.0.0/4 reserved + 255.255.255.255
+
+  return false;
+}
+
+/**
+ * プライベート・特殊用途 IPv6 かどうかを判定する。
+ * IPv4-mapped アドレス (::ffff:x.x.x.x) は内部の IPv4 を再帰的に検査する。
+ */
+function isPrivateIPv6(ip: string): boolean {
+  const v = ip.toLowerCase();
+
+  if (v === "::1") return true; // loopback
+  if (v === "::") return true; // unspecified
+  // fe80::/10 link-local: 先頭 10 ビットが 1111111010 = fe80〜febf
+  if (/^fe[89ab][0-9a-f]/i.test(v)) return true;
+  if (/^f[cd]/.test(v)) return true; // fc00::/7 unique local (fc / fd)
+  if (v.startsWith("ff")) return true; // ff00::/8 multicast
+  if (v.startsWith("2001:db8")) return true; // 2001:db8::/32 documentation
+
+  // IPv4-mapped: URL クラスは ::ffff:127.0.0.1 を ::ffff:7f00:1 のように
+  // 16 進数形式 (xxxx:xxxx) に正規化するため、両形式を検査する。
+  if (v.startsWith("::ffff:")) {
+    const tail = v.slice(7);
+    // dotted-decimal 形式 (直接入力された場合)
+    if (/^\d+\.\d+\.\d+\.\d+$/.test(tail)) {
+      return isPrivateIPv4(tail);
+    }
+    // 16 進数形式 (URL クラスが正規化した形式: xxxx:xxxx)
+    const hexMatch = /^([0-9a-f]{1,4}):([0-9a-f]{1,4})$/.exec(tail);
+    if (hexMatch) {
+      const [, hi, lo] = hexMatch;
+      const ipv4 = ipv4MappedHexToDecimal(hi, lo);
+      if (ipv4 !== null) return isPrivateIPv4(ipv4);
+    }
+  }
+
+  return false;
+}
+
+/**
+ * IPv4-mapped IPv6 の 16 進数部分 (hi:lo) を dotted-decimal に変換する。
+ * 例: "7f00", "1" -> "127.0.0.1"
+ */
+function ipv4MappedHexToDecimal(hi: string, lo: string): string | null {
+  const hiNum = Number.parseInt(hi, 16);
+  const loNum = Number.parseInt(lo, 16);
+  if (Number.isNaN(hiNum) || Number.isNaN(loNum)) return null;
+  return [(hiNum >> 8) & 0xff, hiNum & 0xff, (loNum >> 8) & 0xff, loNum & 0xff].join(".");
+}

--- a/apps/web/worker/collector/url-safety.ts
+++ b/apps/web/worker/collector/url-safety.ts
@@ -20,8 +20,9 @@ export function checkUrlSafety(input: string): UrlSafetyResult {
     return { ok: false, reason: `protocol not allowed: ${parsed.protocol}` };
   }
 
-  // URL.hostname は IPv6 リテラルの場合 "[::1]" のようにブラケット付きで返る
-  const host = parsed.hostname.toLowerCase();
+  // URL.hostname は IPv6 リテラルの場合 "[::1]" のようにブラケット付きで返る。
+  // 末尾ドット (FQDN 形式: "localhost.") を除去してから検査する (DNS では同一視されるため bypass を防ぐ)
+  const host = parsed.hostname.toLowerCase().replace(/\.+$/, "");
 
   // localhost / .localhost / .local / metadata.google.internal などのホスト名
   if (
@@ -68,8 +69,8 @@ function isPrivateIPv4(ip: string): boolean {
   const parts = ip.split(".").map(Number);
   if (parts.length !== 4 || parts.some((n) => Number.isNaN(n) || n < 0 || n > 255)) return false;
 
-  const [a, b] = parts;
-  if (a === undefined || b === undefined) return false;
+  const [a, b, c] = parts;
+  if (a === undefined || b === undefined || c === undefined) return false;
 
   if (a === 0) return true; // 0.0.0.0/8
   if (a === 10) return true; // 10.0.0.0/8
@@ -77,11 +78,12 @@ function isPrivateIPv4(ip: string): boolean {
   if (a === 127) return true; // 127.0.0.0/8 loopback
   if (a === 169 && b === 254) return true; // 169.254.0.0/16 link-local (AWS/GCP metadata)
   if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
-  if (a === 192 && b === 0) return true; // 192.0.0.0/24 + 192.0.2.0/24 (TEST-NET-1)
+  if (a === 192 && b === 0 && c === 0) return true; // 192.0.0.0/24 IETF protocol assignments
+  if (a === 192 && b === 0 && c === 2) return true; // 192.0.2.0/24 TEST-NET-1
   if (a === 192 && b === 168) return true; // 192.168.0.0/16
   if (a === 198 && (b === 18 || b === 19)) return true; // 198.18.0.0/15 benchmark
-  if (a === 198 && b === 51) return true; // 198.51.100.0/24 (TEST-NET-2)
-  if (a === 203 && b === 0) return true; // 203.0.113.0/24 (TEST-NET-3)
+  if (a === 198 && b === 51 && c === 100) return true; // 198.51.100.0/24 TEST-NET-2
+  if (a === 203 && b === 0 && c === 113) return true; // 203.0.113.0/24 TEST-NET-3
   if (a >= 224) return true; // 224.0.0.0/4 multicast + 240.0.0.0/4 reserved + 255.255.255.255
 
   return false;

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -11,6 +11,20 @@ import { pruneOldArticles } from "./db/retention";
 
 const app = new Hono<{ Bindings: Env }>();
 
+// syndication / OPML / サイトマップは他サイトから fetch されるため cross-origin を許可する。
+// それ以外は same-origin に絞り情報漏洩リスクを低減する。
+function isCrossOriginAllowed(pathname: string): boolean {
+  return (
+    pathname === "/feed.json" ||
+    pathname === "/feed.xml" ||
+    pathname === "/feed.atom" ||
+    pathname.startsWith("/feeds/") ||
+    pathname === "/feeds.opml" ||
+    pathname === "/sitemap.xml" ||
+    pathname === "/robots.txt"
+  );
+}
+
 // Security headers (全レスポンスに付与)
 app.use("*", async (c, next) => {
   await next();
@@ -18,12 +32,25 @@ app.use("*", async (c, next) => {
   c.header("X-Frame-Options", "DENY");
   c.header("Referrer-Policy", "strict-origin-when-cross-origin");
   c.header("Permissions-Policy", "geolocation=(), microphone=(), camera=()");
+  // HSTS: 本番 HTTPS のみで提供するため常に有効化。includeSubDomains は workers.dev サブドメインにも適用される。
+  c.header("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  // COOP: top-level browsing context を分離し Spectre 系攻撃の cross-origin leak を防ぐ。
+  c.header("Cross-Origin-Opener-Policy", "same-origin");
+  // CORP: syndication / OPML はサードパーティ RSS リーダーから fetch されるため cross-origin を許可。
+  // SPA / API は same-origin に絞ることで no-cors fetch による情報漏洩リスクを低減する。
+  const pathname = new URL(c.req.url).pathname;
+  if (isCrossOriginAllowed(pathname)) {
+    c.header("Cross-Origin-Resource-Policy", "cross-origin");
+  } else {
+    c.header("Cross-Origin-Resource-Policy", "same-origin");
+  }
   c.header(
     "Content-Security-Policy",
     [
       "default-src 'self'",
       "img-src 'self' data: https:",
-      // fonts.googleapis.com の CSS は <link rel="stylesheet"> 経由で読み込むため style-src の対象
+      // fonts.googleapis.com の CSS は <link rel="stylesheet"> 経由で読み込むため style-src の対象。
+      // 'unsafe-inline' は React の style={{ ... }} prop と Vite が注入するインラインスタイルのために必要。
       "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
       "script-src 'self'",
       "connect-src 'self'",
@@ -47,9 +74,13 @@ app.all("*", async (c) => {
   const url = new URL(c.req.url);
   if (url.pathname.startsWith("/assets/")) {
     const res = await c.env.ASSETS.fetch(c.req.raw);
-    const headers = new Headers(res.headers);
-    headers.set("Cache-Control", "public, max-age=31536000, immutable");
-    return new Response(res.body, { status: res.status, statusText: res.statusText, headers });
+    // new Response(..., { headers }) でヘッダーを丸ごと置換すると global middleware が
+    // c.header() で設定したセキュリティヘッダーが失われる。
+    // 既存ヘッダーをコピーしてから Cache-Control のみ上書きすることでセキュリティヘッダーを保持する。
+    const newRes = new Response(res.body, { status: res.status, statusText: res.statusText });
+    res.headers.forEach((value, key) => newRes.headers.set(key, value));
+    newRes.headers.set("Cache-Control", "public, max-age=31536000, immutable");
+    return newRes;
   }
   return rewriteShell(c.req.raw, c.env);
 });

--- a/apps/web/worker/middleware/access-jwt.ts
+++ b/apps/web/worker/middleware/access-jwt.ts
@@ -1,0 +1,63 @@
+import type { MiddlewareHandler } from "hono";
+import { createRemoteJWKSet, jwtVerify } from "jose";
+import type { Env } from "../types";
+
+export interface AccessUser {
+  email: string | undefined;
+  sub: string | undefined;
+}
+
+interface JwksCache {
+  teamDomain: string;
+  jwks: ReturnType<typeof createRemoteJWKSet>;
+}
+// Worker isolate 内で JWKS を再利用する。jose が内部で 5 分ごとにリフレッシュするため
+// 明示的な TTL 管理は不要。
+let cached: JwksCache | undefined;
+
+function getJwks(teamDomain: string) {
+  if (cached && cached.teamDomain === teamDomain) return cached.jwks;
+  const jwks = createRemoteJWKSet(new URL(`https://${teamDomain}/cdn-cgi/access/certs`));
+  cached = { teamDomain, jwks };
+  return jwks;
+}
+
+export const accessJwtMiddleware: MiddlewareHandler<{
+  Bindings: Env;
+  Variables: { accessUser: AccessUser };
+}> = async (c, next) => {
+  // ローカル開発では Access が前段にいないためスキップする
+  if (c.env.SKIP_ACCESS_JWT === "1") {
+    return await next();
+  }
+
+  const aud = c.env.CF_ACCESS_AUD;
+  const teamDomain = c.env.CF_ACCESS_TEAM_DOMAIN;
+  if (!aud || !teamDomain) {
+    console.error("[access-jwt] CF_ACCESS_AUD or CF_ACCESS_TEAM_DOMAIN not configured");
+    return c.json({ error: "service unavailable" }, 503);
+  }
+
+  const token = c.req.header("cf-access-jwt-assertion");
+  if (!token) {
+    return c.json({ error: "unauthorized" }, 401);
+  }
+
+  try {
+    const jwks = getJwks(teamDomain);
+    const { payload } = await jwtVerify(token, jwks, {
+      issuer: `https://${teamDomain}`,
+      audience: aud,
+    });
+    c.set("accessUser", {
+      email: typeof payload.email === "string" ? payload.email : undefined,
+      sub: typeof payload.sub === "string" ? payload.sub : undefined,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[access-jwt] verification failed: ${msg}`);
+    return c.json({ error: "unauthorized" }, 401);
+  }
+
+  return await next();
+};

--- a/apps/web/worker/middleware/access-jwt.ts
+++ b/apps/web/worker/middleware/access-jwt.ts
@@ -26,8 +26,11 @@ export const accessJwtMiddleware: MiddlewareHandler<{
   Bindings: Env;
   Variables: { accessUser: AccessUser };
 }> = async (c, next) => {
-  // ローカル開発では Access が前段にいないためスキップする
+  // ローカル開発では Access が前段にいないためスキップする。
+  // 下流で c.var.accessUser を参照する route があるため、Variables 契約を維持するため
+  // 空の AccessUser を必ず set する (skip 中に未定義参照すると ReferenceError になる)。
   if (c.env.SKIP_ACCESS_JWT === "1") {
+    c.set("accessUser", { email: undefined, sub: undefined });
     return await next();
   }
 

--- a/apps/web/worker/types.ts
+++ b/apps/web/worker/types.ts
@@ -21,6 +21,12 @@ export interface Env {
   COLLECTOR_ALERT_WEBHOOK?: string;
   // 閾値: feeds_failed がこの値以上になったら通知する (default: "5")
   COLLECTOR_ALERT_THRESHOLD?: string;
+  // Cloudflare Access (Zero Trust) — /api/admin/* の JWT 検証に使う
+  // 本番では `wrangler secret put` で登録。toml には書かない。
+  CF_ACCESS_AUD?: string;
+  CF_ACCESS_TEAM_DOMAIN?: string;
+  // ローカル開発でアクセス JWT 検証をスキップする ("1" でスキップ)
+  SKIP_ACCESS_JWT?: string;
 }
 
 export type FeedCategory = "bigtech" | "ai" | "jp" | "zenn";

--- a/apps/web/worker/utils/auth.ts
+++ b/apps/web/worker/utils/auth.ts
@@ -1,0 +1,51 @@
+import type { MiddlewareHandler } from "hono";
+import type { Env } from "../types";
+
+/**
+ * 定数時間比較。長さが異なる場合も同じバイト数を読みに行くことで、
+ * 文字列長の length oracle 化を抑止する (UTF-8 のバイト長を比較対象とする)。
+ * 完全な対策は Web Crypto の `crypto.subtle.timingSafeEqual` などだが、
+ * Cloudflare Workers ではまだ未提供の API があるため自前実装にしている。
+ */
+export function timingSafeEqual(a: string, b: string): boolean {
+  const enc = new TextEncoder();
+  const ab = enc.encode(a);
+  const bb = enc.encode(b);
+  // 比較対象を同じバイト長に揃えて毎回ループを回すことで、長さ判定だけで早期 return しない。
+  // 長さが異なる場合は最終的に length 比較で false を返す。
+  const len = Math.max(ab.length, bb.length);
+  let result = ab.length ^ bb.length;
+  for (let i = 0; i < len; i++) {
+    const av = i < ab.length ? ab[i]! : 0;
+    const bv = i < bb.length ? bb[i]! : 0;
+    result |= av ^ bv;
+  }
+  return result === 0;
+}
+
+// 現行 token または次世代 token のいずれかに一致すれば認証 OK。
+// ローテーション期間中は両方を受け入れ、完了後に ADMIN_TOKEN_NEXT を削除する。
+export function isValidAdminToken(token: string, env: Env): boolean {
+  const current = env.ADMIN_TOKEN;
+  const next = env.ADMIN_TOKEN_NEXT;
+  if (current && timingSafeEqual(token, current)) return true;
+  if (next && timingSafeEqual(token, next)) return true;
+  return false;
+}
+
+/**
+ * Bearer token を検証する Hono middleware。
+ * - ADMIN_TOKEN 未設定時は 503
+ * - ヘッダー欠落 / 不一致は 401
+ */
+export const adminAuthMiddleware: MiddlewareHandler<{ Bindings: Env }> = async (c, next) => {
+  if (!c.env.ADMIN_TOKEN) {
+    return c.json({ error: "service unavailable" }, 503);
+  }
+  const auth = c.req.header("authorization") ?? "";
+  const token = auth.replace(/^Bearer\s+/i, "");
+  if (!token || !isValidAdminToken(token, c.env)) {
+    return c.json({ error: "unauthorized" }, 401);
+  }
+  return await next();
+};

--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -37,6 +37,15 @@ ALERT_MIN_FAILURES = "3"
 ALERT_FEED_STREAK = "5"
 COLLECTOR_ALERT_THRESHOLD = "5"
 
+# Cloudflare Access (Zero Trust) — /api/admin/* の認証
+# CF_ACCESS_AUD と CF_ACCESS_TEAM_DOMAIN は本番では `wrangler secret put` で登録する
+# (toml には書かない)。Phase 1 では Access の本設定が完了するまで JWT 検証を bypass する。
+# Cloudflare One ダッシュボードで Self-hosted application を作成し、secret を登録した後、
+# この行を削除して JWT 検証を有効化する。詳細は docs/auth.md を参照。
+# TODO(#375): CF_ACCESS_AUD / CF_ACCESS_TEAM_DOMAIN を secret 登録した時点でこの行を削除する。
+# 削除を忘れると本番で /api/admin/* が adminAuthMiddleware (Bearer) のみで守られる状態が継続する。
+SKIP_ACCESS_JWT = "1"
+
 [[analytics_engine_datasets]]
 binding = "COLLECTOR_AE"
 dataset = "tnb_collector_events"
@@ -70,3 +79,5 @@ READONLY = "1"
 CORS_ALLOWED_ORIGINS = "https://tech-news-bot.rikeda71.workers.dev"
 ALERT_MIN_FAILURES = "3"
 ALERT_FEED_STREAK = "5"
+# preview 環境では Access が前段に居ないため JWT 検証を bypass する。
+SKIP_ACCESS_JWT = "1"

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -5,7 +5,7 @@ tech-news-bot の管理エンドポイント (`/api/admin/*`) は **Cloudflare A
 
 ## アーキテクチャ
 
-```
+```text
 [ブラウザ] -> [Cloudflare Access (ネットワーク層)] -> [Worker]
                   | 未認証 -> ログインページへ
                   | 認証済み -> Cf-Access-Jwt-Assertion 付与
@@ -50,7 +50,7 @@ secret 登録後は `wrangler.toml` の `SKIP_ACCESS_JWT = "1"` を削除すれ�
 ローカルでは Access の前段がいないため、`accessJwtMiddleware` は早期 return で
 スキップする必要がある。`.dev.vars` (gitignore) に以下を記述:
 
-```
+```text
 SKIP_ACCESS_JWT=1
 ```
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,0 +1,70 @@
+# Authentication & Cloudflare Access
+
+tech-news-bot の管理エンドポイント (`/api/admin/*`) は **Cloudflare Access (Zero Trust)** で
+認証保護することを前提に設計されている。
+
+## アーキテクチャ
+
+```
+[ブラウザ] -> [Cloudflare Access (ネットワーク層)] -> [Worker]
+                  | 未認証 -> ログインページへ
+                  | 認証済み -> Cf-Access-Jwt-Assertion 付与
+                                       |
+                                  [accessJwtMiddleware]
+                                       |
+                                  [adminAuthMiddleware]  (Bearer token, 並行運用)
+                                       |
+                                  [admin handler]
+```
+
+cron (`scheduled()`) は Access を経由せず内部発火するため、middleware の影響を受けない。
+
+## 設定手順
+
+### 1. Cloudflare Zero Trust ダッシュボードでアプリケーション登録
+
+1. https://one.dash.cloudflare.com/ にアクセス
+2. **Access** -> **Applications** -> **Add an application** -> **Self-hosted**
+3. アプリ設定:
+   - **Application name**: `tech-news-bot-admin`
+   - **Session Duration**: 24h など
+   - **Application domain**: `tech-news-bot.<account>.workers.dev/api/admin/*`
+4. ポリシー設定:
+   - **Action**: Allow
+   - **Include**: `Emails ending in @your-domain.com` または GitHub/Google IdP
+5. **Audience Tag** (`CF_ACCESS_AUD`) と **Team Domain** (`<team>.cloudflareaccess.com`) を控える
+
+### 2. Worker 側の env 設定
+
+`wrangler secret put CF_ACCESS_AUD` と `wrangler secret put CF_ACCESS_TEAM_DOMAIN` で
+本番に登録する。`[vars]` には書かない (運用統一)。
+
+### 3. `/api/admin/*` の前段に middleware を適用
+
+`apps/web/worker/api/router.ts` で admin パス group の冒頭に
+`api.use("/admin/*", accessJwtMiddleware)` で適用済み。
+secret 登録後は `wrangler.toml` の `SKIP_ACCESS_JWT = "1"` を削除すれば JWT 検証が有効化される。
+
+## ローカル開発
+
+ローカルでは Access の前段がいないため、`accessJwtMiddleware` は早期 return で
+スキップする必要がある。`.dev.vars` (gitignore) に以下を記述:
+
+```
+SKIP_ACCESS_JWT=1
+```
+
+`vitest` 環境では `vitest.config.ts` の miniflare binding で同じく `"1"` を設定する。
+
+## トークン運用
+
+- 既存の `ADMIN_TOKEN` (Bearer) も並行運用する
+- CLI / cron / GitHub Actions からは `Authorization: Bearer <ADMIN_TOKEN>` で叩く
+- 人間がブラウザから叩く際は Access ログイン経由
+- どちらの認証もパスしない場合は 401
+
+## トラブルシューティング
+
+- 401 が出る: `Cf-Access-Jwt-Assertion` ヘッダーが欠落、または audience tag が一致しない
+- 503 が出る: `CF_ACCESS_AUD` / `CF_ACCESS_TEAM_DOMAIN` が未設定
+- ローカルで動かない: `.dev.vars` に `SKIP_ACCESS_JWT=1` を書く

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       hono:
         specifier: ^4.12.15
         version: 4.12.15
+      jose:
+        specifier: ^6.2.3
+        version: 6.2.3
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -1657,6 +1660,9 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -3302,6 +3308,8 @@ snapshots:
   is-plain-obj@4.1.0: {}
 
   jiti@2.6.1: {}
+
+  jose@6.2.3: {}
 
   js-tokens@4.0.0: {}
 


### PR DESCRIPTION
Closes #375

## Summary

- **CI / supply chain**: pin all 10 GitHub Actions workflows to 40-char commit SHAs and bump every `setup-node` to Node.js 24 (matches `engines.node`).
- **Authn (Phase 1)**: add Cloudflare Access JWT middleware (JOSE + remote JWKS) ahead of `/api/admin/*`, and consolidate the duplicated bearer-token auth from `admin.ts` / `reports.ts` into `worker/utils/auth.ts`. The new `timingSafeEqual` runs over UTF-8 byte buffers so the length-oracle leak is no longer a fast-path early return.
- **CORS**: drop the implicit `*` fallback in `router.ts` when `CORS_ALLOWED_ORIGINS` is unset; reflect only allow-listed origins.
- **SSRF**: `worker/collector/url-safety.ts` blocks RFC1918 / loopback / link-local / IPv6 mapped IPs in `validateFeedUrl`, preventing the admin validate endpoint from being used as a metadata-service probe.
- **Markdown XSS**: `client/utils/safe-href.ts` sanitizes `<a>` href in the react-markdown renderer (`ReportDetail`) and `ArticleCard`, rejecting `javascript:` / `data:` URIs.
- **Headers**: emit HSTS / COOP / conditional CORP from the Worker, with header propagation preserved for `ASSETS.fetch`.
- **Input validation**: anchor `DATE_RANGE_RE`, round-trip `isValidDate` via UTC reformat to detect calendar overflow, enforce `MAX_PARAM_LENGTH=200` and `q.length <= 100`.
- **ShareButtons**: `rel="noopener noreferrer"` on external `_blank` links.

`SKIP_ACCESS_JWT="1"` is intentionally retained in `wrangler.toml [vars]` for both production and preview during the migration window. A `TODO(#375)` documents the deletion condition (after `wrangler secret put CF_ACCESS_AUD/CF_ACCESS_TEAM_DOMAIN`). Bearer `ADMIN_TOKEN` auth runs in parallel until Access is fully enabled.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm format --check`
- [x] `pnpm test:client` (349/349)
- [x] `pnpm test` (724/727 — the 3 failures are pre-existing flaky tests in `tests/worker/api/admin.test.ts` for `POST /api/admin/collect` / `POST /api/admin/collector/run` that depend on real external RSS fetches under a 500ms timeout. Reproduced on main with the changes stashed.)
- [x] `pnpm build`
- [x] code-reviewer agent: must-fix and should-fix items addressed (TODO on `SKIP_ACCESS_JWT`, doc cleanup, `url-safety.ts` placement under `collector/`, `timingSafeEqual` length oracle, `ISO_RE` regex dedup).

## Operator follow-up

After this PR merges, the Access setup checklist in `docs/auth.md` should be executed:

1. Create the Self-hosted application in Cloudflare One.
2. `wrangler secret put CF_ACCESS_AUD` and `wrangler secret put CF_ACCESS_TEAM_DOMAIN`.
3. Remove the `SKIP_ACCESS_JWT = "1"` line from `wrangler.toml` (both `[vars]` and `[env.preview.vars]`) and deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cloudflare Access JWT authentication for admin endpoints with local development bypass support.
  * Added URL safety validation to prevent SSRF attacks when processing feed URLs.
  * Added link sanitization to block dangerous URI schemes in article content.

* **Bug Fixes**
  * Strengthened API input validation for date parameters, author names, and feed IDs to return HTTP 400 on invalid inputs.

* **Security**
  * Added security headers: Strict-Transport-Security, Cross-Origin-Opener-Policy, Cross-Origin-Resource-Policy.
  * Enhanced CORS to respect configured origins without wildcard fallback.

* **Documentation**
  * Added authentication guide and environment variable examples for local development.

* **Chores**
  * Pinned GitHub Actions to specific commit SHAs across all workflows for reproducibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->