### PR TITLE
test(worker): adopt soft assertions in db & utils specs

### DIFF
--- a/apps/web/tests/worker/db/articles.test.ts
+++ b/apps/web/tests/worker/db/articles.test.ts
@@ -174,8 +174,8 @@ describe("articles db", () => {
 
     const onlyPersonal = await listArticles(env.DB, { limit: 10, category: "personal" });
     expect(onlyPersonal.articles.map((a) => a.guid)).toEqual(["gp2", "gp1"]);
-    expect(onlyPersonal.articles[0].category).toBe("personal");
-    expect(onlyPersonal.articles[0].lang).toBe("ja");
+    expect.soft(onlyPersonal.articles[0].category).toBe("personal");
+    expect.soft(onlyPersonal.articles[0].lang).toBe("ja");
   });
 
   describe("FTS5 trigram Japanese full-text search", () => {

--- a/apps/web/tests/worker/db/feeds.test.ts
+++ b/apps/web/tests/worker/db/feeds.test.ts
@@ -104,12 +104,12 @@ describe("loadFeedHeadersAll", () => {
 
     const map = await loadFeedHeadersAll(env.DB, ["feed-a", "feed-b", "feed-c"]);
     expect(map.size).toBe(3);
-    expect(map.get("feed-a")).toEqual({
+    expect.soft(map.get("feed-a")).toEqual({
       last_etag: '"a-etag"',
       last_modified: "Mon, 01 Jan 2024 00:00:00 GMT",
     });
-    expect(map.get("feed-b")).toEqual({ last_etag: '"b-etag"', last_modified: null });
-    expect(map.get("feed-c")).toEqual({ last_etag: null, last_modified: null });
+    expect.soft(map.get("feed-b")).toEqual({ last_etag: '"b-etag"', last_modified: null });
+    expect.soft(map.get("feed-c")).toEqual({ last_etag: null, last_modified: null });
   });
 
   it("omits unknown feed ids from the returned Map", async () => {

--- a/apps/web/tests/worker/db/runs.test.ts
+++ b/apps/web/tests/worker/db/runs.test.ts
@@ -23,14 +23,14 @@ describe("runs db", () => {
 
     const runs = await listRuns(env.DB);
     expect(runs).toHaveLength(1);
-    expect(runs[0].id).toBe(run_id);
-    expect(runs[0].started_at).toBe(startedAt);
-    expect(runs[0].completed_at).toBe(completedAt);
-    expect(runs[0].feeds_total).toBe(10);
-    expect(runs[0].feeds_ok).toBe(8);
-    expect(runs[0].feeds_failed).toBe(2);
-    expect(runs[0].articles_inserted).toBe(42);
-    expect(runs[0].error).toBeNull();
+    expect.soft(runs[0].id).toBe(run_id);
+    expect.soft(runs[0].started_at).toBe(startedAt);
+    expect.soft(runs[0].completed_at).toBe(completedAt);
+    expect.soft(runs[0].feeds_total).toBe(10);
+    expect.soft(runs[0].feeds_ok).toBe(8);
+    expect.soft(runs[0].feeds_failed).toBe(2);
+    expect.soft(runs[0].articles_inserted).toBe(42);
+    expect.soft(runs[0].error).toBeNull();
   });
 
   it("startRun → recordRunFeed → getRun round-trip", async () => {
@@ -50,15 +50,15 @@ describe("runs db", () => {
 
     const feedA = detail!.feeds.find((f) => f.feed_id === "feed-a");
     expect(feedA).not.toBeUndefined();
-    expect(feedA!.status).toBe("ok");
-    expect(feedA!.articles_inserted).toBe(5);
-    expect(feedA!.duration_ms).toBe(1200);
-    expect(feedA!.error).toBeNull();
+    expect.soft(feedA!.status).toBe("ok");
+    expect.soft(feedA!.articles_inserted).toBe(5);
+    expect.soft(feedA!.duration_ms).toBe(1200);
+    expect.soft(feedA!.error).toBeNull();
 
     const feedB = detail!.feeds.find((f) => f.feed_id === "feed-b");
     expect(feedB).not.toBeUndefined();
-    expect(feedB!.status).toBe("failed");
-    expect(feedB!.error).toBe("HTTP 503 error");
+    expect.soft(feedB!.status).toBe("failed");
+    expect.soft(feedB!.error).toBe("HTTP 503 error");
   });
 
   it("getRun returns null for unknown id", async () => {
@@ -80,9 +80,9 @@ describe("runs db", () => {
     await startRun(env.DB, "2024-04-02T00:00:00.000Z", 1);
 
     const runs = await listRuns(env.DB);
-    expect(runs[0].started_at).toBe("2024-04-03T00:00:00.000Z");
-    expect(runs[1].started_at).toBe("2024-04-02T00:00:00.000Z");
-    expect(runs[2].started_at).toBe("2024-04-01T00:00:00.000Z");
+    expect.soft(runs[0].started_at).toBe("2024-04-03T00:00:00.000Z");
+    expect.soft(runs[1].started_at).toBe("2024-04-02T00:00:00.000Z");
+    expect.soft(runs[2].started_at).toBe("2024-04-01T00:00:00.000Z");
   });
 
   it("error field is truncated to 200 characters", async () => {

--- a/apps/web/tests/worker/db/runs.test.ts
+++ b/apps/web/tests/worker/db/runs.test.ts
@@ -45,7 +45,7 @@ describe("runs db", () => {
 
     const detail = await getRun(env.DB, run_id);
     expect(detail).not.toBeNull();
-    expect(detail!.run.id).toBe(run_id);
+    expect.soft(detail!.run.id).toBe(run_id);
     expect(detail!.feeds).toHaveLength(3);
 
     const feedA = detail!.feeds.find((f) => f.feed_id === "feed-a");

--- a/apps/web/tests/worker/utils/xml.test.ts
+++ b/apps/web/tests/worker/utils/xml.test.ts
@@ -60,9 +60,9 @@ describe("parseXml", () => {
         rss: { channel: { item: { title: string; link: string; guid: string } } };
       };
       const item = result.rss.channel.item;
-      expect(item.title).toBe("Post One");
-      expect(item.link).toBe("https://example.com/1");
-      expect(item.guid).toBe("guid-001");
+      expect.soft(item.title).toBe("Post One");
+      expect.soft(item.link).toBe("https://example.com/1");
+      expect.soft(item.guid).toBe("guid-001");
     });
   });
 
@@ -81,8 +81,8 @@ describe("parseXml", () => {
     it("parses entry from Atom", () => {
       const result = parseXml(ATOM_XML) as { feed: { entry: { title: string; id: string } } };
       const entry = result.feed.entry;
-      expect(entry.title).toBe("Atom Entry");
-      expect(entry.id).toBe("tag:example.com,2024:1");
+      expect.soft(entry.title).toBe("Atom Entry");
+      expect.soft(entry.id).toBe("tag:example.com,2024:1");
     });
   });
 


### PR DESCRIPTION
## 変更内容

db 層 / utils 層のテスト 4 ファイルに soft assertion を導入した (Wave 4 最終 PR)。

### 触ったファイル

| ファイル | soft 化した箇所 |
|---|---|
| `apps/web/tests/worker/db/articles.test.ts` | `inserts and retrieves personal category articles`: `articles[0].category` / `.lang` を soft 化 |
| `apps/web/tests/worker/db/feeds.test.ts` | `returns saved etag/last_modified for each feed in one query`: `map.get("feed-a/b/c")` の 3 toEqual を soft 化 |
| `apps/web/tests/worker/db/runs.test.ts` | `startRun → finishRun → listRuns round-trip`: 8 フィールドを soft 化 / `startRun → recordRunFeed → getRun round-trip`: feedA・feedB の各フィールドを soft 化 / `listRuns orders by started_at desc`: 3 観点を soft 化 |
| `apps/web/tests/worker/utils/xml.test.ts` | `parses item title from RSS`: title / link / guid を soft 化 / `parses entry from Atom`: title / id を soft 化 |

### guard で plain を維持した箇所

- `expect(inserted).toBe(2)` — 後続の `onlyPersonal.articles[0]` 参照の前提 (length == 2 のガード)
- `expect(page1.nextCursor).not.toBeNull()` — 後続の `cursor!` 使用のガード
- `expect(runs).toHaveLength(1)` — 後続の `runs[0]` 参照のガード
- `expect(detail).not.toBeNull()` — 後続の `detail!.run` / `detail!.feeds` 参照のガード
- `expect(detail!.feeds).toHaveLength(3)` — 後続の `feeds.find(...)` が意図した数のガード
- `expect(feedA).not.toBeUndefined()` — 後続の `feedA!.status` 等のガード
- `expect(feedB).not.toBeUndefined()` — 後続の `feedB!.status` 等のガード
- `expect("rss" in result).toBe(true)` 等 TypeScript narrow 観点は plain (RSS/Atom/RDF root 判別系)

### 触らないと判断したファイル

- `db/reports.test.ts` — assert 数が少なく、guard / 独立観点の区別が微妙で効果薄と判定済み
- `utils/auth.test.ts` — 各 it が単一 assert のため soft 化の恩恵なし

Closes #387

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test assertions for better failure reporting across multiple test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->