### PR TITLE
feat(skills): add tech-news-reports skill + reports.mjs CLI for D1 reports operations (#366)

### DIFF
--- a/.claude/skills/tech-news-reports/SKILL.md
+++ b/.claude/skills/tech-news-reports/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: tech-news-reports
+description: D1 に保存済みの自動生成レポート (daily / weekly / monthly) を一覧・詳細閲覧・削除・期間重複検出する skill。「保存済みのレポートを見たい」「重複してるレポートを整理したい」「不要な report を削除したい」のような問い合わせで起動する。
+---
+
+# tech-news-reports skill
+
+D1 の `reports` テーブルに蓄積された自動生成レポートを操作する。
+
+## 対応操作
+
+| 操作     | サブコマンド    | 説明                                        |
+| -------- | --------------- | ------------------------------------------- |
+| 一覧     | `list`          | kind / 期間でフィルタしてレポート一覧を取得 |
+| 詳細閲覧 | `show`          | 指定 id のレポートを本文ごと取得            |
+| 重複検出 | `find-overlaps` | 期間が重複するレポートペアを検出            |
+| 削除     | `delete`        | 指定 id のレポートを削除 (dry-run default)  |
+
+マージは別 skill (将来追加予定) が担当する。本 skill では find-overlaps の結果から「マージ候補」として提示するだけで、マージ自体は実施しない。
+
+## 手順
+
+### Step 1 — ユーザー意図の分類
+
+ユーザーの要望を以下のどれかに分類する:
+
+- **一覧 (list)**: 「レポートを一覧したい」「今週分の weekly レポートは？」
+- **詳細閲覧 (show)**: 「report id=5 の内容を見たい」「レポート 3 番を表示して」
+- **重複検出 (find-overlaps)**: 「重複してるレポートがないか確認して」「weekly のレポートが被ってないか調べて」
+- **削除 (delete)**: 「古いレポートを消したい」「id=7 のレポートを削除して」
+
+### Step 2 — target の確認
+
+`--target=remote` (本番 D1) か `--target=local` (ローカル開発 DB) を確認する。
+
+- 確認済みでない場合は必ず聞く
+- 本番 (remote) の操作は特に注意喚起する
+
+### Step 3 — CLI 実行
+
+```sh
+# 一覧
+node tools/d1-client/reports.mjs list [--kind=daily|weekly|monthly] [--from=<ISO>] [--to=<ISO>] [--limit=N] --target=<local|remote>
+
+# 詳細
+node tools/d1-client/reports.mjs show <id> --target=<local|remote>
+
+# 重複検出
+node tools/d1-client/reports.mjs find-overlaps [--kind=daily|weekly|monthly] --target=<local|remote>
+
+# 削除 (dry-run)
+node tools/d1-client/reports.mjs delete <id|id1,id2,...> --target=<local|remote>
+
+# 削除 (実行) — ユーザー明示確認後のみ
+node tools/d1-client/reports.mjs delete <id|id1,id2,...> --target=<local|remote> --apply
+```
+
+### Step 4 — 結果の整形
+
+- `list` の結果は markdown 表で表示する
+- `show` の結果は `content` フィールドをそのまま表示する (markdown として描画)
+- `find-overlaps` の結果は重複ペアを表形式で表示し、マージ候補として提示する
+- `delete` の dry-run 結果は「以下のレポートを削除します (確認してください)」と前置きして対象を表示する
+
+### Step 5 — 削除の確認フロー (delete のみ)
+
+1. まず `--apply` なしで dry-run を実行し、対象レポートをユーザーに目視確認させる
+2. ユーザーが「削除してください」と明示確認してから `--apply` を付けて実行する
+3. 確認なしに `--apply` を付けない
+
+## ガードレール
+
+- **削除は dry-run default**: ユーザーが明示確認したときのみ `--apply` を付ける
+- **本番削除の警告**: `--target=remote` で delete を行う場合、「本番の reports を削除するとレポート viewer からも消えます。本当に削除してよいですか？」と強く確認する
+- **認証エラー**: 401/403 が出た場合は以下を案内する:
+  ```sh
+  pnpm --filter @tnb/web exec wrangler login
+  ```
+
+## 出力フォーマット例
+
+### list
+
+```json
+{
+  "target": "remote",
+  "filters": { "kind": "weekly", "from": null, "to": null },
+  "total": 3,
+  "reports": [
+    {
+      "id": 5,
+      "kind": "weekly",
+      "period_start": "2026-04-21T00:00:00Z",
+      "period_end": "2026-04-28T00:00:00Z",
+      "category": null,
+      "lang": "ja",
+      "source_skill": "tech-news-weekly",
+      "generated_at": "2026-04-28T06:00:00Z",
+      "content_len": 4200
+    }
+  ]
+}
+```
+
+### find-overlaps
+
+```json
+{
+  "target": "local",
+  "total_pairs": 1,
+  "overlaps": [
+    {
+      "a": { "id": 3, "kind": "weekly", "period_start": "2026-04-14T00:00:00Z", "period_end": "2026-04-21T00:00:00Z", ... },
+      "b": { "id": 4, "kind": "weekly", "period_start": "2026-04-17T00:00:00Z", "period_end": "2026-04-24T00:00:00Z", ... }
+    }
+  ]
+}
+```
+
+## 関連ファイル
+
+- 実装: `tools/d1-client/reports.mjs`
+- スキーマ: `migrations/0010_reports.sql`
+- 関連 skill: `.claude/skills/tech-news-digest/SKILL.md`, `.claude/skills/tech-news-weekly/SKILL.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ Cloudflare Workers (無料枠) 上で 3 時間ごとに tech blog の RSS / Atom
 | `tech-news-search`  | 特定キーワードで FTS5 全文検索し深掘り解説                          |
 | `tech-news-related` | ピボット記事 1 本を起点に関連記事を D1 から探して関係性マップを生成 |
 | `tech-news-summary` | 単一の記事 URL を渡して本文ベースで深く日本語要約                   |
+| `tech-news-reports` | 保存済みのレポート一覧 / 詳細 / 重複検出 / 削除                     |
 
 ### 開発支援 skill
 

--- a/tools/d1-client/README.md
+++ b/tools/d1-client/README.md
@@ -49,6 +49,171 @@ node tools/d1-client/recent.mjs --since=today --category=bigtech,ai,jp --target=
 }
 ```
 
+## reports.mjs — レポートの一覧・詳細・削除・重複検出
+
+D1 の `reports` テーブルに保存された自動生成レポートを操作する。`tech-news-reports` skill が使用する。
+
+```sh
+node tools/d1-client/reports.mjs <list|show|delete|find-overlaps> [options]
+```
+
+### list — レポート一覧
+
+```sh
+node tools/d1-client/reports.mjs list [options]
+```
+
+| オプション | デフォルト | 説明                                                 |
+| ---------- | ---------- | ---------------------------------------------------- |
+| `--kind`   | なし       | `daily` / `weekly` / `monthly` で絞り込み            |
+| `--from`   | なし       | ISO 8601 datetime。`generated_at >= from` でフィルタ |
+| `--to`     | なし       | ISO 8601 datetime。`generated_at <= to` でフィルタ   |
+| `--limit`  | `50`       | 最大取得件数 (上限 1000)                             |
+| `--target` | `local`    | `local` または `remote`                              |
+
+例:
+
+```sh
+node tools/d1-client/reports.mjs list --target=remote
+node tools/d1-client/reports.mjs list --kind=weekly --target=remote
+node tools/d1-client/reports.mjs list --kind=daily --from=2026-04-01T00:00:00Z --to=2026-04-30T23:59:59Z --target=remote
+```
+
+出力 JSON:
+
+```json
+{
+  "target": "remote",
+  "filters": { "kind": "weekly", "from": null, "to": null },
+  "total": 3,
+  "reports": [
+    {
+      "id": 5,
+      "kind": "weekly",
+      "period_start": "2026-04-21T00:00:00Z",
+      "period_end": "2026-04-28T00:00:00Z",
+      "category": null,
+      "lang": "ja",
+      "source_skill": "tech-news-weekly",
+      "generated_at": "2026-04-28T06:00:00Z",
+      "content_len": 4200
+    }
+  ]
+}
+```
+
+### show — レポート詳細
+
+```sh
+node tools/d1-client/reports.mjs show <id> [--target=local|remote]
+```
+
+例:
+
+```sh
+node tools/d1-client/reports.mjs show 5 --target=remote
+```
+
+出力 JSON:
+
+```json
+{
+  "target": "remote",
+  "report": {
+    "id": 5,
+    "kind": "weekly",
+    "period_start": "2026-04-21T00:00:00Z",
+    "period_end": "2026-04-28T00:00:00Z",
+    "category": null,
+    "lang": "ja",
+    "content": "...",
+    "meta_json": null,
+    "source_skill": "tech-news-weekly",
+    "generated_at": "2026-04-28T06:00:00Z"
+  }
+}
+```
+
+### delete — レポート削除
+
+デフォルトは dry-run。`--apply` を付けたときのみ実際に削除する。
+
+```sh
+node tools/d1-client/reports.mjs delete <id|id1,id2,...> [--target=local|remote] [--apply]
+```
+
+例:
+
+```sh
+# dry-run (対象確認)
+node tools/d1-client/reports.mjs delete 5 --target=remote
+# 複数 id
+node tools/d1-client/reports.mjs delete 3,4,5 --target=remote
+# 実際に削除
+node tools/d1-client/reports.mjs delete 5 --target=remote --apply
+```
+
+出力 JSON:
+
+```json
+{
+  "target": "remote",
+  "dry_run": true,
+  "requested_ids": [5],
+  "found_ids": [5],
+  "deleted_count": 0,
+  "found_reports": [...]
+}
+```
+
+### find-overlaps — 重複期間レポートの検出
+
+同じ (kind, category, lang) 内で期間が重複するレポートのペアを検出する。
+
+```sh
+node tools/d1-client/reports.mjs find-overlaps [--kind=daily|weekly|monthly] [--target=local|remote]
+```
+
+例:
+
+```sh
+node tools/d1-client/reports.mjs find-overlaps --target=remote
+node tools/d1-client/reports.mjs find-overlaps --kind=weekly --target=remote
+```
+
+出力 JSON:
+
+```json
+{
+  "target": "remote",
+  "total_pairs": 1,
+  "overlaps": [
+    {
+      "a": {
+        "id": 3,
+        "kind": "weekly",
+        "period_start": "2026-04-14T00:00:00Z",
+        "period_end": "2026-04-21T00:00:00Z",
+        "category": null,
+        "lang": "ja",
+        "source_skill": "tech-news-weekly",
+        "generated_at": "2026-04-21T06:00:00Z"
+      },
+      "b": {
+        "id": 4,
+        "kind": "weekly",
+        "period_start": "2026-04-17T00:00:00Z",
+        "period_end": "2026-04-24T00:00:00Z",
+        "category": null,
+        "lang": "ja",
+        "source_skill": "tech-news-weekly",
+        "generated_at": "2026-04-24T06:00:00Z"
+      }
+    }
+  ]
+}
+```
+
 ## search.mjs — キーワード全文検索で記事を取得
 
 FTS5 (trigram tokenizer, `migrations/0003_fts5_trigram.sql` で設定) を使ってキーワード検索した記事を返す。`tech-news-search` skill が使用する。

--- a/tools/d1-client/reports.mjs
+++ b/tools/d1-client/reports.mjs
@@ -21,7 +21,15 @@ const WRANGLER_DIR = path.join(REPO_ROOT, "apps", "web");
 const DB_NAME = "tech-news-bot-db";
 
 const VALID_KINDS = ["daily", "weekly", "monthly"];
+const VALID_TARGETS = ["local", "remote"];
 const ISO_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})$/;
+const POS_INT_RE = /^\d+$/;
+
+// SQL リテラルへ文字列を埋め込む際の escape。validate* と二重防御。
+// 値は事前に allowlist / regex で検証済みなので通常はシングルクォート escape で十分。
+function sqlQuote(s) {
+  return `'${s.replace(/'/g, "''")}'`;
+}
 
 function parseArgs(argv) {
   const positional = [];
@@ -89,6 +97,15 @@ function validateKind(kind) {
   }
 }
 
+function validateTarget(target) {
+  if (!VALID_TARGETS.includes(target)) {
+    process.stderr.write(
+      `Invalid --target value: ${target}. Allowed: ${VALID_TARGETS.join(", ")}\n`,
+    );
+    process.exit(2);
+  }
+}
+
 function validateIso(value, name) {
   if (value !== null && !ISO_RE.test(value)) {
     process.stderr.write(
@@ -99,11 +116,16 @@ function validateIso(value, name) {
 }
 
 function validateIds(rawIds) {
-  const ids = rawIds
+  const tokens = rawIds
     .split(",")
     .map((s) => s.trim())
-    .filter(Boolean)
-    .map((s) => Number.parseInt(s, 10));
+    .filter(Boolean);
+  // `parseInt("3abc", 10)` は 3 を返してしまうので、先に厳密な数字フォーマットを要求する。
+  if (tokens.some((t) => !POS_INT_RE.test(t))) {
+    process.stderr.write(`Invalid id(s): ${rawIds}. Must be positive integer(s).\n`);
+    process.exit(2);
+  }
+  const ids = tokens.map((t) => Number.parseInt(t, 10));
   if (ids.some((id) => !Number.isFinite(id) || id <= 0)) {
     process.stderr.write(`Invalid id(s): ${rawIds}. Must be positive integer(s).\n`);
     process.exit(2);
@@ -113,14 +135,16 @@ function validateIds(rawIds) {
 
 function cmdList(opts) {
   validateKind(opts.kind);
+  validateTarget(opts.target);
   validateIso(opts.from, "--from");
   validateIso(opts.to, "--to");
 
   const limit = Math.max(1, Math.min(opts.limit, 1000));
   const where = ["1=1"];
-  if (opts.kind) where.push(`kind = '${opts.kind}'`);
-  if (opts.from) where.push(`generated_at >= '${opts.from}'`);
-  if (opts.to) where.push(`generated_at <= '${opts.to}'`);
+  // sqlQuote で escape する (validate を通っていても二重防御)。
+  if (opts.kind) where.push(`kind = ${sqlQuote(opts.kind)}`);
+  if (opts.from) where.push(`generated_at >= ${sqlQuote(opts.from)}`);
+  if (opts.to) where.push(`generated_at <= ${sqlQuote(opts.to)}`);
 
   const sql = `SELECT id, kind, period_start, period_end, category, lang, source_skill, generated_at, length(content) AS content_len FROM reports WHERE ${where.join(" AND ")} ORDER BY generated_at DESC LIMIT ${limit};`;
 
@@ -146,6 +170,7 @@ function cmdList(opts) {
 }
 
 function cmdShow(id, opts) {
+  validateTarget(opts.target);
   const sql = `SELECT id, kind, period_start, period_end, category, lang, content, meta_json, source_skill, generated_at FROM reports WHERE id = ${id};`;
 
   let rows;
@@ -169,6 +194,7 @@ function cmdShow(id, opts) {
 }
 
 function cmdDelete(ids, opts) {
+  validateTarget(opts.target);
   const idList = ids.join(", ");
 
   // dry-run: SELECT して対象行を確認
@@ -231,8 +257,9 @@ function cmdDelete(ids, opts) {
 
 function cmdFindOverlaps(opts) {
   validateKind(opts.kind);
+  validateTarget(opts.target);
 
-  const kindClause = opts.kind ? `AND a.kind = '${opts.kind}'` : "";
+  const kindClause = opts.kind ? `AND a.kind = ${sqlQuote(opts.kind)}` : "";
 
   const sql = `
 SELECT

--- a/tools/d1-client/reports.mjs
+++ b/tools/d1-client/reports.mjs
@@ -1,0 +1,356 @@
+#!/usr/bin/env node
+// D1 の reports テーブルを操作する CLI。
+// .claude/skills/tech-news-reports が呼ぶクライアント。
+//
+// Usage:
+//   node tools/d1-client/reports.mjs list [--kind=daily|weekly|monthly] [--from=<ISO>] [--to=<ISO>] [--limit=N] [--target=local|remote]
+//   node tools/d1-client/reports.mjs show <id> [--target=local|remote]
+//   node tools/d1-client/reports.mjs delete <id|id1,id2,...> [--target=local|remote] [--apply]
+//   node tools/d1-client/reports.mjs find-overlaps [--kind=daily|weekly|monthly] [--target=local|remote]
+//
+// Output (stdout): JSON object
+// Errors: human-readable text -> stderr, exit code 1
+
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = path.resolve(path.dirname(__filename), "..", "..");
+const WRANGLER_DIR = path.join(REPO_ROOT, "apps", "web");
+const DB_NAME = "tech-news-bot-db";
+
+const VALID_KINDS = ["daily", "weekly", "monthly"];
+const ISO_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})$/;
+
+function parseArgs(argv) {
+  const positional = [];
+  const opts = {
+    kind: null,
+    from: null,
+    to: null,
+    limit: 50,
+    target: "local",
+    apply: false,
+  };
+  for (const arg of argv.slice(2)) {
+    if (arg === "--apply") {
+      opts.apply = true;
+      continue;
+    }
+    const m = arg.match(/^--([\w-]+)=(.+)$/);
+    if (m) {
+      const [, k, v] = m;
+      if (k === "kind") opts.kind = v;
+      else if (k === "from") opts.from = v;
+      else if (k === "to") opts.to = v;
+      else if (k === "limit") opts.limit = Number.parseInt(v, 10) || 50;
+      else if (k === "target") opts.target = v;
+    } else {
+      positional.push(arg);
+    }
+  }
+  return { positional, opts };
+}
+
+function execWrangler(sql, target) {
+  const args = [
+    "exec",
+    "wrangler",
+    "d1",
+    "execute",
+    DB_NAME,
+    target === "remote" ? "--remote" : "--local",
+    "--json",
+    "--command",
+    sql,
+  ];
+  const result = spawnSync("pnpm", args, { cwd: WRANGLER_DIR, encoding: "utf8" });
+  if (result.status !== 0) {
+    const msg = (result.stderr || result.stdout || "").trim();
+    throw new Error(`wrangler d1 execute failed (exit ${result.status}):\n${msg}`);
+  }
+  const stdout = result.stdout.trim();
+  // wrangler は前後にバナーを出すことがあるので JSON 部分のみ抜き出す
+  const start = stdout.indexOf("[");
+  const end = stdout.lastIndexOf("]");
+  if (start < 0 || end < 0 || end <= start) {
+    throw new Error(`wrangler stdout did not contain JSON array:\n${stdout}`);
+  }
+  const parsed = JSON.parse(stdout.slice(start, end + 1));
+  // wrangler --json: [{ results: [...], success: true, meta: {...} }]
+  return parsed[0]?.results ?? [];
+}
+
+function validateKind(kind) {
+  if (kind !== null && !VALID_KINDS.includes(kind)) {
+    process.stderr.write(`Invalid --kind value: ${kind}. Allowed: ${VALID_KINDS.join(", ")}\n`);
+    process.exit(2);
+  }
+}
+
+function validateIso(value, name) {
+  if (value !== null && !ISO_RE.test(value)) {
+    process.stderr.write(
+      `Invalid ${name} value: ${value}. Must match ISO 8601 datetime (e.g. 2026-01-01T00:00:00Z)\n`,
+    );
+    process.exit(2);
+  }
+}
+
+function validateIds(rawIds) {
+  const ids = rawIds
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((s) => Number.parseInt(s, 10));
+  if (ids.some((id) => !Number.isFinite(id) || id <= 0)) {
+    process.stderr.write(`Invalid id(s): ${rawIds}. Must be positive integer(s).\n`);
+    process.exit(2);
+  }
+  return ids;
+}
+
+function cmdList(opts) {
+  validateKind(opts.kind);
+  validateIso(opts.from, "--from");
+  validateIso(opts.to, "--to");
+
+  const limit = Math.max(1, Math.min(opts.limit, 1000));
+  const where = ["1=1"];
+  if (opts.kind) where.push(`kind = '${opts.kind}'`);
+  if (opts.from) where.push(`generated_at >= '${opts.from}'`);
+  if (opts.to) where.push(`generated_at <= '${opts.to}'`);
+
+  const sql = `SELECT id, kind, period_start, period_end, category, lang, source_skill, generated_at, length(content) AS content_len FROM reports WHERE ${where.join(" AND ")} ORDER BY generated_at DESC LIMIT ${limit};`;
+
+  let reports;
+  try {
+    reports = execWrangler(sql, opts.target);
+  } catch (err) {
+    process.stderr.write(`${err.message}\n`);
+    process.exit(1);
+  }
+
+  const result = {
+    target: opts.target,
+    filters: {
+      kind: opts.kind ?? null,
+      from: opts.from ?? null,
+      to: opts.to ?? null,
+    },
+    total: reports.length,
+    reports,
+  };
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+function cmdShow(id, opts) {
+  const sql = `SELECT id, kind, period_start, period_end, category, lang, content, meta_json, source_skill, generated_at FROM reports WHERE id = ${id};`;
+
+  let rows;
+  try {
+    rows = execWrangler(sql, opts.target);
+  } catch (err) {
+    process.stderr.write(`${err.message}\n`);
+    process.exit(1);
+  }
+
+  if (rows.length === 0) {
+    process.stderr.write(`Report id=${id} not found.\n`);
+    process.exit(1);
+  }
+
+  const result = {
+    target: opts.target,
+    report: rows[0],
+  };
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+function cmdDelete(ids, opts) {
+  const idList = ids.join(", ");
+
+  // dry-run: SELECT して対象行を確認
+  const selectSql = `SELECT id, kind, period_start, period_end, category, lang, source_skill, generated_at FROM reports WHERE id IN (${idList});`;
+
+  let found;
+  try {
+    found = execWrangler(selectSql, opts.target);
+  } catch (err) {
+    process.stderr.write(`${err.message}\n`);
+    process.exit(1);
+  }
+
+  const foundIds = found.map((r) => r.id);
+
+  if (!opts.apply) {
+    // dry-run
+    const result = {
+      target: opts.target,
+      dry_run: true,
+      requested_ids: ids,
+      found_ids: foundIds,
+      deleted_count: 0,
+      found_reports: found,
+    };
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return;
+  }
+
+  // --apply: 実際に DELETE
+  if (foundIds.length === 0) {
+    const result = {
+      target: opts.target,
+      dry_run: false,
+      requested_ids: ids,
+      found_ids: [],
+      deleted_count: 0,
+    };
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return;
+  }
+
+  const deleteSql = `DELETE FROM reports WHERE id IN (${foundIds.join(", ")});`;
+  try {
+    execWrangler(deleteSql, opts.target);
+  } catch (err) {
+    process.stderr.write(`${err.message}\n`);
+    process.exit(1);
+  }
+
+  const result = {
+    target: opts.target,
+    dry_run: false,
+    requested_ids: ids,
+    found_ids: foundIds,
+    deleted_count: foundIds.length,
+  };
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+function cmdFindOverlaps(opts) {
+  validateKind(opts.kind);
+
+  const kindClause = opts.kind ? `AND a.kind = '${opts.kind}'` : "";
+
+  const sql = `
+SELECT
+  a.id        AS a_id,
+  a.kind      AS a_kind,
+  a.period_start AS a_period_start,
+  a.period_end   AS a_period_end,
+  a.category  AS a_category,
+  a.lang      AS a_lang,
+  a.source_skill AS a_source_skill,
+  a.generated_at AS a_generated_at,
+  b.id        AS b_id,
+  b.kind      AS b_kind,
+  b.period_start AS b_period_start,
+  b.period_end   AS b_period_end,
+  b.category  AS b_category,
+  b.lang      AS b_lang,
+  b.source_skill AS b_source_skill,
+  b.generated_at AS b_generated_at
+FROM reports a
+JOIN reports b
+  ON a.kind = b.kind
+  AND COALESCE(a.category, '__all__') = COALESCE(b.category, '__all__')
+  AND COALESCE(a.lang, '__all__') = COALESCE(b.lang, '__all__')
+  AND a.period_start < b.period_end
+  AND a.period_end > b.period_start
+  AND a.id < b.id
+${kindClause}
+ORDER BY a.kind, a.period_start, a.id, b.id;
+  `.trim();
+
+  let rows;
+  try {
+    rows = execWrangler(sql, opts.target);
+  } catch (err) {
+    process.stderr.write(`${err.message}\n`);
+    process.exit(1);
+  }
+
+  const overlaps = rows.map((row) => ({
+    a: {
+      id: row.a_id,
+      kind: row.a_kind,
+      period_start: row.a_period_start,
+      period_end: row.a_period_end,
+      category: row.a_category,
+      lang: row.a_lang,
+      source_skill: row.a_source_skill,
+      generated_at: row.a_generated_at,
+    },
+    b: {
+      id: row.b_id,
+      kind: row.b_kind,
+      period_start: row.b_period_start,
+      period_end: row.b_period_end,
+      category: row.b_category,
+      lang: row.b_lang,
+      source_skill: row.b_source_skill,
+      generated_at: row.b_generated_at,
+    },
+  }));
+
+  const result = {
+    target: opts.target,
+    total_pairs: overlaps.length,
+    overlaps,
+  };
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+function main() {
+  const { positional, opts } = parseArgs(process.argv);
+  const subcommand = positional[0];
+
+  if (!subcommand) {
+    process.stderr.write("Usage: reports.mjs <list|show|delete|find-overlaps> [options]\n");
+    process.exit(2);
+  }
+
+  switch (subcommand) {
+    case "list":
+      cmdList(opts);
+      break;
+    case "show": {
+      const rawId = positional[1];
+      if (!rawId) {
+        process.stderr.write("Usage: reports.mjs show <id> [--target=local|remote]\n");
+        process.exit(2);
+      }
+      const ids = validateIds(rawId);
+      if (ids.length !== 1) {
+        process.stderr.write("show requires exactly one id.\n");
+        process.exit(2);
+      }
+      cmdShow(ids[0], opts);
+      break;
+    }
+    case "delete": {
+      const rawIds = positional[1];
+      if (!rawIds) {
+        process.stderr.write(
+          "Usage: reports.mjs delete <id|id1,id2,...> [--target=local|remote] [--apply]\n",
+        );
+        process.exit(2);
+      }
+      const ids = validateIds(rawIds);
+      cmdDelete(ids, opts);
+      break;
+    }
+    case "find-overlaps":
+      cmdFindOverlaps(opts);
+      break;
+    default:
+      process.stderr.write(
+        `Unknown subcommand: ${subcommand}. Use list|show|delete|find-overlaps\n`,
+      );
+      process.exit(2);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- D1 の `reports` テーブルを操作する CLI `tools/d1-client/reports.mjs` を追加 (list / show / delete / find-overlaps)
- 上記 CLI を呼び出すための `tech-news-reports` skill を追加
- `dry-run by default` (delete は `--apply` を付けない限り対象を表示するのみ)、`local|remote` 切替、id allowlist + sqlQuote の二重防御で安全性を担保

## Background
2026/04/30 daily report の差し替え対応で、production D1 のレポート行を確認 / 削除する手順が標準化されていないことが露呈した。今後 LLM が架空 URL や誤情報を含むレポートを生成した場合に即時対応できるよう、CLI + skill 化する。

## Changes
- `tools/d1-client/reports.mjs` (新規, 383 行)
  - subcommand: `list` / `show` / `delete` / `find-overlaps`
  - `--target=local|remote` (default `local`), `--apply` (delete のみ実 SQL 発行)
  - 入力検証: `VALID_KINDS`, `VALID_TARGETS`, `POS_INT_RE` (positive int only), ISO 8601 regex, `sqlQuote()` (二重防御)
  - `find-overlaps`: 同 kind / 同 COALESCE(category,'__all__') / 同 COALESCE(lang,'__all__') 内で半開区間 overlap を検出
  - wrangler の前後バナーを除いた JSON 部分のみ抽出してパース
- `.claude/skills/tech-news-reports/SKILL.md` (新規)
  - 起動形式・dry-run 規約・delete 時の事前確認チェックリスト
- `tools/d1-client/README.md` (新規, reports.mjs 用ドキュメント)
- `CLAUDE.md` に skill の存在を 1 行追記

## Test plan
- [x] `node tools/d1-client/reports.mjs list --target=local` が空配列でも JSON を返す
- [x] `delete <id>` (no `--apply`) が dry_run JSON を返す
- [x] `delete <id> --apply` が実際に DELETE を発行する
- [x] `find-overlaps` が SELECT のみ発行 (副作用なし)
- [x] 不正入力 (`--kind=foo`, `id=abc`, `--target=prod`) で exit 2 + stderr メッセージ

Closes #366