### PR TITLE
fix(reports): normalize daily report period to JST calendar day (#390)

### DIFF
--- a/.claude/skills/tech-news-digest/SKILL.md
+++ b/.claude/skills/tech-news-digest/SKILL.md
@@ -292,8 +292,8 @@ Stage 2〜4 は articles 0 件のためスキップする (`/tmp/report.md` の�
 ```json
 {
   "kind": "daily",
-  "period_start": "<since の ISO 8601 (実行時刻 -24h でよい)>",
-  "period_end": "<実行時刻の ISO 8601>",
+  "period_start": "<任意の仮値。workflow が JST 暦日に上書きする>",
+  "period_end": "<任意の仮値。workflow が JST 暦日に上書きする>",
   "category": null,
   "lang": null,
   "included_categories": ["bigtech", "ai", "jp"],

--- a/.claude/skills/tech-news-digest/SKILL.md
+++ b/.claude/skills/tech-news-digest/SKILL.md
@@ -292,7 +292,7 @@ Stage 2〜4 は articles 0 件のためスキップする (`/tmp/report.md` の�
 ```json
 {
   "kind": "daily",
-  "period_start": "<since の ISO 8601 (実行時刻 -24h)>",
+  "period_start": "<since の ISO 8601 (実行時刻 -24h でよい)>",
   "period_end": "<実行時刻の ISO 8601>",
   "category": null,
   "lang": null,
@@ -304,6 +304,8 @@ Stage 2〜4 は articles 0 件のためスキップする (`/tmp/report.md` の�
   "by_feed": <object — 0 件のときは {}>
 }
 ```
+
+> **注**: `period_start` / `period_end` は workflow (`.github/workflows/report-daily.yml`) が POST 直前に **JST 暦日 (00:00 〜 翌 00:00 JST)** に上書きする。skill 側はとりあえず実行時刻ベースの値を入れておけばよく、最終的に D1 に保存される値は workflow 側の上書き後の暦日整合した期間になる。これは隣接日 row との境界 overlap (#390) を防ぐため。
 
 #### 3. `/tmp/slack-message.md`
 

--- a/.github/workflows/report-daily.yml
+++ b/.github/workflows/report-daily.yml
@@ -93,20 +93,23 @@ jobs:
           # skill が出力する generated_at ベースの sliding-window だと隣接日の row が
           # 境界で部分 overlap してしまうため (#390)、POST 前にここで暦日丸めを行い、
           # /tmp/report-meta.json の period_start / period_end を上書きする。
-          PERIOD_START_UTC=$(python3 -c "from datetime import datetime, timedelta, timezone
-          jst = timezone(timedelta(hours=9))
-          start = datetime.now(jst).replace(hour=0, minute=0, second=0, microsecond=0)
-          print(start.astimezone(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'))")
-          PERIOD_END_UTC=$(python3 -c "from datetime import datetime, timedelta, timezone
+          # start / end は 1 回の python3 呼び出しで同時に取得する (2 回 spawn する間に
+          # 日付が変わると 2 日分の period が生成されるため)。
+          read -r PERIOD_START_UTC PERIOD_END_UTC <<<"$(python3 -c "from datetime import datetime, timedelta, timezone
           jst = timezone(timedelta(hours=9))
           start = datetime.now(jst).replace(hour=0, minute=0, second=0, microsecond=0)
           end = start + timedelta(days=1)
-          print(end.astimezone(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'))")
-          jq \
+          fmt = '%Y-%m-%dT%H:%M:%SZ'
+          print(start.astimezone(timezone.utc).strftime(fmt), end.astimezone(timezone.utc).strftime(fmt))")"
+          if ! jq \
             --arg ps "$PERIOD_START_UTC" \
             --arg pe "$PERIOD_END_UTC" \
             '.period_start = $ps | .period_end = $pe' \
-            /tmp/report-meta.json > /tmp/report-meta.json.tmp
+            /tmp/report-meta.json > /tmp/report-meta.json.tmp; then
+            rm -f /tmp/report-meta.json.tmp
+            echo "Failed to override period in /tmp/report-meta.json" >&2
+            exit 1
+          fi
           mv /tmp/report-meta.json.tmp /tmp/report-meta.json
 
           # report-meta.json は kind / period_start / period_end / category / lang /

--- a/.github/workflows/report-daily.yml
+++ b/.github/workflows/report-daily.yml
@@ -89,6 +89,26 @@ jobs:
             exit 1
           fi
 
+          # Daily report の period を JST 暦日 (00:00 〜 翌 00:00 JST) に正規化する。
+          # skill が出力する generated_at ベースの sliding-window だと隣接日の row が
+          # 境界で部分 overlap してしまうため (#390)、POST 前にここで暦日丸めを行い、
+          # /tmp/report-meta.json の period_start / period_end を上書きする。
+          PERIOD_START_UTC=$(python3 -c "from datetime import datetime, timedelta, timezone
+          jst = timezone(timedelta(hours=9))
+          start = datetime.now(jst).replace(hour=0, minute=0, second=0, microsecond=0)
+          print(start.astimezone(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'))")
+          PERIOD_END_UTC=$(python3 -c "from datetime import datetime, timedelta, timezone
+          jst = timezone(timedelta(hours=9))
+          start = datetime.now(jst).replace(hour=0, minute=0, second=0, microsecond=0)
+          end = start + timedelta(days=1)
+          print(end.astimezone(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'))")
+          jq \
+            --arg ps "$PERIOD_START_UTC" \
+            --arg pe "$PERIOD_END_UTC" \
+            '.period_start = $ps | .period_end = $pe' \
+            /tmp/report-meta.json > /tmp/report-meta.json.tmp
+          mv /tmp/report-meta.json.tmp /tmp/report-meta.json
+
           # report-meta.json は kind / period_start / period_end / category / lang /
           # source_skill / generated_at と追加メタ (dedup_total, by_category, ...) を含む。
           # API body は { ...meta, content, meta } の形に jq で組み立てる。


### PR DESCRIPTION
## Summary
- daily report の `period_start` / `period_end` を **JST 暦日 (00:00 〜 翌 00:00 JST)** に正規化する
- skill が出力した `generated_at` ベースの sliding-window 値を、POST 直前に workflow 側で上書き
- 隣接日の row が境界で部分 overlap してしまう問題 (#390) を解消

## Background
#367 の overlap 検証 + merge スクリプトを本番 D1 に適用しようとしたところ、daily report の cluster 1 (5 行) が連続した別日の row まで巻き込んで union されてしまうことが判明。原因は daily の `period_start` / `period_end` が `generated_at` を起点にしたスライディング窓で、暦日に揃っていないため。

## Approach
1. workflow yaml の "Save report to D1" ステップで `python3` を使い JST 当日の 0:00 / 翌 0:00 (UTC ISO 8601) を計算
2. `jq` で `/tmp/report-meta.json` の `period_start` / `period_end` を上書き
3. SKILL.md に「workflow が上書きする」旨を追記 (skill 側で計算する必要なし)

例 (実行: 2026-04-30 16:48 JST):
- 修正前: period_start=skill 任意, period_end=skill 任意 (sliding-window)
- 修正後: period_start=`2026-04-29T15:00:00Z` (JST 04-30 00:00), period_end=`2026-04-30T15:00:00Z` (JST 05-01 00:00)

`generated_at` は実行時刻のまま (これまで通り)。

## Why workflow-side override
- skill (LLM) に「JST 暦日丸め」を計算させるのは指示が増えて failure 余地が大きい
- workflow 側なら `python3` で確実 (Ubuntu runner 標準)
- skill の責務 (記事収集 + markdown 生成) と workflow の責務 (DB 永続化のための形式整形) が綺麗に分離

## Base branch
PR #383 (`chore/daily-report-link-grounding`) を base にしている。`.github/workflows/report-daily.yml` の slim 化を含むため、main を base にすると competing edits になる。PR #383 が先に merge されたら自動で main 経由になる。

## Test plan
- [x] python3 で計算した値が JST 暦日に整合: `2026-04-29T15:00:00Z` 〜 `2026-04-30T15:00:00Z`
- [x] yaml が valid (`yaml.safe_load` で parse 可)
- [x] jq override が他フィールドを保持しつつ period のみ書き換え
- [ ] 次回 scheduled `report-daily` 実行で D1 row の period が JST 暦日整合になることを確認
- [ ] 翌日以降 `find-overlaps --kind=daily` が overlap を返さなくなることを確認 (既存 row の遡及修正はしない)

## Out of scope (follow-up)
- 既存 daily 行の period 遡及修正は別作業 (本 PR はあくまで今後の生成分の正規化)
- `recent.mjs --since=today` の sliding-window 仕様は変えない (記事収集の対象期間は別問題)

closes #390