### PR TITLE
style(client): improve readability of stats charts

### DIFF
--- a/apps/web/client/components/CalendarHeatmap.tsx
+++ b/apps/web/client/components/CalendarHeatmap.tsx
@@ -148,13 +148,13 @@ export function CalendarHeatmap({ days: initialDays = 90 }: Props) {
         <div className="overflow-x-auto pb-[var(--space-1)]">
           {/* 月ラベル行 */}
           <div
-            className="grid gap-[3px] ml-[24px] mb-[2px]"
+            className="grid gap-[3px] ml-[28px] mb-[var(--space-1)]"
             style={{ gridTemplateColumns: `repeat(${totalWeeks}, 1fr)` }}
           >
             {Array.from({ length: totalWeeks }, (_, w) => {
               const label = monthLabels.find((m) => m.weekIndex === w);
               return (
-                <div key={w} className="text-[0.65rem] text-[var(--fg-muted)] whitespace-nowrap">
+                <div key={w} className="text-[0.7rem] text-[var(--fg-muted)] whitespace-nowrap">
                   {label?.label ?? ""}
                 </div>
               );
@@ -163,21 +163,20 @@ export function CalendarHeatmap({ days: initialDays = 90 }: Props) {
 
           <div className="flex gap-[var(--space-1)] items-start">
             {/* 曜日ラベル列 */}
-            <div className="grid [grid-template-rows:repeat(7,12px)] gap-[3px] shrink-0 w-[20px]">
+            <div className="grid [grid-template-rows:repeat(7,14px)] gap-[3px] shrink-0 w-[24px]">
               {DAY_LABELS.map((label, i) => (
                 <div
                   key={i}
-                  className="text-[0.6rem] text-[var(--fg-muted)] leading-[12px] text-right"
+                  className="text-[0.65rem] text-[var(--fg-muted)] leading-[14px] text-right"
                 >
-                  {/* 月・水・金のみ表示してスペースを節約する */}
-                  {i % 2 === 1 ? label : ""}
+                  {label}
                 </div>
               ))}
             </div>
 
             {/* ヒートマップグリッド: 縦 7 行 (曜日) × 横 N 週 */}
             <div
-              className="grid [grid-template-rows:repeat(7,12px)] [grid-auto-flow:column] gap-[3px] shrink-0"
+              className="grid [grid-template-rows:repeat(7,14px)] [grid-auto-flow:column] gap-[3px] shrink-0"
               style={{ gridTemplateColumns: `repeat(${totalWeeks}, 1fr)` }}
             >
               {cells.map((cell, idx) => {
@@ -190,7 +189,7 @@ export function CalendarHeatmap({ days: initialDays = 90 }: Props) {
                 return (
                   <div
                     key={idx}
-                    className={`w-[12px] h-[12px] rounded-[2px] transition-opacity duration-100 hover:opacity-80${
+                    className={`w-[14px] h-[14px] rounded-[3px] ring-1 ring-inset ring-[var(--border-subtle)]/40 transition-transform duration-100 hover:scale-125 hover:ring-[var(--accent)]${
                       level >= 0 ? ` ${bgClass}` : " invisible"
                     }`}
                     data-level={level}
@@ -204,16 +203,17 @@ export function CalendarHeatmap({ days: initialDays = 90 }: Props) {
           </div>
 
           {/* 凡例 */}
-          <div className="flex items-center gap-[3px] mt-[var(--space-2)] justify-end">
-            <span className="text-[0.65rem] text-[var(--fg-muted)] mx-[2px]">少</span>
+          <div className="flex items-center gap-[var(--space-1)] mt-[var(--space-3)] justify-end text-[var(--font-size-xs)] text-[var(--fg-muted)]">
+            <span>記事数</span>
+            <span className="ml-[var(--space-1)]">少</span>
             {[0, 1, 2, 3, 4].map((level) => (
               <div
                 key={level}
-                className={`w-[12px] h-[12px] rounded-[2px] ${LEVEL_BG_CLASSES[level] ?? ""}`}
+                className={`w-[14px] h-[14px] rounded-[3px] ring-1 ring-inset ring-[var(--border-subtle)]/40 ${LEVEL_BG_CLASSES[level] ?? ""}`}
                 aria-hidden
               />
             ))}
-            <span className="text-[0.65rem] text-[var(--fg-muted)] mx-[2px]">多</span>
+            <span>多</span>
           </div>
         </div>
       )}

--- a/apps/web/client/components/StatsChart.tsx
+++ b/apps/web/client/components/StatsChart.tsx
@@ -6,44 +6,63 @@ interface StatsChartProps {
 }
 
 // カテゴリごとの色 (CSS 変数が使えないため直値; ライト/ダーク両対応の中間色)
+// zenn は bigtech との判別性確保のため青ではなく紫に変更
 const CATEGORY_COLORS: Record<string, string> = {
   bigtech: "#4493f8",
   ai: "#d29922",
   jp: "#3fb950",
-  zenn: "#3ea8ff",
+  zenn: "#a371f7",
 };
 
 const CHART_W = 800;
-const CHART_H = 160;
-const PAD_LEFT = 32;
-const PAD_RIGHT = 8;
-const PAD_TOP = 8;
-const PAD_BOTTOM = 32;
+const CHART_H = 220;
+const PAD_LEFT = 36;
+const PAD_RIGHT = 12;
+const PAD_TOP = 12;
+const PAD_BOTTOM = 36;
 const INNER_W = CHART_W - PAD_LEFT - PAD_RIGHT;
 const INNER_H = CHART_H - PAD_TOP - PAD_BOTTOM;
+
+// y 軸の上限を「キリのいい値」に丸める (50 / 100 / 200 …)
+function niceCeil(value: number): number {
+  if (value <= 0) return 1;
+  const exp = Math.floor(Math.log10(value));
+  const base = 10 ** exp;
+  const f = value / base;
+  const niceF = f <= 1 ? 1 : f <= 2 ? 2 : f <= 5 ? 5 : 10;
+  return niceF * base;
+}
 
 export function StatsChart({ data, categories }: StatsChartProps) {
   if (data.length === 0) return null;
 
   // 各日の合計を計算して y 軸最大値を求める
   const totals = data.map((p) => categories.reduce((s, c) => s + p[c], 0));
-  const maxTotal = Math.max(...totals, 1);
+  const rawMax = Math.max(...totals, 1);
+  const maxTotal = niceCeil(rawMax);
 
   const barCount = data.length;
   const barGap = 2;
   const barW = Math.max(1, (INNER_W - barGap * (barCount - 1)) / barCount);
 
-  // x 軸ラベルは最初・中央・最後の 3 点のみ表示
-  const labelIndices = new Set([0, Math.floor((barCount - 1) / 2), barCount - 1]);
+  // x 軸ラベル: 7 日刻みに加え、必ず先頭と末尾を含める
+  const labelStep = Math.max(1, Math.floor(barCount / 5));
+  const labelIndices = new Set<number>();
+  labelIndices.add(0);
+  labelIndices.add(barCount - 1);
+  for (let i = 0; i < barCount; i += labelStep) labelIndices.add(i);
+
+  // y 軸グリッド/ラベル: 5 等分 (0%, 25%, 50%, 75%, 100%)
+  const gridRatios = [0, 0.25, 0.5, 0.75, 1];
 
   return (
     <figure className="m-0">
       {/* 凡例 */}
-      <div className="flex flex-wrap gap-[var(--space-3)] mb-[var(--space-2)] text-[var(--font-size-sm)] text-[var(--fg-muted)]">
+      <div className="flex flex-wrap gap-[var(--space-3)] mb-[var(--space-3)] text-[var(--font-size-sm)] text-[var(--fg-secondary)]">
         {categories.map((cat) => (
           <span key={cat} className="flex items-center gap-[var(--space-1)]">
             <span
-              className="inline-block w-[10px] h-[10px] rounded-[var(--radius-sm)] shrink-0"
+              className="inline-block w-[12px] h-[12px] rounded-[var(--radius-sm)] shrink-0"
               style={{ background: CATEGORY_COLORS[cat] ?? "#999" }}
             />
             {cat}
@@ -56,10 +75,10 @@ export function StatsChart({ data, categories }: StatsChartProps) {
         preserveAspectRatio="none"
         aria-label="カテゴリ別 30 日記事数トレンド"
         role="img"
-        className="block w-full h-auto [aspect-ratio:800/160] text-[var(--fg-primary)]"
+        className="block w-full h-auto [aspect-ratio:800/220] text-[var(--fg-primary)]"
       >
-        {/* y 軸グリッド線 (0 / 50% / 100%) */}
-        {[0, 0.5, 1].map((ratio) => {
+        {/* y 軸グリッド線 + ラベル */}
+        {gridRatios.map((ratio) => {
           const y = PAD_TOP + INNER_H * (1 - ratio);
           const label = Math.round(maxTotal * ratio);
           return (
@@ -70,16 +89,17 @@ export function StatsChart({ data, categories }: StatsChartProps) {
                 x2={CHART_W - PAD_RIGHT}
                 y2={y}
                 stroke="currentColor"
-                strokeOpacity="0.15"
+                strokeOpacity={ratio === 0 ? "0.35" : "0.15"}
                 strokeWidth="1"
+                strokeDasharray={ratio === 0 ? "" : "3 3"}
               />
               <text
-                x={PAD_LEFT - 4}
+                x={PAD_LEFT - 6}
                 y={y + 4}
                 textAnchor="end"
-                fontSize="10"
+                fontSize="11"
                 fill="currentColor"
-                fillOpacity="0.5"
+                fillOpacity="0.65"
               >
                 {label}
               </text>
@@ -106,7 +126,6 @@ export function StatsChart({ data, categories }: StatsChartProps) {
                     width={barW}
                     height={h}
                     fill={CATEGORY_COLORS[cat] ?? "#999"}
-                    opacity="0.85"
                   >
                     <title>
                       {point.date} / {cat}: {val}
@@ -118,11 +137,11 @@ export function StatsChart({ data, categories }: StatsChartProps) {
               {labelIndices.has(i) && (
                 <text
                   x={x + barW / 2}
-                  y={CHART_H - 4}
+                  y={CHART_H - 8}
                   textAnchor="middle"
-                  fontSize="10"
+                  fontSize="11"
                   fill="currentColor"
-                  fillOpacity="0.6"
+                  fillOpacity="0.65"
                 >
                   {point.date.slice(5)}
                 </text>

--- a/apps/web/client/components/StatsDashboard.tsx
+++ b/apps/web/client/components/StatsDashboard.tsx
@@ -34,7 +34,7 @@ function BarRow({
 }) {
   const pct = maxCount > 0 ? Math.round((count / maxCount) * 100) : 0;
   return (
-    <div className="grid [grid-template-columns:minmax(120px,180px)_1fr_60px] items-center gap-[var(--space-3)]">
+    <div className="grid [grid-template-columns:minmax(120px,180px)_1fr_56px] items-center gap-[var(--space-3)]">
       {onClick ? (
         <button
           type="button"
@@ -50,12 +50,16 @@ function BarRow({
         </span>
       )}
       <div
-        className="h-[8px] rounded-[var(--radius-full)] bg-[var(--accent)] opacity-70 min-w-[2px] transition-opacity duration-100 hover:opacity-100"
+        className="relative h-[12px] rounded-[var(--radius-full)] bg-[var(--bg-overlay)] overflow-hidden"
         role="img"
         aria-label={`${label}: ${count}件`}
-        style={{ width: `${pct}%` }}
-      />
-      <span className="text-[var(--font-size-sm)] text-[var(--fg-muted)] text-right [font-variant-numeric:tabular-nums]">
+      >
+        <div
+          className="h-full rounded-[var(--radius-full)] bg-[var(--accent)] min-w-[2px] transition-[width] duration-200"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span className="text-[var(--font-size-sm)] font-semibold text-[var(--fg-primary)] text-right [font-variant-numeric:tabular-nums]">
         {count.toLocaleString("ja-JP")}
       </span>
     </div>


### PR DESCRIPTION
## Summary

Stats ページのグラフ周りが「見づらい」というフィードバックを受け、StatsChart / CalendarHeatmap / StatsDashboard の BarRow を中心に視認性を改善しました。

- **StatsChart** (カテゴリ別 30 日トレンド)
  - 高さを 160→220px に拡大して縦の押し潰しを解消
  - y 軸グリッドを 3 本→5 本（点線 + ベースラインを濃く）、最大値を `niceCeil` でキリのいい値に丸めてラベルを読みやすく
  - x 軸ラベルを 3 点 → 約 5 等分 + 先頭末尾必須に
  - 軸ラベルのフォントサイズと不透明度を引き上げ
  - `zenn` を青 (`#3ea8ff`) → 紫 (`#a371f7`) に変更し `bigtech` との判別性を確保
- **CalendarHeatmap**
  - セルを 12×12px → 14×14px に拡大、薄い ring で空セルの輪郭可視化
  - 曜日ラベルを「月・水・金のみ」→ 7 曜日すべてに
  - ホバーで `scale-125` ＋ accent ring で強調
  - 凡例に「記事数」を明示
- **StatsDashboard BarRow** (著者別 / フィード別 / 言語別 / カテゴリ別)
  - 背景トラックを敷き、バー高 8→12px、フル不透明
  - 数値カラムを `fg-muted` → `fg-primary` (semibold) に強調

## Test plan

- [x] `pnpm typecheck` pass
- [x] `pnpm check` (lint + format on 3 files) pass
- [x] `pnpm test:client` 関連 4 ファイル 37 tests pass
- [ ] `e2e` (Playwright) — 影響範囲を grep で確認、グラフの DOM 詳細にはアサートしていないため通る想定
- [ ] ローカル `pnpm dev` で /stats ページを目視確認 (Chrome 拡張未接続のため未実施)