### PR TITLE
refactor(api): consolidate category/lang guards into shared module

### DIFF
--- a/apps/web/tests/worker/api/_guards.test.ts
+++ b/apps/web/tests/worker/api/_guards.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vite-plus/test";
+import { VALID_CATEGORIES, VALID_LANGS, isCategory, isLang } from "../../../worker/api/_guards";
+import type { Category, Lang } from "../../../worker/api/_guards";
+
+describe("VALID_CATEGORIES / VALID_LANGS — 配列の不変性", () => {
+  it("VALID_CATEGORIES は 4 要素を持つ", () => {
+    expect(VALID_CATEGORIES).toHaveLength(4);
+  });
+
+  it("VALID_CATEGORIES は期待する値を過不足なく含む", () => {
+    expect.soft(VALID_CATEGORIES).toContain("bigtech");
+    expect.soft(VALID_CATEGORIES).toContain("ai");
+    expect.soft(VALID_CATEGORIES).toContain("jp");
+    expect.soft(VALID_CATEGORIES).toContain("personal");
+  });
+
+  it("VALID_LANGS は 2 要素を持つ", () => {
+    expect(VALID_LANGS).toHaveLength(2);
+  });
+
+  it("VALID_LANGS は期待する値を過不足なく含む", () => {
+    expect.soft(VALID_LANGS).toContain("ja");
+    expect.soft(VALID_LANGS).toContain("en");
+  });
+});
+
+describe("isCategory", () => {
+  it("有効な全 category 値で true を返す", () => {
+    for (const v of VALID_CATEGORIES) {
+      expect.soft(isCategory(v)).toBe(true);
+    }
+  });
+
+  it("無効な文字列で false を返す", () => {
+    expect.soft(isCategory("unknown")).toBe(false);
+    expect.soft(isCategory("")).toBe(false);
+    expect.soft(isCategory("BIGTECH")).toBe(false);
+    expect.soft(isCategory("AI")).toBe(false);
+  });
+
+  it("string 以外の型で false を返す", () => {
+    expect.soft(isCategory(null)).toBe(false);
+    expect.soft(isCategory(undefined)).toBe(false);
+    expect.soft(isCategory(42)).toBe(false);
+    expect.soft(isCategory({})).toBe(false);
+  });
+
+  it("narrow 後の値を Category 型として代入できる", () => {
+    const raw: unknown = "ai";
+    if (isCategory(raw)) {
+      // コンパイルエラーなく代入できれば型が正しく narrow されている
+      const cat: Category = raw;
+      expect(cat).toBe("ai");
+    } else {
+      expect.fail("isCategory('ai') should return true");
+    }
+  });
+});
+
+describe("isLang", () => {
+  it("有効な全 lang 値で true を返す", () => {
+    for (const v of VALID_LANGS) {
+      expect.soft(isLang(v)).toBe(true);
+    }
+  });
+
+  it("無効な文字列で false を返す", () => {
+    expect.soft(isLang("zh")).toBe(false);
+    expect.soft(isLang("")).toBe(false);
+    expect.soft(isLang("JA")).toBe(false);
+    expect.soft(isLang("EN")).toBe(false);
+  });
+
+  it("string 以外の型で false を返す", () => {
+    expect.soft(isLang(null)).toBe(false);
+    expect.soft(isLang(undefined)).toBe(false);
+    expect.soft(isLang(0)).toBe(false);
+    expect.soft(isLang(false)).toBe(false);
+  });
+
+  it("narrow 後の値を Lang 型として代入できる", () => {
+    const raw: unknown = "ja";
+    if (isLang(raw)) {
+      // コンパイルエラーなく代入できれば型が正しく narrow されている
+      const lang: Lang = raw;
+      expect(lang).toBe("ja");
+    } else {
+      expect.fail("isLang('ja') should return true");
+    }
+  });
+});

--- a/apps/web/tests/worker/api/_guards.test.ts
+++ b/apps/web/tests/worker/api/_guards.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 import { VALID_CATEGORIES, VALID_LANGS, isCategory, isLang } from "../../../worker/api/_guards";
-import type { Category, Lang } from "../../../worker/api/_guards";
+import type { FeedCategory, FeedLang } from "../../../worker/types";
 
 describe("VALID_CATEGORIES / VALID_LANGS — 配列の不変性", () => {
   it("VALID_CATEGORIES は 4 要素を持つ", () => {
@@ -45,11 +45,11 @@ describe("isCategory", () => {
     expect.soft(isCategory({})).toBe(false);
   });
 
-  it("narrow 後の値を Category 型として代入できる", () => {
+  it("narrow 後の値を FeedCategory 型として代入できる", () => {
     const raw: unknown = "ai";
     if (isCategory(raw)) {
       // コンパイルエラーなく代入できれば型が正しく narrow されている
-      const cat: Category = raw;
+      const cat: FeedCategory = raw;
       expect(cat).toBe("ai");
     } else {
       expect.fail("isCategory('ai') should return true");
@@ -78,11 +78,11 @@ describe("isLang", () => {
     expect.soft(isLang(false)).toBe(false);
   });
 
-  it("narrow 後の値を Lang 型として代入できる", () => {
+  it("narrow 後の値を FeedLang 型として代入できる", () => {
     const raw: unknown = "ja";
     if (isLang(raw)) {
       // コンパイルエラーなく代入できれば型が正しく narrow されている
-      const lang: Lang = raw;
+      const lang: FeedLang = raw;
       expect(lang).toBe("ja");
     } else {
       expect.fail("isLang('ja') should return true");

--- a/apps/web/worker/api/_guards.ts
+++ b/apps/web/worker/api/_guards.ts
@@ -6,10 +6,8 @@ export const VALID_CATEGORIES = [
   "jp",
   "personal",
 ] as const satisfies readonly FeedCategory[];
-export type Category = (typeof VALID_CATEGORIES)[number];
 
 export const VALID_LANGS = ["ja", "en"] as const satisfies readonly FeedLang[];
-export type Lang = (typeof VALID_LANGS)[number];
 
 // unknown を受け取れるよう定義することで、URL パラメータ (string | null | undefined) と
 // リクエスト body のフィールド (unknown) の両方から呼び出せる。

--- a/apps/web/worker/api/_guards.ts
+++ b/apps/web/worker/api/_guards.ts
@@ -1,0 +1,25 @@
+import type { FeedCategory, FeedLang } from "../types";
+
+export const VALID_CATEGORIES = [
+  "bigtech",
+  "ai",
+  "jp",
+  "personal",
+] as const satisfies readonly FeedCategory[];
+export type Category = (typeof VALID_CATEGORIES)[number];
+
+export const VALID_LANGS = ["ja", "en"] as const satisfies readonly FeedLang[];
+export type Lang = (typeof VALID_LANGS)[number];
+
+// unknown を受け取れるよう定義することで、URL パラメータ (string | null | undefined) と
+// リクエスト body のフィールド (unknown) の両方から呼び出せる。
+const _categorySet = new Set<string>(VALID_CATEGORIES);
+const _langSet = new Set<string>(VALID_LANGS);
+
+export function isCategory(value: unknown): value is FeedCategory {
+  return typeof value === "string" && _categorySet.has(value);
+}
+
+export function isLang(value: unknown): value is FeedLang {
+  return typeof value === "string" && _langSet.has(value);
+}

--- a/apps/web/worker/api/articles.ts
+++ b/apps/web/worker/api/articles.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import type { Context } from "hono";
-import type { Env, FeedCategory, FeedLang } from "../types";
+import type { Env } from "../types";
 import { loadAllFeeds } from "../feed-config";
 import {
   countArticlesByDay,
@@ -35,26 +35,16 @@ import type {
   ArticleRelatedResponse,
   ArticleSearchResponse,
 } from "./types";
-import { makeOneOf } from "../utils/types";
+import { isCategory, isLang } from "./_guards";
 
 const FEEDS_VERSION = (feedsYaml as FeedsFile).version;
 
 const app = new Hono<{ Bindings: Env }>();
 
-const VALID_CATEGORIES = [
-  "bigtech",
-  "ai",
-  "jp",
-  "personal",
-] as const satisfies readonly FeedCategory[];
-const VALID_LANGS = ["ja", "en"] as const satisfies readonly FeedLang[];
 const VALID_FEED_IDS = new Set(loadAllFeeds().map((f) => f.id));
 const VALID_CALENDAR_DAYS = [7, 30, 90, 365] as const;
 // URL パラメータの長さ上限。意図せず長い文字列が D1 クエリに流れ込むのを防ぐ
 const MAX_PARAM_LENGTH = 200;
-
-const isCategory = makeOneOf<FeedCategory>(VALID_CATEGORIES);
-const isLang = makeOneOf<FeedLang>(VALID_LANGS);
 
 // ISO 8601 の日時部分 (時刻まで)。decodeCursor の publishedAt 検証と
 // since/until の ISO 形式チェック (時刻部分以降は内部で 10 文字に切り詰めて検証) に共用する。

--- a/apps/web/worker/api/feeds.ts
+++ b/apps/web/worker/api/feeds.ts
@@ -3,13 +3,10 @@ import { loadAllFeeds } from "../feed-config";
 import type { Env, FeedCategory, FeedLang } from "../types";
 import { findFeedWithStats, getRecentArticlesByFeed, listFeedsWithStats } from "../db/feeds";
 import { getFeedHealth } from "../db/runs";
-import { makeOneOf } from "../utils/types";
+import { isCategory, isLang } from "./_guards";
 import type { FeedsListResponse, FeedDetailResponse, FeedRunHealthResponse } from "./types";
 
 const app = new Hono<{ Bindings: Env }>();
-
-const isCategory = makeOneOf<FeedCategory>(["bigtech", "ai", "jp", "personal"]);
-const isLang = makeOneOf<FeedLang>(["ja", "en"]);
 
 app.get("/", async (c) => {
   const { req } = c;

--- a/apps/web/worker/api/reports.ts
+++ b/apps/web/worker/api/reports.ts
@@ -9,6 +9,7 @@ import type {
   AdminReportOverlapResponse,
   AdminReportSaveResponse,
 } from "./types";
+import { isCategory, isLang } from "./_guards";
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -17,8 +18,6 @@ const app = new Hono<{ Bindings: Env }>();
 app.use("*", adminAuthMiddleware);
 
 const VALID_KINDS = new Set<ReportKind>(["daily", "weekly", "monthly"]);
-const VALID_CATEGORIES = new Set(["bigtech", "ai", "jp", "personal"]);
-const VALID_LANGS = new Set(["ja", "en"]);
 // content が極端に長くなるのを防ぐ (D1 の row size と Worker の CPU 時間を意識)。
 // 1MB は markdown レポートとしては十分すぎる量。
 const MAX_CONTENT_BYTES = 1_000_000;
@@ -77,7 +76,7 @@ function parseInput(
 
   let category: string | null = null;
   if (body.category !== undefined && body.category !== null) {
-    if (typeof body.category !== "string" || !VALID_CATEGORIES.has(body.category)) {
+    if (!isCategory(body.category)) {
       return {
         ok: false,
         error: "category must be one of: bigtech | ai | jp | personal (or null)",
@@ -88,7 +87,7 @@ function parseInput(
 
   let lang: string | null = null;
   if (body.lang !== undefined && body.lang !== null) {
-    if (typeof body.lang !== "string" || !VALID_LANGS.has(body.lang)) {
+    if (!isLang(body.lang)) {
       return { ok: false, error: "lang must be one of: ja | en (or null)" };
     }
     lang = body.lang;

--- a/apps/web/worker/api/syndication.ts
+++ b/apps/web/worker/api/syndication.ts
@@ -5,24 +5,14 @@ import { listArticles } from "../db/articles";
 import { computeSyndicationEtag } from "../utils/etag";
 import { loadAllFeeds } from "../feed-config";
 import feedsYaml from "../feeds.yaml";
-import { makeOneOf } from "../utils/types";
 import { buildUrlParts } from "./syndication/shared";
 import type { FeedMeta } from "./syndication/shared";
 import { renderJsonFeed } from "./syndication/json";
 import { renderAtomFeed } from "./syndication/atom";
 import { renderRssFeed } from "./syndication/rss";
+import { isCategory, isLang } from "./_guards";
 
 const FEEDS_VERSION = (feedsYaml as FeedsFile).version;
-
-const VALID_CATEGORIES = [
-  "bigtech",
-  "ai",
-  "jp",
-  "personal",
-] as const satisfies readonly FeedCategory[];
-const VALID_LANGS = ["ja", "en"] as const satisfies readonly FeedLang[];
-const isCategory = makeOneOf<FeedCategory>(VALID_CATEGORIES);
-const isLang = makeOneOf<FeedLang>(VALID_LANGS);
 const FEED_LIMIT = 50;
 const SITE_TITLE = "Tech News Bot";
 const SITE_DESCRIPTION = "Big tech / AI / 日本企業の technical blog を集約した RSS / JSON Feed";


### PR DESCRIPTION
## Summary

- `apps/web/worker/api/_guards.ts` を新規作成し、`VALID_CATEGORIES` / `VALID_LANGS` / `isCategory` / `isLang` / `Category` / `Lang` を集約
- `articles.ts` (L44-57) と `syndication.ts` (L17-25) から重複定義を削除し、`_guards` からの import に置き換え
- `reports.ts` の `Set<string>` ベースの `VALID_CATEGORIES` / `VALID_LANGS` を削除し、型ガード `isCategory` / `isLang` に統一

## reports.ts で見つかった差分

`reports.ts` は `new Set(["bigtech", "ai", "jp", "personal"])` という `Set<string>` ベースで定義しており、`FeedCategory` 型との関連がなかった。中身は他 2 ファイルと一致していたため、差分なく `isCategory`/`isLang` に置き換え可能だった。

また `isCategory`/`isLang` は `unknown` を受け取るよう実装することで、URL パラメータ (`string | null | undefined`) と body フィールド (`unknown`) の両方から型エラーなく呼び出せる。

## テスト

`apps/web/tests/worker/api/_guards.test.ts` を新規追加:
- `isCategory` / `isLang` の全有効値で `true`、無効文字列・非 string 型で `false`
- narrow 後の値を `Category` / `Lang` 型として代入できることをコンパイル + 実行で確認
- `VALID_CATEGORIES` / `VALID_LANGS` の要素数と中身を assert

Closes #397