### PR TITLE
feat(reports): add half-open period overlap validation and merge script (#367)

### DIFF
--- a/apps/web/tests/worker/api/reports.test.ts
+++ b/apps/web/tests/worker/api/reports.test.ts
@@ -3,6 +3,7 @@ import { SELF } from "cloudflare:test";
 import type {
   AdminReportDetailResponse,
   AdminReportListResponse,
+  AdminReportOverlapResponse,
   AdminReportSaveResponse,
 } from "../../../worker/api/types";
 
@@ -68,7 +69,13 @@ describe("POST /api/admin/reports", () => {
     const res = await SELF.fetch("https://example.com/api/admin/reports", {
       method: "POST",
       headers: { ...NEXT_AUTH, "content-type": "application/json" },
-      body: JSON.stringify(buildPayload({ period_start: "2026-04-27T00:00:00.000Z" })),
+      body: JSON.stringify(
+        buildPayload({
+          period_start: "2026-04-30T00:00:00.000Z",
+          period_end: "2026-05-01T00:00:00.000Z",
+          generated_at: "2026-05-01T00:00:00.000Z",
+        }),
+      ),
     });
     expect(res.status).toBe(200);
   });
@@ -211,6 +218,310 @@ describe("POST /api/admin/reports", () => {
     const body = (await res.json()) as { error: string };
     expect(body.error).toBe("period_end must be after period_start");
   });
+
+  // ---- overlap validation ----
+  // 各テストは互いに干渉しないよう、独自の月/期間を使う (DB はテスト間でリセットされない)。
+
+  it("200: exact same period → upsert update (no overlap)", async () => {
+    // 1回目登録 (2025-01 の週)
+    await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(
+        buildPayload({
+          kind: "weekly",
+          period_start: "2025-01-06T00:00:00.000Z",
+          period_end: "2025-01-13T00:00:00.000Z",
+          content: "first",
+          generated_at: "2025-01-13T00:00:00.000Z",
+        }),
+      ),
+    });
+    // 同一 period で上書き → 200
+    const res = await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(
+        buildPayload({
+          kind: "weekly",
+          period_start: "2025-01-06T00:00:00.000Z",
+          period_end: "2025-01-13T00:00:00.000Z",
+          content: "updated",
+          generated_at: "2025-01-13T00:01:00.000Z",
+        }),
+      ),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as AdminReportSaveResponse;
+    expect(body.ok).toBe(true);
+  });
+
+  it("409: partial overlap (start shifted by 1 day)", async () => {
+    // 既存: 2025-02-03 〜 2025-02-10
+    await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(
+        buildPayload({
+          kind: "weekly",
+          period_start: "2025-02-03T00:00:00.000Z",
+          period_end: "2025-02-10T00:00:00.000Z",
+          content: "existing-shift-start",
+          generated_at: "2025-02-10T00:00:00.000Z",
+        }),
+      ),
+    });
+    // 新規: 2025-02-04 〜 2025-02-11 (start 違い, overlap あり)
+    const res = await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(
+        buildPayload({
+          kind: "weekly",
+          period_start: "2025-02-04T00:00:00.000Z",
+          period_end: "2025-02-11T00:00:00.000Z",
+          content: "overlapping start",
+          generated_at: "2025-02-11T00:00:00.000Z",
+        }),
+      ),
+    });
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as AdminReportOverlapResponse;
+    expect.soft(body.error).toMatch(/overlap/i);
+    expect.soft(Array.isArray(body.conflicting_ids)).toBe(true);
+    expect.soft(body.conflicting_ids.length).toBeGreaterThan(0);
+  });
+
+  it("409: partial overlap (end shifted by 1 day)", async () => {
+    // 既存: 2025-03-03 〜 2025-03-10
+    await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(
+        buildPayload({
+          kind: "weekly",
+          period_start: "2025-03-03T00:00:00.000Z",
+          period_end: "2025-03-10T00:00:00.000Z",
+          content: "existing-shift-end",
+          generated_at: "2025-03-10T00:00:00.000Z",
+        }),
+      ),
+    });
+    // 新規: 2025-03-02 〜 2025-03-09 (end 違い, overlap あり)
+    const res = await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(
+        buildPayload({
+          kind: "weekly",
+          period_start: "2025-03-02T00:00:00.000Z",
+          period_end: "2025-03-09T00:00:00.000Z",
+          content: "overlapping end",
+          generated_at: "2025-03-11T00:00:00.000Z",
+        }),
+      ),
+    });
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as AdminReportOverlapResponse;
+    expect.soft(body.error).toMatch(/overlap/i);
+    expect.soft(body.conflicting_ids.length).toBeGreaterThan(0);
+  });
+
+  it("409: new period fully contains existing", async () => {
+    // 既存: 2025-04-07 〜 2025-04-12
+    await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(
+        buildPayload({
+          kind: "weekly",
+          period_start: "2025-04-07T00:00:00.000Z",
+          period_end: "2025-04-12T00:00:00.000Z",
+          content: "inner-existing",
+          generated_at: "2025-04-12T00:00:00.000Z",
+        }),
+      ),
+    });
+    // 新規: 2025-04-06 〜 2025-04-13 (既存を完全内包)
+    const res = await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(
+        buildPayload({
+          kind: "weekly",
+          period_start: "2025-04-06T00:00:00.000Z",
+          period_end: "2025-04-13T00:00:00.000Z",
+          content: "outer-new",
+          generated_at: "2025-04-13T00:00:00.000Z",
+        }),
+      ),
+    });
+    expect(res.status).toBe(409);
+  });
+
+  it("409: existing period fully contains new", async () => {
+    // 既存: 2025-05-05 〜 2025-05-12
+    await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(
+        buildPayload({
+          kind: "weekly",
+          period_start: "2025-05-05T00:00:00.000Z",
+          period_end: "2025-05-12T00:00:00.000Z",
+          content: "outer-existing",
+          generated_at: "2025-05-12T00:00:00.000Z",
+        }),
+      ),
+    });
+    // 新規: 2025-05-06 〜 2025-05-11 (既存に内包される)
+    const res = await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(
+        buildPayload({
+          kind: "weekly",
+          period_start: "2025-05-06T00:00:00.000Z",
+          period_end: "2025-05-11T00:00:00.000Z",
+          content: "inner-new",
+          generated_at: "2025-05-13T00:00:00.000Z",
+        }),
+      ),
+    });
+    expect(res.status).toBe(409);
+  });
+
+  it("200: adjacent periods (new start == existing end) → no overlap (half-open)", async () => {
+    // 既存: 2025-06-02 〜 2025-06-09
+    await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(
+        buildPayload({
+          kind: "weekly",
+          period_start: "2025-06-02T00:00:00.000Z",
+          period_end: "2025-06-09T00:00:00.000Z",
+          content: "adjacent prev",
+          generated_at: "2025-06-09T00:00:00.000Z",
+        }),
+      ),
+    });
+    // 新規: 2025-06-09 〜 2025-06-16 (start == 既存 end → 半開区間で重ならない)
+    const res = await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(
+        buildPayload({
+          kind: "weekly",
+          period_start: "2025-06-09T00:00:00.000Z",
+          period_end: "2025-06-16T00:00:00.000Z",
+          content: "adjacent next",
+          generated_at: "2025-06-16T00:00:00.000Z",
+        }),
+      ),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("200: different kind → no overlap check", async () => {
+    // 既存: kind=weekly, 2025-07-07 〜 2025-07-14
+    await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(
+        buildPayload({
+          kind: "weekly",
+          period_start: "2025-07-07T00:00:00.000Z",
+          period_end: "2025-07-14T00:00:00.000Z",
+          content: "weekly-diff-kind",
+          generated_at: "2025-07-14T00:00:00.000Z",
+        }),
+      ),
+    });
+    // 新規: kind=monthly, overlapping period → 別 kind なので通る
+    const res = await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(
+        buildPayload({
+          kind: "monthly",
+          period_start: "2025-07-08T00:00:00.000Z",
+          period_end: "2025-07-15T00:00:00.000Z",
+          content: "monthly-diff-kind",
+          generated_at: "2025-07-15T00:00:00.000Z",
+        }),
+      ),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("200: different category → no overlap check", async () => {
+    // 既存: kind=weekly, category=null, 2025-08-04 〜 2025-08-11
+    await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(
+        buildPayload({
+          kind: "weekly",
+          period_start: "2025-08-04T00:00:00.000Z",
+          period_end: "2025-08-11T00:00:00.000Z",
+          category: null,
+          content: "all-category",
+          generated_at: "2025-08-11T00:00:00.000Z",
+        }),
+      ),
+    });
+    // 新規: category=bigtech, overlapping period → 別 category なので通る
+    const res = await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(
+        buildPayload({
+          kind: "weekly",
+          period_start: "2025-08-05T00:00:00.000Z",
+          period_end: "2025-08-12T00:00:00.000Z",
+          category: "bigtech",
+          content: "bigtech-only",
+          generated_at: "2025-08-12T00:00:00.000Z",
+        }),
+      ),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("200: different lang → no overlap check", async () => {
+    // 既存: kind=weekly, lang=ja, 2025-09-01 〜 2025-09-08
+    await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(
+        buildPayload({
+          kind: "weekly",
+          period_start: "2025-09-01T00:00:00.000Z",
+          period_end: "2025-09-08T00:00:00.000Z",
+          lang: "ja",
+          content: "ja-report",
+          generated_at: "2025-09-08T00:00:00.000Z",
+        }),
+      ),
+    });
+    // 新規: lang=en, overlapping period → 別 lang なので通る
+    const res = await SELF.fetch("https://example.com/api/admin/reports", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(
+        buildPayload({
+          kind: "weekly",
+          period_start: "2025-09-02T00:00:00.000Z",
+          period_end: "2025-09-09T00:00:00.000Z",
+          lang: "en",
+          content: "en-report",
+          generated_at: "2025-09-09T00:00:00.000Z",
+        }),
+      ),
+    });
+    expect(res.status).toBe(200);
+  });
 });
 
 describe("GET /api/admin/reports", () => {
@@ -225,8 +536,9 @@ describe("GET /api/admin/reports", () => {
       headers: JSON_HEADERS,
       body: JSON.stringify(
         buildPayload({
-          period_start: "2026-04-26T00:00:00.000Z",
-          generated_at: "2026-04-27T00:00:00.000Z",
+          period_start: "2026-03-26T00:00:00.000Z",
+          period_end: "2026-03-27T00:00:00.000Z",
+          generated_at: "2026-03-27T00:00:00.000Z",
           content: "older",
         }),
       ),
@@ -236,8 +548,9 @@ describe("GET /api/admin/reports", () => {
       headers: JSON_HEADERS,
       body: JSON.stringify(
         buildPayload({
-          period_start: "2026-04-28T00:00:00.000Z",
-          generated_at: "2026-04-29T00:00:00.000Z",
+          period_start: "2026-03-28T00:00:00.000Z",
+          period_end: "2026-03-29T00:00:00.000Z",
+          generated_at: "2026-03-29T00:00:00.000Z",
           content: "newer",
         }),
       ),
@@ -256,7 +569,14 @@ describe("GET /api/admin/reports", () => {
     await SELF.fetch("https://example.com/api/admin/reports", {
       method: "POST",
       headers: JSON_HEADERS,
-      body: JSON.stringify(buildPayload({ kind: "weekly" })),
+      body: JSON.stringify(
+        buildPayload({
+          kind: "weekly",
+          period_start: "2026-10-06T00:00:00.000Z",
+          period_end: "2026-10-13T00:00:00.000Z",
+          generated_at: "2026-10-13T00:00:00.000Z",
+        }),
+      ),
     });
     const res = await SELF.fetch("https://example.com/api/admin/reports?kind=weekly", {
       headers: AUTH,

--- a/apps/web/tests/worker/db/reports.test.ts
+++ b/apps/web/tests/worker/db/reports.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vite-plus/test";
+import { env } from "cloudflare:test";
+import { OverlapError, findOverlappingReports, upsertReport } from "../../../worker/db/reports";
+import type { ReportInput } from "../../../worker/db/reports";
+
+function baseInput(overrides: Partial<ReportInput> = {}): ReportInput {
+  return {
+    kind: "weekly",
+    period_start: "2026-04-21T00:00:00.000Z",
+    period_end: "2026-04-28T00:00:00.000Z",
+    category: null,
+    lang: null,
+    content: "# Test Report",
+    meta_json: null,
+    source_skill: "test",
+    generated_at: "2026-04-28T00:01:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("findOverlappingReports", () => {
+  it("returns empty array when no rows exist", async () => {
+    const overlaps = await findOverlappingReports(env.DB, baseInput());
+    expect(overlaps).toHaveLength(0);
+  });
+
+  it("returns empty array for exact same period (handled by UNIQUE upsert)", async () => {
+    await upsertReport(env.DB, baseInput({ generated_at: "2026-04-28T00:00:00.000Z" }));
+    // 完全一致は overlap ではない
+    const overlaps = await findOverlappingReports(
+      env.DB,
+      baseInput({
+        period_start: "2026-04-21T00:00:00.000Z",
+        period_end: "2026-04-28T00:00:00.000Z",
+      }),
+    );
+    expect(overlaps).toHaveLength(0);
+  });
+
+  it("detects partial overlap (start shifted)", async () => {
+    await upsertReport(env.DB, baseInput({ generated_at: "2026-04-28T00:00:00.000Z" }));
+    // 既存: 04-21〜04-28 / 新規: 04-22〜04-29 → overlap
+    const overlaps = await findOverlappingReports(
+      env.DB,
+      baseInput({
+        period_start: "2026-04-22T00:00:00.000Z",
+        period_end: "2026-04-29T00:00:00.000Z",
+      }),
+    );
+    expect(overlaps.length).toBeGreaterThan(0);
+  });
+
+  it("returns empty array for adjacent period (new start == existing end)", async () => {
+    await upsertReport(env.DB, baseInput({ generated_at: "2026-04-28T00:00:00.000Z" }));
+    // 既存 end == 新規 start → 半開区間で overlap なし
+    const overlaps = await findOverlappingReports(
+      env.DB,
+      baseInput({
+        period_start: "2026-04-28T00:00:00.000Z",
+        period_end: "2026-05-05T00:00:00.000Z",
+      }),
+    );
+    expect(overlaps).toHaveLength(0);
+  });
+
+  it("returns empty array for different category", async () => {
+    await upsertReport(
+      env.DB,
+      baseInput({ category: null, generated_at: "2026-04-28T00:00:00.000Z" }),
+    );
+    // category=bigtech は別グループ → overlap なし
+    const overlaps = await findOverlappingReports(
+      env.DB,
+      baseInput({
+        category: "bigtech",
+        period_start: "2026-04-22T00:00:00.000Z",
+        period_end: "2026-04-29T00:00:00.000Z",
+      }),
+    );
+    expect(overlaps).toHaveLength(0);
+  });
+});
+
+describe("upsertReport overlap guard", () => {
+  it("throws OverlapError when overlapping row exists", async () => {
+    await upsertReport(env.DB, baseInput({ generated_at: "2026-04-28T00:00:00.000Z" }));
+    await expect(
+      upsertReport(
+        env.DB,
+        baseInput({
+          period_start: "2026-04-22T00:00:00.000Z",
+          period_end: "2026-04-29T00:00:00.000Z",
+          generated_at: "2026-04-29T00:00:00.000Z",
+        }),
+      ),
+    ).rejects.toBeInstanceOf(OverlapError);
+  });
+
+  it("OverlapError contains conflicting ids", async () => {
+    const { id } = await upsertReport(
+      env.DB,
+      baseInput({ generated_at: "2026-04-28T00:00:00.000Z" }),
+    );
+    let caught: OverlapError | null = null;
+    try {
+      await upsertReport(
+        env.DB,
+        baseInput({
+          period_start: "2026-04-22T00:00:00.000Z",
+          period_end: "2026-04-29T00:00:00.000Z",
+          generated_at: "2026-04-29T00:00:00.000Z",
+        }),
+      );
+    } catch (err) {
+      if (err instanceof OverlapError) caught = err;
+    }
+    expect(caught).not.toBeNull();
+    expect(caught!.conflictingIds).toContain(id);
+  });
+});

--- a/apps/web/tests/worker/db/reports.test.ts
+++ b/apps/web/tests/worker/db/reports.test.ts
@@ -38,7 +38,10 @@ describe("findOverlappingReports", () => {
   });
 
   it("detects partial overlap (start shifted)", async () => {
-    await upsertReport(env.DB, baseInput({ generated_at: "2026-04-28T00:00:00.000Z" }));
+    const { id } = await upsertReport(
+      env.DB,
+      baseInput({ generated_at: "2026-04-28T00:00:00.000Z" }),
+    );
     // 既存: 04-21〜04-28 / 新規: 04-22〜04-29 → overlap
     const overlaps = await findOverlappingReports(
       env.DB,
@@ -47,7 +50,8 @@ describe("findOverlappingReports", () => {
         period_end: "2026-04-29T00:00:00.000Z",
       }),
     );
-    expect(overlaps.length).toBeGreaterThan(0);
+    expect(overlaps).toHaveLength(1);
+    expect(overlaps[0]?.id).toBe(id);
   });
 
   it("returns empty array for adjacent period (new start == existing end)", async () => {

--- a/apps/web/worker/api/reports.ts
+++ b/apps/web/worker/api/reports.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import type { Env } from "../types";
 import { adminAuthMiddleware } from "../utils/auth";
-import { getReport, listReports, upsertReport } from "../db/reports";
+import { OverlapError, getReport, listReports, upsertReport } from "../db/reports";
 import type { ReportInput, ReportKind } from "../db/reports";
 import type {
   AdminReportDetailResponse,
@@ -141,7 +141,21 @@ app.post("/", async (c) => {
     return c.json({ error: validated.error }, 400);
   }
 
-  const { id } = await upsertReport(c.env.DB, validated.input);
+  let id: number;
+  try {
+    ({ id } = await upsertReport(c.env.DB, validated.input));
+  } catch (err) {
+    if (err instanceof OverlapError) {
+      return c.json(
+        {
+          error: "report period overlaps with existing report(s)",
+          conflicting_ids: err.conflictingIds,
+        },
+        409,
+      );
+    }
+    throw err;
+  }
 
   return c.json<AdminReportSaveResponse>({ ok: true, id });
 });

--- a/apps/web/worker/api/reports.ts
+++ b/apps/web/worker/api/reports.ts
@@ -6,6 +6,7 @@ import type { ReportInput, ReportKind } from "../db/reports";
 import type {
   AdminReportDetailResponse,
   AdminReportListResponse,
+  AdminReportOverlapResponse,
   AdminReportSaveResponse,
 } from "./types";
 
@@ -146,7 +147,7 @@ app.post("/", async (c) => {
     ({ id } = await upsertReport(c.env.DB, validated.input));
   } catch (err) {
     if (err instanceof OverlapError) {
-      return c.json(
+      return c.json<AdminReportOverlapResponse>(
         {
           error: "report period overlaps with existing report(s)",
           conflicting_ids: err.conflictingIds,

--- a/apps/web/worker/api/types.ts
+++ b/apps/web/worker/api/types.ts
@@ -196,6 +196,11 @@ export interface AdminReportSaveResponse {
   id: number;
 }
 
+export interface AdminReportOverlapResponse {
+  error: string;
+  conflicting_ids: number[];
+}
+
 export interface AdminReportListResponse {
   reports: ReportRow[];
 }

--- a/apps/web/worker/db/reports.ts
+++ b/apps/web/worker/db/reports.ts
@@ -41,6 +41,10 @@ export async function findOverlappingReports(
   db: D1Database,
   input: Pick<ReportInput, "kind" | "period_start" | "period_end" | "category" | "lang">,
 ): Promise<ReportRow[]> {
+  // bind 順: ?1=kind, ?2=category, ?3=lang, ?4=input.period_start, ?5=input.period_end
+  // half-open overlap 条件 (existing.start < input.end AND existing.end > input.start) を
+  // ?4/?5 経由で表現する。`existing.period_end > ?4` の `?4` は input.period_start を指す
+  // (column 名と placeholder 番号が一致しないため、bind 順を変更しないこと)。
   const result = await db
     .prepare(
       `SELECT id, kind, period_start, period_end, category, lang, source_skill, generated_at
@@ -48,9 +52,9 @@ export async function findOverlappingReports(
        WHERE kind = ?1
          AND COALESCE(category, '${ALL_SENTINEL}') = COALESCE(?2, '${ALL_SENTINEL}')
          AND COALESCE(lang,     '${ALL_SENTINEL}') = COALESCE(?3, '${ALL_SENTINEL}')
-         AND period_start < ?5
-         AND period_end   > ?4
-         AND NOT (period_start = ?4 AND period_end = ?5)`,
+         AND period_start < ?5  -- existing.period_start < input.period_end
+         AND period_end   > ?4  -- existing.period_end   > input.period_start
+         AND NOT (period_start = ?4 AND period_end = ?5)  -- 完全一致は ON CONFLICT で処理`,
     )
     .bind(input.kind, input.category, input.lang, input.period_start, input.period_end)
     .all<ReportRow>();

--- a/apps/web/worker/db/reports.ts
+++ b/apps/web/worker/db/reports.ts
@@ -33,10 +33,50 @@ export interface ReportDetailRow extends ReportRow {
 
 const ALL_SENTINEL = "__all__";
 
+// 半開区間 [period_start, period_end) が既存 row と overlap する row を返す。
+// 完全一致 (period_start == new.period_start AND period_end == new.period_end) は
+// 既存の UNIQUE 制約 + ON CONFLICT UPDATE で処理されるため overlap 扱いしない。
+// 同 kind / 同 COALESCE(category, '__all__') / 同 COALESCE(lang, '__all__') のみ対象。
+export async function findOverlappingReports(
+  db: D1Database,
+  input: Pick<ReportInput, "kind" | "period_start" | "period_end" | "category" | "lang">,
+): Promise<ReportRow[]> {
+  const result = await db
+    .prepare(
+      `SELECT id, kind, period_start, period_end, category, lang, source_skill, generated_at
+       FROM reports
+       WHERE kind = ?1
+         AND COALESCE(category, '${ALL_SENTINEL}') = COALESCE(?2, '${ALL_SENTINEL}')
+         AND COALESCE(lang,     '${ALL_SENTINEL}') = COALESCE(?3, '${ALL_SENTINEL}')
+         AND period_start < ?5
+         AND period_end   > ?4
+         AND NOT (period_start = ?4 AND period_end = ?5)`,
+    )
+    .bind(input.kind, input.category, input.lang, input.period_start, input.period_end)
+    .all<ReportRow>();
+  return result.results ?? [];
+}
+
+// overlap した既存レポートが存在するときに upsertReport が throw するエラー。
+export class OverlapError extends Error {
+  public readonly conflictingIds: number[];
+  constructor(conflictingIds: number[]) {
+    super(`report period overlaps with existing report(s): ids=[${conflictingIds.join(",")}]`);
+    this.name = "OverlapError";
+    this.conflictingIds = conflictingIds;
+  }
+}
+
 // (kind, period_start, period_end, category, lang) で upsert する。
 // UNIQUE index が COALESCE(category, '__all__') で張られているため、
 // ON CONFLICT の target にも同じ式を指定する必要がある (SQLite 3.24+ の挙動)。
+// 半開区間 overlap が検出された場合は OverlapError を throw する。
 export async function upsertReport(db: D1Database, input: ReportInput): Promise<{ id: number }> {
+  const overlapping = await findOverlappingReports(db, input);
+  if (overlapping.length > 0) {
+    throw new OverlapError(overlapping.map((r) => r.id));
+  }
+
   const result = await db
     .prepare(
       `INSERT INTO reports

--- a/docs/reports-pipeline.md
+++ b/docs/reports-pipeline.md
@@ -102,6 +102,7 @@ CORS は付けず、Bearer `ADMIN_TOKEN` (rotation 中は `ADMIN_TOKEN_NEXT` も
 - `category` / `lang` は許可リスト + `null`
 - 各 ISO 8601 は `new Date(s).toISOString() === s` で round-trip チェック
 - `READONLY=1` の場合は POST が 403
+- 同 (kind, category, lang) 内で半開区間 overlap が検出された場合は **409** `{ error, conflicting_ids }` を返す。完全一致は従来どおり upsert update。既存重複の解消は `node tools/d1-client/merge-overlapping-reports.mjs --target=local|remote [--apply]` を使用 (デフォルト dry-run)。
 
 ### Response
 

--- a/tools/d1-client/merge-overlapping-reports.mjs
+++ b/tools/d1-client/merge-overlapping-reports.mjs
@@ -2,9 +2,12 @@
 // production 既存の period-overlap レポートを 1 行にマージする one-shot スクリプト。
 //
 // Usage:
-//   node tools/d1-client/merge-overlapping-reports.mjs --target=local|remote [--apply]
+//   node tools/d1-client/merge-overlapping-reports.mjs --target=local|remote [--kind=<k1,k2,...>] [--apply]
 //
 // Default: dry-run (DB 変更なし)。--apply で実際に UPDATE / DELETE を実行する。
+// --kind= 指定時は対象 kind に絞って overlap 検出 (例: --kind=weekly,monthly)。
+// daily の period は generated_at ベースで暦日に揃っていないため、隣接日の row が
+// 境界誤差で部分 overlap してしまう。誤って巻き込まないために --kind フィルタを使うこと。
 //
 // 出力 (stdout): JSON
 //   {
@@ -29,8 +32,10 @@ const DB_NAME = "tech-news-bot-db";
 
 // ---- CLI args ----
 
+const VALID_KINDS = new Set(["daily", "weekly", "monthly"]);
+
 function parseArgs(argv) {
-  const out = { target: "local", apply: false };
+  const out = { target: "local", apply: false, kinds: null };
   for (const arg of argv.slice(2)) {
     if (arg === "--apply") {
       out.apply = true;
@@ -40,6 +45,12 @@ function parseArgs(argv) {
     if (!m) continue;
     const [, k, v] = m;
     if (k === "target") out.target = v;
+    else if (k === "kind") {
+      out.kinds = v
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+    }
   }
   return out;
 }
@@ -150,6 +161,15 @@ function main() {
     process.stderr.write(`Invalid --target=${opts.target}. Use local or remote.\n`);
     process.exit(2);
   }
+  if (opts.kinds) {
+    const invalid = opts.kinds.filter((k) => !VALID_KINDS.has(k));
+    if (invalid.length > 0) {
+      process.stderr.write(
+        `Invalid --kind value(s): ${invalid.join(",")}. Allowed: ${[...VALID_KINDS].join(",")}\n`,
+      );
+      process.exit(2);
+    }
+  }
 
   let rows;
   try {
@@ -157,6 +177,11 @@ function main() {
   } catch (err) {
     process.stderr.write(`Failed to fetch rows: ${err.message}\n`);
     process.exit(1);
+  }
+
+  if (opts.kinds) {
+    const allowed = new Set(opts.kinds);
+    rows = rows.filter((r) => allowed.has(r.kind));
   }
 
   const clusters = clusterRows(rows);

--- a/tools/d1-client/merge-overlapping-reports.mjs
+++ b/tools/d1-client/merge-overlapping-reports.mjs
@@ -6,8 +6,8 @@
 //
 // Default: dry-run (DB 変更なし)。--apply で実際に UPDATE / DELETE を実行する。
 // --kind= 指定時は対象 kind に絞って overlap 検出 (例: --kind=weekly,monthly)。
-// daily の period は generated_at ベースで暦日に揃っていないため、隣接日の row が
-// 境界誤差で部分 overlap してしまう。誤って巻き込まないために --kind フィルタを使うこと。
+// daily を含めると隣接日 (別日) の row が同一クラスタに巻き込まれることがあるため、
+// weekly/monthly の重複統合には `--kind=weekly,monthly` のように絞ること。
 //
 // 出力 (stdout): JSON
 //   {
@@ -162,6 +162,14 @@ function main() {
     process.exit(2);
   }
   if (opts.kinds) {
+    if (opts.kinds.length === 0) {
+      // `--kind=` や `--kind=,` のような空 csv は空配列になる。silent に全件 filter してしまうと
+      // dry-run で 0 cluster 終了して merge 漏れに気付けないため fail-fast にする。
+      process.stderr.write(
+        `--kind= must contain at least one kind. Allowed: ${[...VALID_KINDS].join(",")}\n`,
+      );
+      process.exit(2);
+    }
     const invalid = opts.kinds.filter((k) => !VALID_KINDS.has(k));
     if (invalid.length > 0) {
       process.stderr.write(

--- a/tools/d1-client/merge-overlapping-reports.mjs
+++ b/tools/d1-client/merge-overlapping-reports.mjs
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+// production 既存の period-overlap レポートを 1 行にマージする one-shot スクリプト。
+//
+// Usage:
+//   node tools/d1-client/merge-overlapping-reports.mjs --target=local|remote [--apply]
+//
+// Default: dry-run (DB 変更なし)。--apply で実際に UPDATE / DELETE を実行する。
+//
+// 出力 (stdout): JSON
+//   {
+//     target: "local" | "remote",
+//     dry_run: boolean,
+//     clusters: [{ keep_id, dropped_ids, period_start, period_end, kind, category, lang }],
+//     total_dropped: number
+//   }
+//
+// 注意: マージ時は各クラスタで最新 generated_at の row を keep とし、
+//       drop 側の content / meta_json は失われる。
+//       keep の period_start = MIN, period_end = MAX に拡張する。
+
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = path.resolve(path.dirname(__filename), "..", "..");
+const WRANGLER_DIR = path.join(REPO_ROOT, "apps", "web");
+const DB_NAME = "tech-news-bot-db";
+
+// ---- CLI args ----
+
+function parseArgs(argv) {
+  const out = { target: "local", apply: false };
+  for (const arg of argv.slice(2)) {
+    if (arg === "--apply") {
+      out.apply = true;
+      continue;
+    }
+    const m = arg.match(/^--([\w-]+)=(.+)$/);
+    if (!m) continue;
+    const [, k, v] = m;
+    if (k === "target") out.target = v;
+  }
+  return out;
+}
+
+// ---- wrangler helper (inline from recent.mjs) ----
+
+function execWrangler(sql, target) {
+  const args = [
+    "exec",
+    "wrangler",
+    "d1",
+    "execute",
+    DB_NAME,
+    target === "remote" ? "--remote" : "--local",
+    "--json",
+    "--command",
+    sql,
+  ];
+  const result = spawnSync("pnpm", args, { cwd: WRANGLER_DIR, encoding: "utf8" });
+  if (result.status !== 0) {
+    const msg = (result.stderr || result.stdout || "").trim();
+    throw new Error(`wrangler d1 execute failed (exit ${result.status}):\n${msg}`);
+  }
+  const stdout = result.stdout.trim();
+  const start = stdout.indexOf("[");
+  const end = stdout.lastIndexOf("]");
+  if (start < 0 || end < 0 || end <= start) {
+    throw new Error(`wrangler stdout did not contain JSON array:\n${stdout}`);
+  }
+  const parsed = JSON.parse(stdout.slice(start, end + 1));
+  return parsed[0]?.results ?? [];
+}
+
+// ---- overlap pair enumeration ----
+
+const FETCH_ROWS_SQL = `
+SELECT id, kind, period_start, period_end,
+       COALESCE(category, '__all__') AS cat,
+       COALESCE(lang, '__all__')     AS lng,
+       category, lang, generated_at
+FROM reports
+ORDER BY kind, cat, lng, period_start;
+`.trim();
+
+// 半開区間 [a_start, a_end) と [b_start, b_end) が overlap するか判定
+// 完全一致は UNIQUE 制約で重複しないはずだが、念のため除外しない (merge 対象にする)。
+function overlaps(a, b) {
+  return a.period_start < b.period_end && a.period_end > b.period_start;
+}
+
+// Union-Find
+function makeUF(n) {
+  const parent = Array.from({ length: n }, (_, i) => i);
+  function find(x) {
+    while (parent[x] !== x) {
+      parent[x] = parent[parent[x]];
+      x = parent[x];
+    }
+    return x;
+  }
+  function union(x, y) {
+    parent[find(x)] = find(y);
+  }
+  return { find, union };
+}
+
+// 同 (kind, cat, lng) グループ内で overlap するペアを Union-Find でクラスタ化
+function clusterRows(rows) {
+  // グループ化
+  const groups = new Map();
+  for (const row of rows) {
+    const key = `${row.kind}|${row.cat}|${row.lng}`;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(row);
+  }
+
+  const clusters = [];
+  for (const group of groups.values()) {
+    if (group.length < 2) continue;
+    const uf = makeUF(group.length);
+    for (let i = 0; i < group.length; i++) {
+      for (let j = i + 1; j < group.length; j++) {
+        if (overlaps(group[i], group[j])) {
+          uf.union(i, j);
+        }
+      }
+    }
+    // クラスタごとに集約
+    const clusterMap = new Map();
+    for (let i = 0; i < group.length; i++) {
+      const root = uf.find(i);
+      if (!clusterMap.has(root)) clusterMap.set(root, []);
+      clusterMap.get(root).push(group[i]);
+    }
+    for (const members of clusterMap.values()) {
+      if (members.length < 2) continue; // overlap なし
+      clusters.push(members);
+    }
+  }
+  return clusters;
+}
+
+// ---- main ----
+
+function main() {
+  const opts = parseArgs(process.argv);
+  if (!["local", "remote"].includes(opts.target)) {
+    process.stderr.write(`Invalid --target=${opts.target}. Use local or remote.\n`);
+    process.exit(2);
+  }
+
+  let rows;
+  try {
+    rows = execWrangler(FETCH_ROWS_SQL, opts.target);
+  } catch (err) {
+    process.stderr.write(`Failed to fetch rows: ${err.message}\n`);
+    process.exit(1);
+  }
+
+  const clusters = clusterRows(rows);
+
+  const output = {
+    target: opts.target,
+    dry_run: !opts.apply,
+    clusters: [],
+    total_dropped: 0,
+  };
+
+  for (const members of clusters) {
+    // keep: 最新 generated_at
+    members.sort((a, b) => (a.generated_at > b.generated_at ? -1 : 1));
+    const keep = members[0];
+    const drops = members.slice(1);
+
+    const periodStart = members.reduce(
+      (min, r) => (r.period_start < min ? r.period_start : min),
+      keep.period_start,
+    );
+    const periodEnd = members.reduce(
+      (max, r) => (r.period_end > max ? r.period_end : max),
+      keep.period_end,
+    );
+
+    output.clusters.push({
+      keep_id: keep.id,
+      dropped_ids: drops.map((r) => r.id),
+      period_start: periodStart,
+      period_end: periodEnd,
+      kind: keep.kind,
+      category: keep.category ?? null,
+      lang: keep.lang ?? null,
+    });
+    output.total_dropped += drops.length;
+
+    if (opts.apply) {
+      const dropIds = drops.map((r) => r.id).join(",");
+      const updateSQL =
+        `UPDATE reports SET period_start = '${periodStart.replace(/'/g, "''")}', ` +
+        `period_end = '${periodEnd.replace(/'/g, "''")}' ` +
+        `WHERE id = ${keep.id};`;
+      const deleteSQL = `DELETE FROM reports WHERE id IN (${dropIds});`;
+      try {
+        execWrangler(updateSQL, opts.target);
+        execWrangler(deleteSQL, opts.target);
+      } catch (err) {
+        process.stderr.write(`Failed to apply merge for keep_id=${keep.id}: ${err.message}\n`);
+        process.exit(1);
+      }
+    }
+  }
+
+  process.stdout.write(JSON.stringify(output, null, 2) + "\n");
+  process.exit(0);
+}
+
+main();

--- a/tools/d1-client/merge-overlapping-reports.mjs
+++ b/tools/d1-client/merge-overlapping-reports.mjs
@@ -196,14 +196,16 @@ function main() {
 
     if (opts.apply) {
       const dropIds = drops.map((r) => r.id).join(",");
-      const updateSQL =
+      // UPDATE と DELETE を 1 回の `wrangler d1 execute --command` に渡してアトミックに実行する。
+      // 別呼び出しに分けると UPDATE 成功・DELETE 失敗で keep の period が拡張済み + drop が残る
+      // 中途半端な状態になり、再 POST で 409 が返り続ける詰みケースを生む。
+      const mergeSQL =
         `UPDATE reports SET period_start = '${periodStart.replace(/'/g, "''")}', ` +
         `period_end = '${periodEnd.replace(/'/g, "''")}' ` +
-        `WHERE id = ${keep.id};`;
-      const deleteSQL = `DELETE FROM reports WHERE id IN (${dropIds});`;
+        `WHERE id = ${keep.id}; ` +
+        `DELETE FROM reports WHERE id IN (${dropIds});`;
       try {
-        execWrangler(updateSQL, opts.target);
-        execWrangler(deleteSQL, opts.target);
+        execWrangler(mergeSQL, opts.target);
       } catch (err) {
         process.stderr.write(`Failed to apply merge for keep_id=${keep.id}: ${err.message}\n`);
         process.exit(1);


### PR DESCRIPTION
## Summary
- `upsertReport` に半開区間 overlap 検証を追加 (同 kind / 同 COALESCE(category,'__all__') / 同 COALESCE(lang,'__all__'))
- overlap 発生時は `OverlapError` を throw し、Admin API では 409 + `conflicting_ids` を返す
- 既存の重複データを検出して merge する CLI `tools/d1-client/merge-overlapping-reports.mjs` を追加 (UPDATE + DELETE を 1 回の `wrangler d1 execute` にまとめて atomicity を確保)

## Background
2026/04/30 時点で D1 reports に同 (kind, category, lang) の period 重複行があることが判明。UNIQUE 制約は完全一致のみで、`weekly 04-21 ~ 04-28` と `weekly 04-22 ~ 04-29` のような部分 overlap は防げていなかった。今後の発生を防ぐ guard と既存重複の merge を同梱する。

## Changes
- `apps/web/worker/db/reports.ts`
  - `findOverlappingReports()`: 半開区間 (`existing.start < input.end AND existing.end > input.start`) で検出。完全一致 (`existing.start = input.start AND existing.end = input.end`) は ON CONFLICT で処理されるため除外
  - `upsertReport()`: insert 前に overlap check → `OverlapError` throw
  - placeholder 番号と column 名の mismatch を inline コメントで明示 (`?4`=input.period_start を `existing.period_end > ?4` で使う等)
- `apps/web/worker/api/reports.ts`: `OverlapError` を 409 + `AdminReportOverlapResponse` 型で返す
- `apps/web/worker/api/types.ts`: `AdminReportOverlapResponse` 追加
- `apps/web/tests/worker/db/reports.test.ts`: `findOverlappingReports` / `upsertReport` overlap guard の単体テスト
- `apps/web/tests/worker/api/reports.test.ts`: 409 応答の e2e
- `tools/d1-client/merge-overlapping-reports.mjs` (新規, 220 行)
  - dry-run by default, `--apply` で実行
  - 同グループ内で最も広い period に統合し、他行を削除
  - UPDATE + DELETE を 1 SQL にまとめて発行 (途中失敗で半端な状態にならない)
- `docs/reports-pipeline.md`: overlap 検証の振る舞いを 1 行追記

## Test plan
- [x] `apps/web/tests/worker/db/reports.test.ts` で overlap 検出 (start shifted / adjacent / different category) を確認
- [x] `apps/web/tests/worker/api/reports.test.ts` で 409 応答 + `conflicting_ids` を確認
- [x] `vp lint` / `vp fmt --check` / `vp test` (既存 fail 3 件は本変更と無関係: external fetch 依存)
- [ ] `merge-overlapping-reports.mjs --target=remote` (dry-run) で本番 D1 の重複行を一覧確認
- [ ] `--apply` で merge 実施

Closes #367

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reports now detect overlapping time periods for submissions with identical kind, category, and language settings
  * API returns HTTP 409 with an error message and list of conflicting report IDs when overlaps are detected
  * New merge utility tool to help resolve pre-existing overlapping reports

* **Tests**
  * Added test coverage for overlap detection and conflict handling

* **Documentation**
  * Updated endpoint documentation to describe overlap detection behavior and error responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->