### PR TITLE
feat(workflows): add manual-collect for ad-hoc admin/collect dispatch

### DIFF
--- a/.github/workflows/manual-collect.yml
+++ b/.github/workflows/manual-collect.yml
@@ -1,0 +1,48 @@
+name: Manual Collect
+
+# /api/admin/collect を手動で叩く。新フィード追加直後の確認や cron 障害時の復旧用。
+# 全 enabled feed を対象にするか、feed_id を指定して単発実行できる。
+
+on:
+  workflow_dispatch:
+    inputs:
+      feed_id:
+        description: "feed id (空なら全 enabled feed を収集)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  collect:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      WORKER_URL: https://tech-news-bot.rikeda71.workers.dev
+      ADMIN_TOKEN: ${{ secrets.WORKER_ADMIN_TOKEN }}
+      FEED_ID: ${{ inputs.feed_id }}
+    steps:
+      - name: Trigger admin/collect
+        run: |
+          if [ -n "$FEED_ID" ]; then
+            BODY=$(jq -nc --arg id "$FEED_ID" '{feed_id: $id}')
+          else
+            BODY=""
+          fi
+          # -w で HTTP status を末尾に出し、jq で run_id を抜き出す
+          response=$(curl -sS -X POST \
+            -H "Authorization: Bearer $ADMIN_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$BODY" \
+            -w "\n%{http_code}" \
+            "$WORKER_URL/api/admin/collect")
+          status=$(printf "%s" "$response" | tail -n1)
+          body=$(printf "%s" "$response" | sed '$d')
+          echo "status: $status"
+          echo "body: $body"
+          if [ "$status" != "200" ]; then
+            echo "::error::admin/collect returned $status"
+            exit 1
+          fi
+          echo "$body" | jq .


### PR DESCRIPTION
Closes #389

## Summary

- 新規 workflow \`.github/workflows/manual-collect.yml\` を追加
- workflow_dispatch のみで起動。inputs.feed_id (任意) で単一フィードだけ収集できる
- \`secrets.WORKER_ADMIN_TOKEN\` を Authorization header で送信
- HTTP status を検査し、200 以外なら job 失敗

## 動機

Cloudflare cron は 6 時間ごと (\`0 */6 * * *\` UTC) なので、新フィード追加直後の動作確認や、cron 障害復旧時に再収集したいケースで待ち時間が出る。GitHub Actions に \`secrets.WORKER_ADMIN_TOKEN\` 経由で \`/api/admin/collect\` を叩く workflow_dispatch を 1 本用意すれば、ローカルから token を扱わずに済む。

## Test plan

- [ ] merge 後、Actions UI から \`Run workflow\` で起動 (空入力 = 全 enabled feed)
- [ ] レスポンス body に \`{"ok":true,"run_id":N,"async":true}\` が含まれる
- [ ] feed_id=zenn-mizchi を指定した実行で、当該フィードのみ収集される (run_feeds 1 件)
- [ ] 不正 token / 無効 feed_id は job が失敗する

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new manual workflow for on-demand data collection operations with optional configuration parameters to streamline collection tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->