### PR TITLE
fix(workflows): cancel in-progress preview deploy on PR close

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -63,6 +63,14 @@ jobs:
   cleanup-preview:
     if: github.event.action == 'closed'
     runs-on: ubuntu-latest
+    # deploy-preview と同じ concurrency group に入れる。
+    # PR を merge する直前に force-push が走ると synchronize → closed が連続発火し、
+    # cleanup の wrangler delete が完了した直後に deploy-preview が完走して
+    # worker を再 deploy してしまうレースがある。cancel-in-progress で先行する
+    # deploy-preview を打ち切ってから cleanup を走らせる。
+    concurrency:
+      group: preview-pr-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
## Summary

- `cleanup-preview` job に `deploy-preview` と同じ `concurrency` group を付与し、PR merge 直前の `synchronize` → `closed` 連続発火で `deploy-preview` が `cleanup-preview` 完了後に走り、worker が再 deploy されるレースを抑止する。
- 実例: PR #385 / #392 (本日 merge) では cleanup の `wrangler delete` 完了直後に deploy-preview が完走 → `tech-news-bot-pr-{385,392}` が残骸化していた。

Closes #394

## Test plan

- [ ] CI green (`vp check` 等)
- [ ] この PR を merge した直後に `pnpm exec wrangler deployments list --name tech-news-bot-pr-<this PR number>` が `10007: Worker does not exist` を返すことを確認
- [ ] (本 PR の merge 自体が回帰検証になる)