### PR TITLE
fix(reports): ground daily report links in collected articles to prevent fabricated URLs (#365)

### DIFF
--- a/.claude/skills/tech-news-digest/EVALUATION.md
+++ b/.claude/skills/tech-news-digest/EVALUATION.md
@@ -88,7 +88,36 @@ WebFetch 失敗率 = (summary based) がついた記事数 / Stage 2 選定記�
 
 ---
 
-### 6. 重複記事数 (客観)
+### 6. fabricated_url_count (客観)
+
+**定義**: 出力 markdown 中の `[text](url)` link のうち、Stage 1 `articles[].url` 集合に含まれない url の件数。
+
+**計算式**:
+
+```
+fabricated_url_count = |出力 link URL 集合| - |出力 link URL 集合 ∩ articles[].url 集合|
+```
+
+**測定手順**:
+
+1. skill 実行時の Stage 1 JSON (`articles[].url` の配列) を `/tmp/stage1_urls.txt` に保存
+2. skill の最終出力 markdown を `/tmp/report.md` に保存
+3. 以下のコマンドで link を抽出し set difference を確認:
+
+```sh
+# 出力 markdown から URL を抽出
+grep -oE '\]\([^)]+\)' /tmp/report.md | sed 's/](\(.*\))/\1/' | sort -u > /tmp/output_urls.txt
+# Stage 1 URL と差分を確認
+comm -23 /tmp/output_urls.txt <(sort /tmp/stage1_urls.txt) | wc -l
+```
+
+**許容範囲**: **0 件** (ゼロトレランス)。1 件以上で退行とみなす。
+
+**退行時の対応**: SKILL.md ガードレールの「URL 捏造禁止」節と workflow prompt の URL 制約指示を強化する。
+
+---
+
+### 7. 重複記事数 (客観)
 
 **定義**: Stage 1 の URL de-dup 処理後に残った同一 URL の重複記事数。skill の出力の `## カテゴリ別件数` 合計と、de-dup 前の `total` の差から推定できる。
 
@@ -121,6 +150,7 @@ skill を 1 回実行するごとに `runs.md` に追記する。
 | WebFetch 失敗数 (blocklist 除く) | N 件                 |
 | WebFetch 失敗率                  | X.XX                 |
 | 同一ホスト連続違反数             | N 件                 |
+| fabricated_url_count             | N 件                 |
 | 重要記事再現率                   | X.XX (N/5)           |
 | 要約事実整合性 (平均)            | X.X / 2.0            |
 | トレンド意味性スコア             | N / 5                |
@@ -148,10 +178,11 @@ runs.md に結果を記録
 
 ### チューニング優先度の目安
 
-| 指標                  | 退行 (要対応) | 改善の対象プロンプト箇所        |
-| --------------------- | ------------- | ------------------------------- |
-| 重要記事再現率 < 0.6  | 即時対応      | Stage 2 の選定基準テキスト      |
-| WebFetch 失敗率 ≥ 0.3 | 次回修正      | Stage 3 の blocklist / fallback |
-| トレンド意味性 < 3    | 次回修正      | Stage 4 の分析視点テキスト      |
-| 要約整合性 < 1.5      | 即時対応      | Stage 3 の要約生成プロンプト    |
-| 同一ホスト違反 > 0    | 即時対応      | Stage 3 のバッチ計画説明        |
+| 指標                     | 退行 (要対応) | 改善の対象プロンプト箇所                                                  |
+| ------------------------ | ------------- | ------------------------------------------------------------------------- |
+| 重要記事再現率 < 0.6     | 即時対応      | Stage 2 の選定基準テキスト                                                |
+| WebFetch 失敗率 ≥ 0.3    | 次回修正      | Stage 3 の blocklist / fallback                                           |
+| トレンド意味性 < 3       | 次回修正      | Stage 4 の分析視点テキスト                                                |
+| 要約整合性 < 1.5         | 即時対応      | Stage 3 の要約生成プロンプト                                              |
+| 同一ホスト違反 > 0       | 即時対応      | Stage 3 のバッチ計画説明                                                  |
+| fabricated_url_count ≥ 1 | 即時対応      | SKILL.md ガードレール「URL 捏造禁止」節 + workflow prompt の URL 制約指示 |

--- a/.claude/skills/tech-news-digest/SKILL.md
+++ b/.claude/skills/tech-news-digest/SKILL.md
@@ -61,31 +61,13 @@ node tools/d1-client/recent.mjs --since=week --category=jp --target=remote
 
 **複数カテゴリを対象にする場合 (例: bigtech + ai + jp)**:
 
-`recent.mjs` はカンマ区切り複数指定に非対応のため、カテゴリごとに呼んで URL で de-dup する:
+`recent.mjs` はカンマ区切りの複数カテゴリ指定に対応している。1 回の呼び出しで取得し、URL de-dup も `recent.mjs` 側で実施されるためアプリ側の merge 処理は不要:
 
 ```sh
-# カテゴリごとに取得
-node tools/d1-client/recent.mjs --since=today --category=bigtech --target=remote > /tmp/arts_bigtech.json
-node tools/d1-client/recent.mjs --since=today --category=ai      --target=remote > /tmp/arts_ai.json
-node tools/d1-client/recent.mjs --since=today --category=jp      --target=remote > /tmp/arts_jp.json
+node tools/d1-client/recent.mjs --since=today --category=bigtech,ai,jp --target=remote --limit=600
 ```
 
-取得後、3 つの `articles[]` を結合して URL de-dup する (古い `published_at` 優先):
-
-```js
-const seen = new Map();
-const merged = [];
-for (const a of [...bigtech, ...ai, ...jp].sort((x, y) =>
-  x.published_at.localeCompare(y.published_at),
-)) {
-  if (!seen.has(a.url)) {
-    seen.set(a.url, true);
-    merged.push(a);
-  }
-}
-```
-
-以降の Stage はマージ済み `merged` を `articles` として扱う。
+返り値の `articles[]` は de-dup 済み (古い `published_at` 優先)。以降の Stage はそのまま `articles` を使う。
 
 stdout に出る JSON 形式:
 

--- a/.claude/skills/tech-news-digest/SKILL.md
+++ b/.claude/skills/tech-news-digest/SKILL.md
@@ -127,6 +127,8 @@ stdout に出る JSON 形式:
 
 ### Stage 2: Triage — 重要記事を選定 (quick / deep)
 
+> **URL 制約**: この Stage 以降のすべての出力で使用する URL は、Stage 1 で取得した `articles[].url` のいずれかと **string equality で完全一致** すること。記憶・推測・タイトルからの組み立てによる URL 生成は禁止。
+
 `articles[].summary` (≤500 字抜粋) を読み、次の基準で **重要記事 5〜10 件**を選定する:
 
 - 大きなプロダクト / モデルローンチ (GA、GPT-N、Claude N、新フレームワーク等)
@@ -147,6 +149,8 @@ stdout に出る JSON 形式:
 
 ### Stage 3: Deep read — 本文を WebFetch で取得 (deep のみ)
 
+> **URL 制約**: WebFetch に渡す URL は `articles[].url` のコピーのみ使用する。要約テキストに埋め込むリンクも `articles[].url` から copy-paste すること。
+
 Stage 2 で選定した記事の `url` を WebFetch で取得し、本文を読んだうえで日本語 1〜2 文の要約を生成する。
 
 **同一ホストへの連続 fetch は行わない**。ホスト別にバッチを組み、各バッチ内では parallel fetch し、バッチ間では別ホストのバッチを挟む順序で実行する:
@@ -164,6 +168,8 @@ Stage 2 で選定した記事の `url` を WebFetch で取得し、本文を読�
 - 動画 / pdf / login wall は WebFetch せず `summary` だけで処理 (`(summary based)` 注記)
 
 ### Stage 4: Synthesize — トレンド分析 (deep / trend)
+
+> **URL 制約**: トレンド分析内で関連記事リンクを埋め込む際、URL は必ず `articles[].url` から copy-paste すること。Stage 1 に存在しない URL を生成・推測してはならない。
 
 Stage 1 の全記事 (`articles`、Stage 1 の de-dup 後) を見渡し、タイトル + summary + (deep なら Stage 3 の本文要約) からトレンドを **意味的に** 解釈する。
 
@@ -193,11 +199,13 @@ Markdown で次の構造で返す。`mode` に応じて該当しない節は省�
 Stage 2 で選定した重要記事のリンク集。
 
 - **[<タイトル>](url)** _(<feed_name>, <category>, <YYYY-MM-DD>)_ — <1〜2 文の日本語要約> <(summary based) があれば末尾に>
+<!-- ↑ url は articles[].url を copy-paste。推測・組み立て禁止 -->
 - ...
 
 ## トレンド (横断) ← deep / trend のみ
 
 - **<テーマ>**: <意味的な解釈の 1〜2 文> 関連: [記事 A](url), [記事 B](url)
+<!-- ↑ url は articles[].url を copy-paste。推測・組み立て禁止 -->
 - ...
 
 ## カテゴリ別ハイライト ← deep / trend のみ
@@ -253,6 +261,20 @@ Stage 2 で選定した重要記事のリンク集。
 - **記事 0 件**: 「該当期間に記事なし」と正直に報告する。creative writing で埋めない
 - **WebFetch 連続失敗**: deep モードで選定記事の半数以上が fetch 失敗したら、残りは `quick` 相当 (`(summary based)` 付き) に退避し、出力末尾に `_注: WebFetch が複数失敗したため一部 summary ベース_` を付ける
 - **ストーリー形式・読み物が要求された場合**: 本 skill はリスト形式のダイジェスト専用。テーマ別ストーリーやニュースレター形式が必要な場合は `tech-news-weekly` を案内する
+
+### URL 捏造禁止
+
+出力する markdown link `[text](url)` の `url` はすべて **Stage 1 で取得した `articles[].url` から copy-paste したもの**のみ許容する。
+
+以下の行為は一切禁止:
+
+- 記事タイトルからホスト名 + slug を組み立てて URL を生成する
+- ホスト名の記憶・推測からドメインを書く
+- `articles[]` に存在しない URL を出力する
+
+URL が不確実・不明な場合は `[テキスト]` のようにリンク無しのテキストにする。URL の copy-paste のみ許容される。
+
+**退行判定**: generation evaluation で `fabricated_url_count ≥ 1` の場合は退行とし、SKILL.md ガードレールと workflow prompt の URL 捏造禁止節を強化する。
 
 ## 評価
 

--- a/.claude/skills/tech-news-digest/SKILL.md
+++ b/.claude/skills/tech-news-digest/SKILL.md
@@ -252,13 +252,114 @@ Stage 2 で選定した重要記事のリンク集。
 <jp カテゴリの技術動向 2〜3 点>
 ```
 
+## 自動 daily report 生成モード
+
+GitHub Actions (`.github/workflows/report-daily.yml`) から本 skill を起動する場合、本節の手順に厳密に従う。workflow yaml には skill 起動パラメータのみが書かれており、出力フォーマット・ファイル書き出し・no-articles 挙動・URL grounding はすべて本節を一次ソースとする。
+
+### 起動パラメータ (workflow から渡される想定)
+
+- `since=today` (固定)
+- `mode=deep` (固定)
+- `target=remote` (固定)
+- 対象カテゴリ: `bigtech,ai,jp` (zenn は除外)
+- `lang`: 指定なし
+
+### Stage 1 の呼び方
+
+```sh
+node tools/d1-client/recent.mjs --since=today --category=bigtech,ai,jp --target=remote --limit=600
+```
+
+`recent.mjs` の `--category` カンマ区切り対応版を使用する (1 回呼び出しで bigtech/ai/jp を取得)。返り値の `articles[]` は `recent.mjs` 側で URL de-dup 済み (古い `published_at` 優先)。
+
+### 出力ファイル (Stage 4 完了時に書き出す)
+
+#### 1. `/tmp/report.md`
+
+**記事が 1 件以上ある場合**: 出力フォーマット節の構造に従う。次の節は省略禁止:
+
+- `## Pick 記事リンク一覧`: 各記事に `[<title>](url)` _(<feed_name>, <category>, <YYYY-MM-DD>)_ — 1〜2 文要約。`url` は `articles[].url` の copy-paste のみ
+- `## カテゴリ別動向`: bigtech / ai / jp の `###` サブセクションでカテゴリごとの技術動向 2〜3 点
+
+**記事が 0 件の場合 (`articles.length === 0`)**: 以下の最小レポートを書き出す。creative writing は禁止 — 「ない」事実を「ない」と書く。
+
+```md
+# Tech News Digest — <YYYY-MM-DD> (daily)
+
+期間: <ISO start> 〜 <ISO end> / 総件数 (de-dup 後): 0 / カテゴリ: bigtech=0, ai=0, jp=0
+
+## 概要
+
+本日 (<YYYY-MM-DD>) は対象期間 (UTC 過去 24 時間) 内に bigtech / ai / jp カテゴリの新規収集記事はありませんでした。
+
+## カテゴリ別件数
+
+| Category | 件数 |
+| -------- | ---- |
+| bigtech  | 0    |
+| ai       | 0    |
+| jp       | 0    |
+```
+
+Stage 2〜4 は articles 0 件のためスキップする (`/tmp/report.md` のみ書き出して終了)。
+
+#### 2. `/tmp/report-meta.json`
+
+記事件数に関わらず必ず書き出す (Worker API は記事 0 件でも記録する):
+
+```json
+{
+  "kind": "daily",
+  "period_start": "<since の ISO 8601 (実行時刻 -24h)>",
+  "period_end": "<実行時刻の ISO 8601>",
+  "category": null,
+  "lang": null,
+  "included_categories": ["bigtech", "ai", "jp"],
+  "source_skill": "tech-news-digest",
+  "generated_at": "<実行時刻の ISO 8601>",
+  "dedup_total": <number — 0 でもよい>,
+  "by_category": <object — 0 件のときは {"bigtech": 0, "ai": 0, "jp": 0}>,
+  "by_feed": <object — 0 件のときは {}>
+}
+```
+
+#### 3. `/tmp/slack-message.md`
+
+Slack mrkdwn 記法 (`*bold*`, `_italic_`, `<URL|label>`)。30000 文字以内 (上限。長くても構わない)。末尾に viewer URL は付けない (Actions 側で自動付与される)。
+
+**記事が 1 件以上ある場合**:
+
+- 冒頭にレポート概要 1〜2 文
+- 「カテゴリ別ハイライト (bigtech / ai / jp)」「注目記事 (各記事は 1 行、リンク付き)」を Slack で読みやすく整形
+
+**記事が 0 件の場合**:
+
+```
+本日 (<YYYY-MM-DD>) は対象カテゴリ (bigtech / ai / jp) の新規収集記事はありませんでした。
+```
+
+の 1 行のみで終える。リンクや注目記事節は出さない。
+
+### URL grounding (再掲・絶対遵守)
+
+出力する markdown link `[text](url)` の `url` はすべて **Stage 1 で取得した `articles[].url` から copy-paste したもの**のみ許容する (詳細は「URL 捏造禁止」節)。Stage 4 完了時点で、Stage 1 取得 `articles[].url` の全 URL を「許容 URL 一覧」として内部で保持し、`/tmp/report.md` および `/tmp/slack-message.md` 内のすべての `[text](url)` link が許容 URL 一覧に含まれることを確認してから書き出す。含まれない link は url 部分を削除してテキストのみにする。
+
+### Workflow 側の補助挙動 (skill 側からの期待事項)
+
+skill 自身は触らないが、`/tmp/report.md` `/tmp/report-meta.json` `/tmp/slack-message.md` の 3 ファイルが必ず存在することを前提に Workflow が以下を行う:
+
+- `/api/admin/reports` への POST (記事 0 件でも実行履歴として記録)
+- Slack thread への 2 段投稿 (parent: title + severity / child: 本文 chunk + viewer URL)
+
+skill は上記 3 ファイルを必ず書き出す責務を持つ。書き出さないと workflow が `Skill did not produce required output files; aborting.` で失敗する。
+
 ## ガードレール
 
 - **PII / 機密情報**: 公開記事のみ蓄積されている前提だが、author 名以外の個人情報が混ざっていたら出力から除外する
 - **D1 接続失敗時**:
   - `--target=remote` で 401/403 → `pnpm --filter @tnb/web exec wrangler login` を案内
   - `--target=local` で 0 件 → `pnpm migrate:local` + `pnpm dev` でローカル収集を 1 回回すよう案内
-- **記事 0 件**: 「該当期間に記事なし」と正直に報告する。creative writing で埋めない
+- **記事 0 件**: 「該当期間に記事なし」と正直に報告する。creative writing で埋めない (自動 daily report モードでは「自動 daily report 生成モード」節の最小レポートを書き出す)
 - **WebFetch 連続失敗**: deep モードで選定記事の半数以上が fetch 失敗したら、残りは `quick` 相当 (`(summary based)` 付き) に退避し、出力末尾に `_注: WebFetch が複数失敗したため一部 summary ベース_` を付ける
 - **ストーリー形式・読み物が要求された場合**: 本 skill はリスト形式のダイジェスト専用。テーマ別ストーリーやニュースレター形式が必要な場合は `tech-news-weekly` を案内する
 

--- a/.claude/skills/tech-news-weekly/SKILL.md
+++ b/.claude/skills/tech-news-weekly/SKILL.md
@@ -93,6 +93,8 @@ stdout の JSON 形式は `tech-news-digest` と同一 (`since`, `total`, `dedup
 
 ### Stage 2: Triage — 重要記事の選定
 
+> **URL 制約**: この Stage 以降のすべての出力で使用する URL は、Stage 1 で取得した `articles[].url` のいずれかと **string equality で完全一致** すること。記憶・推測・タイトルからの組み立てによる URL 生成は禁止。
+
 `articles[].summary` (≤500 字抜粋) を読み、週次・月次のレポートに値する記事を選定する。
 
 選定基準 (優先度順):
@@ -117,6 +119,8 @@ stdout の JSON 形式は `tech-news-digest` と同一 (`since`, `total`, `dedup
 
 ### Stage 3: Deep read — 本文を WebFetch で取得
 
+> **URL 制約**: WebFetch に渡す URL および出力に埋め込む link URL は `articles[].url` のコピーのみ使用する。
+
 Stage 2 で選定した記事の `url` を WebFetch で取得し、日本語 1〜2 文の要約を生成する。
 
 **同一ホストへの連続 fetch は行わない**。ホスト別にバッチを組み、各バッチを並列 fetch し、バッチ間では別ホストのバッチを挟む:
@@ -135,6 +139,8 @@ Stage 2 で選定した記事の `url` を WebFetch で取得し、日本語 1�
 - deep モードで選定記事の半数以上が fetch 失敗したら、出力末尾に `_注: WebFetch が複数失敗したため一部 summary ベース_` を付ける
 
 ### Stage 4: テーマ抽出 + 時系列 narrative 生成
+
+> **URL 制約**: ストーリー内に埋め込む関連記事リンクの URL は必ず `articles[].url` から copy-paste すること。Stage 1 に存在しない URL を生成・推測してはならない。
 
 Stage 1 の全記事 (de-dup 後) と Stage 3 の本文要約を総合して、読み物として成立するレポートを生成する。
 
@@ -201,6 +207,7 @@ Stage 1 の全記事 (de-dup 後) と Stage 3 の本文要約を総合して、�
 ## 注目記事ピックアップ ← 必ず出力する。省略禁止
 
 - **[<タイトル>](url)** _(<feed_name>, <category>, <YYYY-MM-DD>)_: <1〜2 文の要約> <(summary based) があれば末尾に>
+<!-- ↑ url は articles[].url を copy-paste。推測・組み立て禁止 -->
 - ...
 
 ## カテゴリ別件数
@@ -224,6 +231,20 @@ Stage 1 の全記事 (de-dup 後) と Stage 3 の本文要約を総合して、�
   - `--target=remote` で 401/403 → `pnpm --filter @tnb/web exec wrangler login` を案内
   - `--target=local` で 0 件 → `pnpm migrate:local` + `pnpm dev` でローカル収集を 1 回回すよう案内
 - **today / 今日 と言われた場合**: 本 skill は週次・月次専用。`tech-news-digest` を使うよう案内する
+
+### URL 捏造禁止
+
+出力する markdown link `[text](url)` の `url` はすべて **Stage 1 で取得した `articles[].url` から copy-paste したもの**のみ許容する。
+
+以下の行為は一切禁止:
+
+- 記事タイトルからホスト名 + slug を組み立てて URL を生成する
+- ホスト名の記憶・推測からドメインを書く
+- `articles[]` に存在しない URL を出力する
+
+URL が不確実・不明な場合は `[テキスト]` のようにリンク無しのテキストにする。URL の copy-paste のみ許容される。
+
+**退行判定**: generation evaluation で `fabricated_url_count ≥ 1` の場合は退行とし、SKILL.md ガードレールと workflow prompt の URL 捏造禁止節を強化する。
 
 ## 関連ファイル
 

--- a/.github/workflows/report-daily.yml
+++ b/.github/workflows/report-daily.yml
@@ -51,60 +51,31 @@ jobs:
           model: "claude-sonnet-4-5-20250929"
           allowed_tools: "Bash,Read,Write,WebFetch,Skill"
           timeout_minutes: 30
-          # daily digest 生成プロンプト。skill 起動と最終ファイル書き出しを明示する。
+          # daily digest 生成プロンプト。詳細な手順 (出力ファイル / フォーマット / no-articles 挙動 /
+          # URL grounding) は .claude/skills/tech-news-digest/SKILL.md の「自動 daily report
+          # 生成モード」節を一次ソースとする。yaml 側は skill 起動パラメータのみを渡す。
           prompt: |
             あなたは tech-news-bot の自動レポート生成エージェントです。
 
-            tech-news-digest skill を以下の引数で起動してください:
+            tech-news-digest skill を「自動 daily report 生成モード」で起動してください。
+            詳細な手順・出力ファイル仕様・記事 0 件時の挙動・URL grounding ルールは
+            すべて .claude/skills/tech-news-digest/SKILL.md の「自動 daily report 生成モード」
+            節に書かれています。skill 側を一次ソースとし、本 prompt の指示と矛盾した場合は
+            SKILL.md を優先してください。
+
+            起動パラメータ:
             - since=today
             - mode=deep
             - target=remote
             - personal カテゴリは除外 (bigtech / ai / jp の 3 カテゴリを対象にする)
             - lang 指定なし
 
-            Stage 1 では bigtech / ai / jp の 3 カテゴリを 1 回の呼び出しで取得してください:
-              node tools/d1-client/recent.mjs --since=today --category=bigtech,ai,jp --target=remote --limit=600
-            取得した articles[] を対象に URL de-dup (古い published_at 優先) する。
-            以降の Stage はマージ済み articles を対象とする。
+            最終的に以下 3 ファイルを必ず書き出してください (記事 0 件でも書き出す):
+            - /tmp/report.md
+            - /tmp/report-meta.json
+            - /tmp/slack-message.md
 
-            Stage 1〜4 を完走したあと、最終的な markdown レポート全文を /tmp/report.md に
-            書き出してください。レポートには以下の節を必ず含めてください:
-            - `## Pick 記事リンク一覧` (必須・省略禁止): 各記事にタイトル/URL/feed_name/category/YYYY-MM-DD/1〜2文要約を含む
-            - `## カテゴリ別動向` (必須): bigtech / ai / jp の各サブセクション (###) でカテゴリごとの技術動向をサマる
-
-            合わせて以下の JSON を /tmp/report-meta.json に書き出してください:
-
-            {
-              "kind": "daily",
-              "period_start": "<since の ISO 8601>",
-              "period_end":   "<実行時刻の ISO 8601>",
-              "category": null,
-              "lang": null,
-              "included_categories": ["bigtech","ai","jp"],
-              "source_skill": "tech-news-digest",
-              "generated_at": "<実行時刻の ISO 8601>",
-              "dedup_total": <number>,
-              "by_category": <object>,
-              "by_feed": <object>
-            }
-
-            注意:
-            - recent.mjs を呼ぶときは --target=remote を必ず指定してください。
-            - 最終 markdown 出力以外のアシスタント発話は最小限に抑えてください。
-            - WebFetch が失敗した記事には (summary based) を末尾に付けてください。
-
-            URL 捏造禁止 (必須):
-            - 出力する markdown link [title](url) の url は、Stage 1 で取得した articles[].url のいずれかと完全一致 (string equality) させてください。articles[] に存在しない url を絶対に作らないでください。
-            - Pick 記事リンク一覧 / カテゴリ別動向 / トレンド の関連記事リンクすべてでこの制約を守ってください。
-            - 不確実な場合はリンク無しのテキストにし、URL の推測 (タイトルからホスト+slug を組み立てる、ホスト名の記憶からドメインを書く等) は一切行わないでください。
-            - Stage 4 完了時点で、Stage 1 取得 articles[].url の全 URL を「許容 URL 一覧」として内部で保持し、出力 markdown 内のすべての [text](url) link が許容 URL 一覧に含まれることを確認してから書き出してください。含まれない link があれば url 部分を削除してテキストのみにしてください。
-
-            加えて、Slack 投稿用のメッセージを /tmp/slack-message.md に書き出してください。
-            - Slack mrkdwn 記法 (*bold*, _italic_, <URL|label>)
-            - 30000 文字以内 (上限。長くても構わない)
-            - 冒頭にレポート概要を 1〜2 文
-            - その後に「カテゴリ別ハイライト (bigtech / ai / jp)」「注目記事 (各記事は 1 行、リンク付き)」を Slack で読みやすく整形
-            - 末尾に viewer URL は付けない (Actions 側で自動付与される)
+            最終ファイル書き出し以外のアシスタント発話は最小限に抑えてください。
 
       - name: Save report to D1 via admin API
         env:

--- a/.github/workflows/report-daily.yml
+++ b/.github/workflows/report-daily.yml
@@ -93,6 +93,12 @@ jobs:
             - 最終 markdown 出力以外のアシスタント発話は最小限に抑えてください。
             - WebFetch が失敗した記事には (summary based) を末尾に付けてください。
 
+            URL 捏造禁止 (必須):
+            - 出力する markdown link [title](url) の url は、Stage 1 で取得した articles[].url のいずれかと完全一致 (string equality) させてください。articles[] に存在しない url を絶対に作らないでください。
+            - Pick 記事リンク一覧 / カテゴリ別動向 / トレンド の関連記事リンクすべてでこの制約を守ってください。
+            - 不確実な場合はリンク無しのテキストにし、URL の推測 (タイトルからホスト+slug を組み立てる、ホスト名の記憶からドメインを書く等) は一切行わないでください。
+            - Stage 4 完了時点で、Stage 1 取得 articles[].url の全 URL を「許容 URL 一覧」として内部で保持し、出力 markdown 内のすべての [text](url) link が許容 URL 一覧に含まれることを確認してから書き出してください。含まれない link があれば url 部分を削除してテキストのみにしてください。
+
             加えて、Slack 投稿用のメッセージを /tmp/slack-message.md に書き出してください。
             - Slack mrkdwn 記法 (*bold*, _italic_, <URL|label>)
             - 30000 文字以内 (上限。長くても構わない)

--- a/.github/workflows/report-monthly.yml
+++ b/.github/workflows/report-monthly.yml
@@ -91,6 +91,12 @@ jobs:
             - 最終 markdown 出力以外のアシスタント発話は最小限に抑えてください。
             - WebFetch が失敗した記事には (summary based) を末尾に付けてください。
 
+            URL 捏造禁止 (必須):
+            - 出力する markdown link [title](url) の url は、Stage 1 で取得した articles[].url のいずれかと完全一致 (string equality) させてください。articles[] に存在しない url を絶対に作らないでください。
+            - 注目記事ピックアップ / カテゴリ別ハイライト / 今月の主要トピック の関連記事リンクすべてでこの制約を守ってください。
+            - 不確実な場合はリンク無しのテキストにし、URL の推測 (タイトルからホスト+slug を組み立てる、ホスト名の記憶からドメインを書く等) は一切行わないでください。
+            - Stage 4 完了時点で、Stage 1 取得 articles[].url の全 URL を「許容 URL 一覧」として内部で保持し、出力 markdown 内のすべての [text](url) link が許容 URL 一覧に含まれることを確認してから書き出してください。含まれない link があれば url 部分を削除してテキストのみにしてください。
+
             加えて、Slack 投稿用のメッセージを /tmp/slack-message.md に書き出してください。
             - Slack mrkdwn 記法 (*bold*, _italic_, <URL|label>)
             - 30000 文字以内 (上限。長くても構わない)

--- a/.github/workflows/report-weekly.yml
+++ b/.github/workflows/report-weekly.yml
@@ -89,6 +89,12 @@ jobs:
             - 最終 markdown 出力以外のアシスタント発話は最小限に抑えてください。
             - WebFetch が失敗した記事には (summary based) を末尾に付けてください。
 
+            URL 捏造禁止 (必須):
+            - 出力する markdown link [title](url) の url は、Stage 1 で取得した articles[].url のいずれかと完全一致 (string equality) させてください。articles[] に存在しない url を絶対に作らないでください。
+            - 注目記事ピックアップ / カテゴリ別ハイライト / 今週の主要トピック の関連記事リンクすべてでこの制約を守ってください。
+            - 不確実な場合はリンク無しのテキストにし、URL の推測 (タイトルからホスト+slug を組み立てる、ホスト名の記憶からドメインを書く等) は一切行わないでください。
+            - Stage 4 完了時点で、Stage 1 取得 articles[].url の全 URL を「許容 URL 一覧」として内部で保持し、出力 markdown 内のすべての [text](url) link が許容 URL 一覧に含まれることを確認してから書き出してください。含まれない link があれば url 部分を削除してテキストのみにしてください。
+
             加えて、Slack 投稿用のメッセージを /tmp/slack-message.md に書き出してください。
             - Slack mrkdwn 記法 (*bold*, _italic_, <URL|label>)
             - 30000 文字以内 (上限。長くても構わない)


### PR DESCRIPTION
## Summary
- daily report で出力されたレポートに架空の URL が含まれていた問題を修正
- daily report 生成手順を `tech-news-digest` skill 側に集約 (workflow yaml は parameter のみを渡す薄いラッパに)
- 記事 0 件のときも fabricated content を生成せず最小レポート (`本日は対象カテゴリの新規収集記事はありませんでした。`) を出力する仕様を skill に明記
- weekly / monthly skill にも URL grounding ルール (`収集済み記事に存在しない URL を生成してはならない`) を追記

## Background
2026/04/30 07:59 の daily report に掲載された link がすべて存在しない URL になっていた。原因は LLM が markdown link の URL を hallucinate していたこと。weekly / monthly では `[xxx](https://...)` 形式で D1 から取得した記事 URL を直接埋め込んでおり問題は出ていないが、daily report のプロンプトが「URL を出力する」明示制約を欠いていた。

## Changes
- `.claude/skills/tech-news-digest/SKILL.md`
  - 「自動 daily report 生成モード」セクションを追加 (workflow からの呼び出し起点)
  - 出力 3 ファイル (`/tmp/report.md`, `/tmp/report-meta.json`, `/tmp/slack-message.md`) の仕様を明記
  - 記事 0 件時のミニマルテンプレートを記載
  - URL grounding ルールを明文化 (`recent.mjs --since=today` で取得した URL のみを使うこと)
  - `recent.mjs` のカンマ区切り `--category` 仕様の記述を訂正
- `.claude/skills/tech-news-weekly/SKILL.md`: URL grounding ルールを追記
- `.github/workflows/report-daily.yml`: prompt を 61 行から 25 行に slim 化、skill 側へ delegation
- `.github/workflows/report-{weekly,monthly}.yml`: URL grounding 関連の最小指示を追加

## Test plan
- [x] `vp lint` / `vp fmt --check` 通過
- [ ] 次回 scheduled run (`report-daily`) で `/tmp/report.md` 内 URL が collected articles の URL と一致することを確認
- [ ] 0 件日があればミニマルテンプレートで Slack 投稿されることを確認

Closes #365