### PR TITLE
feat(collector): reduce subrequests + 3-way daily cron split

### DIFF
--- a/apps/web/tests/worker/api/admin.test.ts
+++ b/apps/web/tests/worker/api/admin.test.ts
@@ -16,7 +16,7 @@ const TEST_FEED: FeedConfig = {
 const AUTH_HEADER = { authorization: "Bearer test-admin-token" };
 
 // feeds.yaml に実在する ID (テスト環境でも loadAllFeeds() から参照される)
-const REAL_FEED_ID = "google-research";
+const REAL_FEED_ID = "google-developers";
 
 beforeEach(async () => {
   await syncFeeds(env.DB, [TEST_FEED]);

--- a/apps/web/tests/worker/api/feeds/health.test.ts
+++ b/apps/web/tests/worker/api/feeds/health.test.ts
@@ -14,7 +14,7 @@ const FEEDS: FeedConfig[] = [
     enabled: true,
   },
   {
-    id: "google-research",
+    id: "google-developers",
     name: "Google Research",
     url: "https://x.test/google",
     category: "bigtech",
@@ -142,10 +142,14 @@ describe("GET /api/feeds/:id/health", () => {
   });
 
   it("returns null last_error when no failures", async () => {
-    // google-research にはランを挿入していないため 0 件
+    // google-developers にはランを挿入していないため 0 件
     // 成功のみのランを別フィードに挿入して確認
-    await insertRun("google-research", "ok", { daysAgoN: 1, durationMs: 150, articlesInserted: 2 });
-    const res = await SELF.fetch("https://example.com/api/feeds/google-research/health");
+    await insertRun("google-developers", "ok", {
+      daysAgoN: 1,
+      durationMs: 150,
+      articlesInserted: 2,
+    });
+    const res = await SELF.fetch("https://example.com/api/feeds/google-developers/health");
     const body = await res.json<{ last_error: null; last_run_status: string }>();
     expect.soft(res.status).toBe(200);
     expect.soft(body.last_error).toBeNull();

--- a/apps/web/tests/worker/api/opml.test.ts
+++ b/apps/web/tests/worker/api/opml.test.ts
@@ -46,10 +46,10 @@ describe("GET /feeds.opml", () => {
   it("xmlUrl points to this service origin with /feeds/<id>.xml path", async () => {
     const res = await SELF.fetch("https://example.com/feeds.opml");
     const text = await res.text();
-    // google-research フィードの xmlUrl がサービス自身のオリジンを使っていること
-    expect(text).toContain('xmlUrl="https://example.com/feeds/google-research.xml"');
+    // google-developers フィードの xmlUrl がサービス自身のオリジンを使っていること
+    expect(text).toContain('xmlUrl="https://example.com/feeds/google-developers.xml"');
     // htmlUrl は feeds.yaml の元 URL を指すこと
-    expect(text).toContain('htmlUrl="https://blog.research.google/feeds/posts/default"');
+    expect(text).toContain('htmlUrl="https://developers.googleblog.com/feeds/posts/default"');
   });
 
   it("enabled: false feeds are excluded", async () => {

--- a/apps/web/tests/worker/api/sitemap.test.ts
+++ b/apps/web/tests/worker/api/sitemap.test.ts
@@ -48,11 +48,11 @@ describe("/sitemap.xml", () => {
     expect(text).toContain("<changefreq>hourly</changefreq>");
   });
 
-  it("contains enabled feed_id URL (google-research)", async () => {
+  it("contains enabled feed_id URL (google-developers)", async () => {
     const res = await SELF.fetch("https://example.com/sitemap.xml");
     const text = await res.text();
     // feeds.yaml で enabled: true のフィードが含まれること
-    expect(text).toContain("/?feed_id=google-research");
+    expect(text).toContain("/?feed_id=google-developers");
     expect(text).toContain("<changefreq>daily</changefreq>");
     expect(text).toContain("<priority>0.6</priority>");
   });

--- a/apps/web/tests/worker/api/syndication/rss.test.ts
+++ b/apps/web/tests/worker/api/syndication/rss.test.ts
@@ -24,7 +24,7 @@ const FEEDS: FeedConfig[] = [
     enabled: true,
   },
   {
-    id: "google-research",
+    id: "google-developers",
     name: "Google Research Blog",
     url: "https://x.test/g",
     category: "bigtech",
@@ -60,7 +60,7 @@ beforeEach(async () => {
     },
     {
       guid: "g-bigtech",
-      feed_id: "google-research",
+      feed_id: "google-developers",
       title: "Google Blog Post",
       url: "https://x.test/g/1",
       summary: null,
@@ -127,12 +127,12 @@ describe("/feeds/:id.xml (per-feed RSS)", () => {
   });
 
   // enabled: false のフィードでも feeds.yaml に id が定義されていれば 200 を返すことを確認する。
-  // google-research は feeds.yaml で enabled: true だが、ここでは enabled: false として
+  // google-developers は feeds.yaml で enabled: true だが、ここでは enabled: false として
   // DB に登録し、それでも過去記事が配信されることを検証する。
   it("serves past articles for a feed regardless of enabled flag in DB", async () => {
     await syncFeeds(env.DB, [
       {
-        id: "google-research",
+        id: "google-developers",
         name: "Google Research Blog",
         url: "https://x.test/gr",
         category: "bigtech",
@@ -144,7 +144,7 @@ describe("/feeds/:id.xml (per-feed RSS)", () => {
     await insertArticles(env.DB, [
       {
         guid: "g-gr",
-        feed_id: "google-research",
+        feed_id: "google-developers",
         title: "Google Research Article",
         url: "https://x.test/gr/1",
         summary: null,
@@ -154,8 +154,8 @@ describe("/feeds/:id.xml (per-feed RSS)", () => {
         lang: "en",
       },
     ]);
-    // feeds.yaml に "google-research" が存在するため 200 が返る
-    const res = await SELF.fetch("https://example.com/feeds/google-research.xml");
+    // feeds.yaml に "google-developers" が存在するため 200 が返る
+    const res = await SELF.fetch("https://example.com/feeds/google-developers.xml");
     expect(res.status).toBe(200);
     const text = await res.text();
     expect(text).toContain("g-gr");

--- a/apps/web/tests/worker/feed-config.test.ts
+++ b/apps/web/tests/worker/feed-config.test.ts
@@ -43,10 +43,10 @@ describe("loadAllFeeds", () => {
     expect(all.length).toBeGreaterThanOrEqual(enabled.length);
   });
 
-  it("includes well-known feeds (google-research, openai-blog, zenn-mizchi)", () => {
+  it("includes well-known feeds (google-developers, openai-blog, zenn-mizchi)", () => {
     const feeds = loadAllFeeds();
     const ids = feeds.map((f) => f.id);
-    expect(ids).toContain("google-research");
+    expect(ids).toContain("google-developers");
     expect(ids).toContain("openai-blog");
     expect(ids).toContain("zenn-mizchi");
   });

--- a/apps/web/worker/collector/index.ts
+++ b/apps/web/worker/collector/index.ts
@@ -5,18 +5,21 @@ import { parseXml, pickText, asArray } from "../utils/xml";
 import { buildGuids } from "./deduplicator";
 import { D1CostAccumulator, writeCollectorEvent, writeD1CostEvent } from "./metrics";
 import { maybeAlert, sendAlert } from "./alert";
-import { insertArticles, type InsertableArticle } from "../db/articles";
 import {
+  buildInsertArticleStmts,
+  findExistingArticleGuids,
+  type InsertableArticle,
+} from "../db/articles";
+import {
+  buildRecordFetchErrorStmt,
+  buildRecordFetchSuccessStmt,
+  buildUpdateFeedHeadersStmt,
   type FeedHeaders,
-  getEnabledFeedIds,
   getFeedStreaks,
-  loadFeedHeadersAll,
-  recordFetchError,
-  recordFetchSuccess,
+  loadEnabledFeedIdsAndHeaders,
   syncFeeds,
-  updateFeedHeaders,
 } from "../db/feeds";
-import { finishRun, recordRunFeed, startRun } from "../db/runs";
+import { buildRecordRunFeedStmt, finishRun, startRun } from "../db/runs";
 
 const MAX_FEED_BYTES = 4 * 1024 * 1024; // 4MB
 const MAX_ITEMS_PER_FEED = 50;
@@ -216,6 +219,17 @@ function isSafeUrl(url: string): boolean {
   return ALLOWED_URL_PREFIXES.some((p) => url.toLowerCase().startsWith(p));
 }
 
+/**
+ * 1 feed 分の収集。per-feed の D1 書き込みを 1 batch にまとめて
+ * Worker の subrequest 上限を圧迫しないようにする。
+ *
+ * Subrequest 内訳 (Cloudflare Workers の subrequest 上限対策):
+ * - 304:    fetch (1) + batch[recordFetchSuccess + recordRunFeed?] (1) = 2
+ * - 200:    fetch (1) + SELECT existing guids (1) + batch[updateHeaders + INSERTs + recordFetchSuccess + recordRunFeed?] (1) = 3
+ * - error:  fetch (1) + batch[recordFetchError + recordRunFeed?] (1) = 2
+ *
+ * runId が null なら recordRunFeed は省略 (テスト等で run tracking 無効時)。
+ */
 async function collectFeed(
   env: Env,
   feed: FeedConfig,
@@ -223,9 +237,12 @@ async function collectFeed(
   summaryMax: number,
   timeoutMs: number,
   maxRetries: number,
+  runId: number | null,
+  d1Acc: D1CostAccumulator,
 ): Promise<CollectResult> {
   const fetchedAt = new Date().toISOString();
   const t0 = performance.now();
+  const feedStart = Date.now();
   try {
     // savedHeaders は collectAll 冒頭で全 enabled feed 分を 1 query でまとめて取得済み。
     // feed あたり 1 read を消費しないので Worker の subrequest 上限対策になる。
@@ -236,7 +253,16 @@ async function collectFeed(
 
     // 304 Not Modified: parse/insert をスキップし last_fetched_at だけ更新する
     if (result.notModified) {
-      await recordFetchSuccess(env.DB, feed.id, fetchedAt, 0, "not_modified");
+      const stmts: D1PreparedStatement[] = [
+        buildRecordFetchSuccessStmt(env.DB, feed.id, fetchedAt, 0, "not_modified"),
+      ];
+      if (runId !== null) {
+        stmts.push(
+          buildRecordRunFeedStmt(env.DB, runId, feed.id, "skipped", 0, Date.now() - feedStart),
+        );
+      }
+      const batchResults = await env.DB.batch(stmts);
+      for (const r of batchResults) d1Acc.add(r.meta);
       writeCollectorEvent(env, {
         feedId: feed.id,
         status: "not_modified",
@@ -246,9 +272,7 @@ async function collectFeed(
       return { feedId: feed.id, status: "not_modified", inserted: 0, parsed: 0 };
     }
 
-    // 200 OK: レスポンスの ETag / Last-Modified を保存する
-    await updateFeedHeaders(env.DB, feed.id, result.etag, result.lastModified);
-
+    // 200 OK path
     const allItems = parseFeed(result.xml!, {
       summaryMaxLength: summaryMax,
       fallbackPublishedAt: fetchedAt,
@@ -278,8 +302,30 @@ async function collectFeed(
       lang: feed.lang,
     }));
 
-    const inserted = await insertArticles(env.DB, rows);
-    await recordFetchSuccess(env.DB, feed.id, fetchedAt, inserted);
+    // FTS トリガが INSERT OR IGNORE の changes() を変動させるため事前に既存 guid を引いて
+    // 新規行のみ INSERT する。SELECT は 1 subrequest だが per-feed batch とは独立して実行する。
+    const existingSet = await findExistingArticleGuids(
+      env.DB,
+      rows.map((r) => r.guid),
+    );
+    const newRows = rows.filter((r) => !existingSet.has(r.guid));
+    const inserted = newRows.length;
+
+    // header 更新 + INSERT 群 + recordFetchSuccess + recordRunFeed を 1 batch に集約。
+    // MAX_ITEMS_PER_FEED=50 + 3 = 53 stmts なので D1 batch 上限 100 を超えない。
+    const stmts: D1PreparedStatement[] = [
+      buildUpdateFeedHeadersStmt(env.DB, feed.id, result.etag, result.lastModified),
+      ...buildInsertArticleStmts(env.DB, newRows),
+      buildRecordFetchSuccessStmt(env.DB, feed.id, fetchedAt, inserted),
+    ];
+    if (runId !== null) {
+      stmts.push(
+        buildRecordRunFeedStmt(env.DB, runId, feed.id, "ok", inserted, Date.now() - feedStart),
+      );
+    }
+    const batchResults = await env.DB.batch(stmts);
+    for (const r of batchResults) d1Acc.add(r.meta);
+
     writeCollectorEvent(env, {
       feedId: feed.id,
       status: "ok",
@@ -291,7 +337,24 @@ async function collectFeed(
     const message = err instanceof Error ? err.message : String(err);
     const errorKind = classifyError(err);
     try {
-      await recordFetchError(env.DB, feed.id, fetchedAt, message);
+      const stmts: D1PreparedStatement[] = [
+        buildRecordFetchErrorStmt(env.DB, feed.id, fetchedAt, message),
+      ];
+      if (runId !== null) {
+        stmts.push(
+          buildRecordRunFeedStmt(
+            env.DB,
+            runId,
+            feed.id,
+            "failed",
+            0,
+            Date.now() - feedStart,
+            message,
+          ),
+        );
+      }
+      const batchResults = await env.DB.batch(stmts);
+      for (const r of batchResults) d1Acc.add(r.meta);
     } catch (logErr) {
       console.error(`Failed to record error for ${feed.id}`, logErr);
     }
@@ -416,7 +479,10 @@ export async function collectAll(
 
   // yaml の enabled=true を前提に、D1 で runtime disabled にされた feed を除外する。
   // feedIds が指定された場合はその ID に含まれるものだけを対象にする。
-  const d1EnabledIds = await getEnabledFeedIds(env.DB);
+  // enabled 判定と conditional GET ヘッダ取得を 1 query に統合して subrequest を削減する。
+  const { enabledIds: d1EnabledIds, headers: headersMap } = await loadEnabledFeedIdsAndHeaders(
+    env.DB,
+  );
   const activeFeeds = feeds.filter((f) => {
     if (!d1EnabledIds.has(f.id)) return false;
     if (opts?.feedIds !== undefined) return opts.feedIds.includes(f.id);
@@ -446,48 +512,22 @@ export async function collectAll(
     }
   }
 
-  const headersMap = await loadFeedHeadersAll(
-    env.DB,
-    activeFeeds.map((f) => f.id),
-  );
   const emptyHeaders: FeedHeaders = { last_etag: null, last_modified: null };
 
-  const results = await runWithConcurrency(activeFeeds, concurrency, async (feed) => {
-    const feedStart = Date.now();
-    const result = await collectFeed(
+  // collectFeed が runId を受け取って per-feed batch に recordRunFeed を含めるため、
+  // ここでは recordRunFeed を別途呼ばない (subrequest 削減)。
+  const results = await runWithConcurrency(activeFeeds, concurrency, (feed) =>
+    collectFeed(
       env,
       feed,
       headersMap.get(feed.id) ?? emptyHeaders,
       summaryMax,
       timeoutMs,
       maxRetries,
-    );
-    const durationMs = Date.now() - feedStart;
-
-    // 各フィードの結果を記録する。失敗しても collectFeed の結果は返す。
-    if (runId !== null) {
-      const status =
-        result.status === "error" ? "failed" : result.status === "not_modified" ? "skipped" : "ok";
-      try {
-        const meta = await recordRunFeed(
-          env.DB,
-          runId,
-          feed.id,
-          status,
-          result.inserted,
-          durationMs,
-          result.status === "error" ? result.error : undefined,
-        );
-        d1Acc.add(meta);
-      } catch (err) {
-        console.error(
-          `[collector] recordRunFeed(${feed.id}) failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
-    }
-
-    return result;
-  });
+      runId,
+      d1Acc,
+    ),
+  );
 
   const inserted = results.reduce((acc, r) => acc + r.inserted, 0);
   const skipped304 = results.filter((r) => r.status === "not_modified").length;

--- a/apps/web/worker/collector/slot.ts
+++ b/apps/web/worker/collector/slot.ts
@@ -1,0 +1,19 @@
+import { loadEnabledFeeds } from "../feed-config";
+
+/**
+ * enabled feed を id 昇順でソートし `total` 等分した上で `slot` 番目のグループの id を返す。
+ *
+ * Free plan の subrequest 上限 (50 / invocation) を満たすため、3 cron に分けて
+ * 1 cron あたり ≒ feeds.length / 3 個のフィードだけを収集する。
+ *
+ * - id 昇順 + 連続 chunk により、feed を追加してもメンバー入れ替えが局所化される
+ *   (中間に挟まると後続 chunk が 1 つずつ右にずれる程度)
+ * - chunk 境界の計算は ceil で「先頭 slot を多め」に詰める。total=3 / feeds=43 のときは 15 / 14 / 14
+ */
+export function pickFeedSlot(slot: number, total: number): string[] {
+  const feeds = loadEnabledFeeds().toSorted((a, b) => a.id.localeCompare(b.id));
+  const chunkSize = Math.ceil(feeds.length / total);
+  const start = slot * chunkSize;
+  const end = Math.min(start + chunkSize, feeds.length);
+  return feeds.slice(start, end).map((f) => f.id);
+}

--- a/apps/web/worker/db/articles.ts
+++ b/apps/web/worker/db/articles.ts
@@ -57,22 +57,30 @@ export interface InsertableArticle {
   lang: FeedLang;
 }
 
-export async function insertArticles(db: D1Database, rows: InsertableArticle[]): Promise<number> {
-  if (rows.length === 0) return 0;
-
-  // FTS トリガの changes() が混入するため、INSERT OR IGNORE の meta.changes は信頼できない。
-  // 事前に existing guid を引いてフィルタする (cron 単一インスタンス前提)。
-  const guids = rows.map((r) => r.guid);
+/**
+ * 既存 guid を引いて Set で返す。
+ * insertArticles の最初の SELECT を collector が直接呼べるように分離した。
+ * collector は per-feed batch に INSERT 文をまとめるため、SELECT だけ事前に必要。
+ */
+export async function findExistingArticleGuids(
+  db: D1Database,
+  guids: string[],
+): Promise<Set<string>> {
+  if (guids.length === 0) return new Set();
   const placeholders = guids.map((_, i) => `?${i + 1}`).join(",");
   const existing = await db
     .prepare(`SELECT guid FROM articles WHERE guid IN (${placeholders})`)
     .bind(...guids)
     .all<{ guid: string }>();
-  const existingSet = new Set((existing.results ?? []).map((r) => r.guid));
-  const newRows = rows.filter((r) => !existingSet.has(r.guid));
-  if (newRows.length === 0) return 0;
+  return new Set((existing.results ?? []).map((r) => r.guid));
+}
 
-  const stmts = newRows.map((r) =>
+/** INSERT OR IGNORE statement を組み立てる。collector の per-feed batch に渡す用。 */
+export function buildInsertArticleStmts(
+  db: D1Database,
+  rows: InsertableArticle[],
+): D1PreparedStatement[] {
+  return rows.map((r) =>
     db
       .prepare(
         `INSERT OR IGNORE INTO articles
@@ -91,6 +99,21 @@ export async function insertArticles(db: D1Database, rows: InsertableArticle[]):
         r.lang,
       ),
   );
+}
+
+export async function insertArticles(db: D1Database, rows: InsertableArticle[]): Promise<number> {
+  if (rows.length === 0) return 0;
+
+  // FTS トリガの changes() が混入するため、INSERT OR IGNORE の meta.changes は信頼できない。
+  // 事前に existing guid を引いてフィルタする (cron 単一インスタンス前提)。
+  const existingSet = await findExistingArticleGuids(
+    db,
+    rows.map((r) => r.guid),
+  );
+  const newRows = rows.filter((r) => !existingSet.has(r.guid));
+  if (newRows.length === 0) return 0;
+
+  const stmts = buildInsertArticleStmts(db, newRows);
   // D1 batch は 1 リクエスト 100 statements が上限
   const BATCH_SIZE = 50;
   for (let i = 0; i < stmts.length; i += BATCH_SIZE) {

--- a/apps/web/worker/db/feeds.ts
+++ b/apps/web/worker/db/feeds.ts
@@ -51,6 +51,27 @@ export async function loadFeedHeadersAll(
 }
 
 /**
+ * 200 応答時のレスポンスヘッダ更新ステートメントを組み立てる。
+ * collector が per-feed batch に詰めて 1 ラウンドトリップで実行するため builder として分離。
+ */
+export function buildUpdateFeedHeadersStmt(
+  db: D1Database,
+  feedId: string,
+  etag: string | null,
+  lastModified: string | null,
+): D1PreparedStatement {
+  return db
+    .prepare(
+      `UPDATE feeds
+       SET last_etag = ?1,
+           last_modified = ?2,
+           updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+       WHERE id = ?3`,
+    )
+    .bind(etag, lastModified, feedId);
+}
+
+/**
  * 200 応答時のレスポンスヘッダを保存する。
  * null を渡すと既存値を NULL 上書きする (サーバが ETag を返さなくなった場合)。
  */
@@ -60,21 +81,12 @@ export async function updateFeedHeaders(
   etag: string | null,
   lastModified: string | null,
 ): Promise<void> {
-  await db
-    .prepare(
-      `UPDATE feeds
-       SET last_etag = ?1,
-           last_modified = ?2,
-           updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
-       WHERE id = ?3`,
-    )
-    .bind(etag, lastModified, feedId)
-    .run();
+  await buildUpdateFeedHeadersStmt(db, feedId, etag, lastModified).run();
 }
 
 export async function syncFeeds(db: D1Database, feeds: FeedConfig[]): Promise<void> {
   if (feeds.length === 0) return;
-  const stmts = feeds.map((f) =>
+  const upserts = feeds.map((f) =>
     db
       .prepare(
         `INSERT INTO feeds (id, name, url, category, lang, enabled, updated_at)
@@ -89,37 +101,48 @@ export async function syncFeeds(db: D1Database, feeds: FeedConfig[]): Promise<vo
       )
       .bind(f.id, f.name, f.url, f.category, f.lang, f.enabled ? 1 : 0),
   );
-  const BATCH_SIZE = 50;
-  for (let i = 0; i < stmts.length; i += BATCH_SIZE) {
-    await db.batch(stmts.slice(i, i + BATCH_SIZE));
-  }
 
   // yaml に存在しない feed を D1 で disable する (orphan cleanup)。
   // 削除しない理由: 過去記事は articles.feed_id 経由で feed 名・カテゴリを引いているため、
   // レコード自体は残し enabled=0 で stats の stale 判定や collector 対象から除外する。
   const ids = feeds.map((f) => f.id);
   const placeholders = ids.map((_, i) => `?${i + 1}`).join(",");
-  await db
+  const orphanStmt = db
     .prepare(
       `UPDATE feeds
        SET enabled = 0,
            updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
        WHERE enabled = 1 AND id NOT IN (${placeholders})`,
     )
-    .bind(...ids)
-    .run();
+    .bind(...ids);
+
+  // upsert と orphan disable を 1 batch に集約して subrequest を削減する。
+  // batch は最大 100 stmts のため、現状の feed 数 (< 100) では分割不要。
+  // 将来 feed 数が 99 以上に増えたら orphan を別 batch に切り出す必要がある。
+  const BATCH_LIMIT = 100;
+  const allStmts = [...upserts, orphanStmt];
+  if (allStmts.length <= BATCH_LIMIT) {
+    await db.batch(allStmts);
+    return;
+  }
+  const BATCH_SIZE = 50;
+  for (let i = 0; i < upserts.length; i += BATCH_SIZE) {
+    await db.batch(upserts.slice(i, i + BATCH_SIZE));
+  }
+  await orphanStmt.run();
 }
 
-export async function recordFetchSuccess(
+/** recordFetchSuccess の SQL を builder として返す。collector の per-feed batch に渡す用。 */
+export function buildRecordFetchSuccessStmt(
   db: D1Database,
   feedId: string,
   fetchedAt: string,
   insertedCount: number,
   // 304 の場合は "not_modified"、それ以外は挿入件数を含む "ok:N" 形式
   statusOverride?: "not_modified",
-): Promise<void> {
+): D1PreparedStatement {
   const status = statusOverride ?? `ok:${insertedCount}`;
-  await db
+  return db
     .prepare(
       `UPDATE feeds
        SET last_fetched_at = ?1,
@@ -130,8 +153,18 @@ export async function recordFetchSuccess(
            updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
        WHERE id = ?3`,
     )
-    .bind(fetchedAt, status, feedId)
-    .run();
+    .bind(fetchedAt, status, feedId);
+}
+
+export async function recordFetchSuccess(
+  db: D1Database,
+  feedId: string,
+  fetchedAt: string,
+  insertedCount: number,
+  // 304 の場合は "not_modified"、それ以外は挿入件数を含む "ok:N" 形式
+  statusOverride?: "not_modified",
+): Promise<void> {
+  await buildRecordFetchSuccessStmt(db, feedId, fetchedAt, insertedCount, statusOverride).run();
 }
 
 /** D1 の feeds.enabled を更新する。id が存在しない場合は found=false を返す。 */
@@ -170,13 +203,34 @@ export async function getEnabledFeedIds(db: D1Database): Promise<Set<string>> {
   return new Set(rows.results.map((r) => r.id));
 }
 
-export async function recordFetchError(
+/**
+ * collector 1 invocation の冒頭で呼ぶ統合クエリ。
+ * enabled=1 の feed id 集合と conditional GET ヘッダを 1 SELECT で同時に返し、
+ * Worker の subrequest を 2 から 1 に削減する。
+ */
+export async function loadEnabledFeedIdsAndHeaders(
+  db: D1Database,
+): Promise<{ enabledIds: Set<string>; headers: Map<string, FeedHeaders> }> {
+  const rows = await db
+    .prepare(`SELECT id, last_etag, last_modified FROM feeds WHERE enabled = 1`)
+    .all<{ id: string; last_etag: string | null; last_modified: string | null }>();
+  const enabledIds = new Set<string>();
+  const headers = new Map<string, FeedHeaders>();
+  for (const row of rows.results ?? []) {
+    enabledIds.add(row.id);
+    headers.set(row.id, { last_etag: row.last_etag, last_modified: row.last_modified });
+  }
+  return { enabledIds, headers };
+}
+
+/** recordFetchError の SQL を builder として返す。collector の per-feed batch に渡す用。 */
+export function buildRecordFetchErrorStmt(
   db: D1Database,
   feedId: string,
   fetchedAt: string,
   error: string,
-): Promise<void> {
-  await db
+): D1PreparedStatement {
+  return db
     .prepare(
       `UPDATE feeds
        SET last_fetched_at = ?1,
@@ -187,8 +241,16 @@ export async function recordFetchError(
            updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
        WHERE id = ?3`,
     )
-    .bind(fetchedAt, error.slice(0, 1000), feedId)
-    .run();
+    .bind(fetchedAt, error.slice(0, 1000), feedId);
+}
+
+export async function recordFetchError(
+  db: D1Database,
+  feedId: string,
+  fetchedAt: string,
+  error: string,
+): Promise<void> {
+  await buildRecordFetchErrorStmt(db, feedId, fetchedAt, error).run();
 }
 
 export interface FeedStreak {

--- a/apps/web/worker/db/runs.ts
+++ b/apps/web/worker/db/runs.ts
@@ -31,6 +31,26 @@ export async function startRun(
   return { run_id, d1Meta: result.meta };
 }
 
+/** recordRunFeed の SQL を builder として返す。collector の per-feed batch に渡す用。 */
+export function buildRecordRunFeedStmt(
+  db: D1Database,
+  run_id: number,
+  feed_id: string,
+  status: "ok" | "failed" | "skipped",
+  articles_inserted: number,
+  duration_ms: number,
+  error?: string,
+): D1PreparedStatement {
+  // 200 文字で切り詰め。長いスタックトレースを D1 に書かないため。
+  const errorTruncated = error ? error.slice(0, 200) : null;
+  return db
+    .prepare(
+      `INSERT INTO collector_run_feeds (run_id, feed_id, status, articles_inserted, duration_ms, error)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6)`,
+    )
+    .bind(run_id, feed_id, status, articles_inserted, duration_ms, errorTruncated);
+}
+
 export async function recordRunFeed(
   db: D1Database,
   run_id: number,
@@ -40,15 +60,15 @@ export async function recordRunFeed(
   duration_ms: number,
   error?: string,
 ): Promise<D1Result["meta"]> {
-  // 200 文字で切り詰め。長いスタックトレースを D1 に書かないため。
-  const errorTruncated = error ? error.slice(0, 200) : null;
-  const result = await db
-    .prepare(
-      `INSERT INTO collector_run_feeds (run_id, feed_id, status, articles_inserted, duration_ms, error)
-       VALUES (?1, ?2, ?3, ?4, ?5, ?6)`,
-    )
-    .bind(run_id, feed_id, status, articles_inserted, duration_ms, errorTruncated)
-    .run();
+  const result = await buildRecordRunFeedStmt(
+    db,
+    run_id,
+    feed_id,
+    status,
+    articles_inserted,
+    duration_ms,
+    error,
+  ).run();
   return result.meta;
 }
 

--- a/apps/web/worker/feeds.yaml
+++ b/apps/web/worker/feeds.yaml
@@ -1,13 +1,6 @@
 version: 1
 feeds:
   # ─────────── Big tech ───────────
-  - id: google-research
-    name: Google Research Blog
-    url: https://blog.research.google/feeds/posts/default
-    category: bigtech
-    lang: en
-    enabled: true
-
   - id: google-developers
     name: Google Developers Blog
     url: https://developers.googleblog.com/feeds/posts/default
@@ -18,13 +11,6 @@ feeds:
   - id: google-cloud
     name: Google Cloud Blog
     url: https://cloudblog.withgoogle.com/rss/
-    category: bigtech
-    lang: en
-    enabled: true
-
-  - id: google-cloudplatform
-    name: Google Cloud Platform Blog
-    url: https://cloudblog.withgoogle.com/products/gcp/rss/
     category: bigtech
     lang: en
     enabled: true
@@ -127,13 +113,6 @@ feeds:
     lang: en
     enabled: true
 
-  - id: microsoft-ai-blog
-    name: Microsoft AI Blog
-    url: https://blogs.microsoft.com/ai/feed/
-    category: ai
-    lang: en
-    enabled: true
-
   # ─────────── AI labs ───────────
   - id: openai-blog
     name: OpenAI News
@@ -166,13 +145,6 @@ feeds:
   - id: huggingface-blog
     name: Hugging Face Blog
     url: https://huggingface.co/blog/feed.xml
-    category: ai
-    lang: en
-    enabled: true
-
-  - id: cohere-blog
-    name: Cohere Blog (Medium)
-    url: https://medium.com/feed/cohere-ai
     category: ai
     lang: en
     enabled: true
@@ -273,13 +245,6 @@ feeds:
   - id: pepabo-tech
     name: GMO Pepabo Tech Blog
     url: https://tech.pepabo.com/feed.xml
-    category: jp
-    lang: ja
-    enabled: true
-
-  - id: wantedly-engineering
-    name: Wantedly Engineering (Medium)
-    url: https://medium.com/feed/wantedly-engineering
     category: jp
     lang: ja
     enabled: true

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -7,6 +7,7 @@ import syndication from "./api/syndication";
 import opml from "./api/opml";
 import { rewriteShell } from "./api/spa-shell";
 import { collectAll } from "./collector";
+import { pickFeedSlot } from "./collector/slot";
 import { pruneOldArticles } from "./db/retention";
 
 const app = new Hono<{ Bindings: Env }>();
@@ -54,26 +55,41 @@ app.all("*", async (c) => {
   return rewriteShell(c.req.raw, c.env);
 });
 
+// 3 cron expression を slot 0/1/2 にマップする。Free plan の subrequest 上限 (50/invocation)
+// を満たすため、enabled feed を 3 等分して各 slot で 1 グループだけ収集する。
+// retention は slot 2 で 1 日 1 回だけ実行する。
+const SLOT_BY_CRON: Record<string, 0 | 1 | 2> = {
+  "0 16 * * *": 0,
+  "30 16 * * *": 1,
+  "0 17 * * *": 2,
+};
+
 const handler: ExportedHandler<Env> = {
   fetch: app.fetch,
-  async scheduled(_controller, env, ctx) {
+  async scheduled(controller, env, ctx) {
     // READONLY=1 の preview 環境ではコレクターを起動しない
     if (env.READONLY === "1") {
       console.log("[scheduled] READONLY mode – skipping");
       return;
     }
 
-    // 6 時間ごとの cron (0 */6 * * *): RSS 収集
+    const slot = SLOT_BY_CRON[controller.cron];
+    if (slot === undefined) {
+      console.warn(`[scheduled] unknown cron expression: ${controller.cron}`);
+      return;
+    }
+
+    const slotFeedIds = pickFeedSlot(slot, 3);
+    console.log(`[scheduled] cron=${controller.cron} slot=${slot} feeds=${slotFeedIds.length}`);
+
     ctx.waitUntil(
-      collectAll(env).catch((err) => {
+      collectAll(env, { source: "cron", feedIds: slotFeedIds }).catch((err) => {
         console.error("[scheduled] collectAll failed", err);
       }),
     );
 
-    const utcHour = new Date().getUTCHours();
-    // Run retention once per day at UTC 18:00 (JST 03:00) — 低トラフィック帯。
-    // cron `0 */6 * * *` は UTC 00,06,12,18 のみ起動するため 17 ではなく 18 に揃える。
-    if (utcHour === 18) {
+    // retention は最終 slot で 1 日 1 回だけ実行する。slot 2 = 17:00 UTC (JST 02:00)
+    if (slot === 2) {
       ctx.waitUntil(
         pruneOldArticles(env.DB, Number(env.RETENTION_DAYS ?? "90")).then((r) => {
           console.log(`[retention] deleted=${r.deleted}`);

--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -18,17 +18,22 @@ database_id = "a6cd7dbc-9f26-46d9-83c8-4a7b89405b7b"
 migrations_dir = "../../migrations"
 
 [triggers]
-# 0 */6 * * * : 6 時間ごと (UTC 00,06,12,18) — RSS 収集
-# Medium 等の外部レート制限と Worker 1 invocation あたりの subrequest 上限を緩和するため
-# 3h → 6h に頻度を下げている。新着の取り込みは最大 6 時間遅れる。
-crons = ["0 */6 * * *"]
+# Daily 3-way split (Free plan: 50 subrequests/invocation の制約を満たすため):
+#   16:00 UTC = 01:00 JST  → slot 0 (enabled feeds の 1/3)
+#   16:30 UTC = 01:30 JST  → slot 1 (enabled feeds の 1/3)
+#   17:00 UTC = 02:00 JST  → slot 2 (enabled feeds の 1/3 + retention)
+# JST 深夜時間帯に集中させ、翌朝 09:00 JST 以降の skill (since=today, 24h rolling)
+# が前日分を確実に含むようにしている (worker/index.ts の SLOT_BY_CRON も併せて更新)。
+crons = ["0 16 * * *", "30 16 * * *", "0 17 * * *"]
 
 [vars]
 # 並列 1: 同一ホスト (Medium) への並列アクセスで 429 を多発させないため。
 # fetch の wallclock は Cron の wall-time 上限内で十分収まる。
 COLLECTOR_CONCURRENCY = "1"
 COLLECTOR_TIMEOUT_MS = "10000"
-COLLECTOR_RETRIES = "2"
+# Free plan の subrequest 上限 (50 / invocation) を守るため最低限の 1 回まで。
+# 5xx / timeout は次の cron (8h 以内) で再取得されるため許容。
+COLLECTOR_RETRIES = "1"
 SUMMARY_MAX_LENGTH = "500"
 RETENTION_DAYS = "90"
 # カンマ区切りで許可する Origin を列挙。* は非推奨 (明示的 origin で制限する)
@@ -63,7 +68,7 @@ database_id = "a6cd7dbc-9f26-46d9-83c8-4a7b89405b7b"
 [env.preview.vars]
 COLLECTOR_CONCURRENCY = "1"
 COLLECTOR_TIMEOUT_MS = "10000"
-COLLECTOR_RETRIES = "2"
+COLLECTOR_RETRIES = "1"
 SUMMARY_MAX_LENGTH = "500"
 RETENTION_DAYS = "90"
 READONLY = "1"


### PR DESCRIPTION
## Summary

Cloudflare Workers Free plan の 50 subrequest/invocation 上限を厳守するため、collector の D1 書き込みを batch 化し、cron を 3 等分して 1 invocation あたりの feed 数を 1/3 に減らす。`uhyo (Zenn)` などで再発していた `Too many subrequests by single Worker invocation` を恒久解消する。

- per-feed の D1 書き込みを 1 batch に集約 (200 path: 3-5 sub → 2-3 sub、304 / error path も 2 sub)
- 初期化を `loadEnabledFeedIdsAndHeaders` で 1 query にまとめ、`syncFeeds` の orphan UPDATE も upsert と同じ batch に折り畳み
- cron を 3-way split (JST 01:00 / 01:30 / 02:00 = UTC 16:00 / 16:30 / 17:00) し、`pickFeedSlot` で id 昇順 + 連続 chunk により feed 追加時のメンバー入れ替えを局所化
- `COLLECTOR_RETRIES`: 2 → 1 (5xx / timeout は次の cron で再取得)
- dead feeds 5 件削除 (google-research / wantedly-engineering / cohere-blog / microsoft-ai-blog / google-cloudplatform)

## Subrequest budget (worst case / slot)

15 feeds × 3 sub + 1 (combined query) + 1 (syncFeeds batch) + 1 (startRun) + 1 (finishRun) + 2 (retention slot のみ) ≈ 49 sub ≤ 50 ✓

## Test plan

- [x] `pnpm test` (worker 660 / 660)
- [x] `pnpm test:client` (338 / 338)
- [x] `pnpm check` (0 errors)
- [ ] CI (deploy 後) で `wrangler tail` を観察し subrequest エラーが消えていること

Closes #393