### PR TITLE
test(worker): adopt soft assertions in mechanically replaceable specs

### DIFF
--- a/apps/web/tests/worker/api/admin-cron-health.test.ts
+++ b/apps/web/tests/worker/api/admin-cron-health.test.ts
@@ -77,13 +77,13 @@ describe("GET /api/admin/cron-health", () => {
       articles_collected: number;
       top_failing_feeds: unknown[];
     };
-    expect(body.window_days).toBe(7);
-    expect(body.runs_total).toBe(0);
-    expect(body.runs_succeeded).toBe(0);
-    expect(body.runs_failed).toBe(0);
-    expect(body.articles_collected).toBe(0);
-    expect(Array.isArray(body.top_failing_feeds)).toBe(true);
-    expect(body.top_failing_feeds).toHaveLength(0);
+    expect.soft(body.window_days).toBe(7);
+    expect.soft(body.runs_total).toBe(0);
+    expect.soft(body.runs_succeeded).toBe(0);
+    expect.soft(body.runs_failed).toBe(0);
+    expect.soft(body.articles_collected).toBe(0);
+    expect.soft(Array.isArray(body.top_failing_feeds)).toBe(true);
+    expect.soft(body.top_failing_feeds).toHaveLength(0);
   });
 
   it("200: runs_total / runs_succeeded / runs_failed のカウントが正しい", async () => {
@@ -103,10 +103,10 @@ describe("GET /api/admin/cron-health", () => {
       runs_failed: number;
       articles_collected: number;
     };
-    expect(body.runs_total).toBe(3);
-    expect(body.runs_succeeded).toBe(2);
-    expect(body.runs_failed).toBe(1);
-    expect(body.articles_collected).toBe(8);
+    expect.soft(body.runs_total).toBe(3);
+    expect.soft(body.runs_succeeded).toBe(2);
+    expect.soft(body.runs_failed).toBe(1);
+    expect.soft(body.articles_collected).toBe(8);
   });
 
   it("200: top_failing_feeds が failures 降順", async () => {
@@ -126,10 +126,10 @@ describe("GET /api/admin/cron-health", () => {
     };
     // feed-a (failures=2) が feed-b (failures=1) より先
     expect(body.top_failing_feeds.length).toBeGreaterThanOrEqual(2);
-    expect(body.top_failing_feeds[0].feed_id).toBe("feed-a");
-    expect(body.top_failing_feeds[0].failures).toBe(2);
-    expect(body.top_failing_feeds[1].feed_id).toBe("feed-b");
-    expect(body.top_failing_feeds[1].failures).toBe(1);
+    expect.soft(body.top_failing_feeds[0].feed_id).toBe("feed-a");
+    expect.soft(body.top_failing_feeds[0].failures).toBe(2);
+    expect.soft(body.top_failing_feeds[1].feed_id).toBe("feed-b");
+    expect.soft(body.top_failing_feeds[1].failures).toBe(1);
   });
 
   it("200: days=7 で古いデータは含まれない", async () => {
@@ -153,8 +153,8 @@ describe("GET /api/admin/cron-health", () => {
     });
     expect(res.status).toBe(200);
     const body = (await res.json()) as { runs_total: number; window_days: number };
-    expect(body.window_days).toBe(30);
-    expect(body.runs_total).toBe(1);
+    expect.soft(body.window_days).toBe(30);
+    expect.soft(body.runs_total).toBe(1);
   });
 
   it("200: Cache-Control ヘッダが private, max-age=60 を含む", async () => {
@@ -163,7 +163,7 @@ describe("GET /api/admin/cron-health", () => {
     });
     expect(res.status).toBe(200);
     const cacheControl = res.headers.get("cache-control") ?? "";
-    expect(cacheControl).toContain("private");
-    expect(cacheControl).toContain("max-age=60");
+    expect.soft(cacheControl).toContain("private");
+    expect.soft(cacheControl).toContain("max-age=60");
   });
 });

--- a/apps/web/tests/worker/api/catalog.test.ts
+++ b/apps/web/tests/worker/api/catalog.test.ts
@@ -7,8 +7,8 @@ const CATALOG_URL = "https://example.com/api";
 describe("GET /api (catalog endpoint)", () => {
   it("returns 200 with JSON body", async () => {
     const res = await SELF.fetch(CATALOG_URL);
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Content-Type")).toContain("application/json");
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Content-Type")).toContain("application/json");
   });
 
   it("sets Cache-Control: public, max-age=3600", async () => {
@@ -19,12 +19,12 @@ describe("GET /api (catalog endpoint)", () => {
   it("response has name, version, description, endpoints, syndication, docs_url fields", async () => {
     const res = await SELF.fetch(CATALOG_URL);
     const body = await res.json<Record<string, unknown>>();
-    expect(typeof body["name"]).toBe("string");
-    expect(typeof body["version"]).toBe("string");
-    expect(typeof body["description"]).toBe("string");
-    expect(Array.isArray(body["endpoints"])).toBe(true);
-    expect(Array.isArray(body["syndication"])).toBe(true);
-    expect(typeof body["docs_url"]).toBe("string");
+    expect.soft(typeof body["name"]).toBe("string");
+    expect.soft(typeof body["version"]).toBe("string");
+    expect.soft(typeof body["description"]).toBe("string");
+    expect.soft(Array.isArray(body["endpoints"])).toBe(true);
+    expect.soft(Array.isArray(body["syndication"])).toBe(true);
+    expect.soft(typeof body["docs_url"]).toBe("string");
   });
 
   it("endpoints array contains entries with method, path, description, auth fields", async () => {
@@ -87,10 +87,10 @@ describe("GET /api (catalog endpoint)", () => {
     const hasRss = formats.some((f) => f.includes("RSS"));
     const hasAtom = formats.some((f) => f.includes("Atom"));
     const hasOpml = formats.some((f) => f.includes("OPML"));
-    expect(hasJsonFeed).toBe(true);
-    expect(hasRss).toBe(true);
-    expect(hasAtom).toBe(true);
-    expect(hasOpml).toBe(true);
+    expect.soft(hasJsonFeed).toBe(true);
+    expect.soft(hasRss).toBe(true);
+    expect.soft(hasAtom).toBe(true);
+    expect.soft(hasOpml).toBe(true);
   });
 
   it("docs_url points to the GitHub repository", async () => {

--- a/apps/web/tests/worker/api/index-page.test.ts
+++ b/apps/web/tests/worker/api/index-page.test.ts
@@ -20,15 +20,15 @@ describe("GET /api", () => {
   it("endpoints array is non-empty", async () => {
     const res = await SELF.fetch("https://example.com/api");
     const body = (await res.json()) as { endpoints: unknown[] };
-    expect(Array.isArray(body.endpoints)).toBe(true);
-    expect(body.endpoints.length).toBeGreaterThan(0);
+    expect.soft(Array.isArray(body.endpoints)).toBe(true);
+    expect.soft(body.endpoints.length).toBeGreaterThan(0);
   });
 
   it("syndication array is non-empty", async () => {
     const res = await SELF.fetch("https://example.com/api");
     const body = (await res.json()) as { syndication: unknown[] };
-    expect(Array.isArray(body.syndication)).toBe(true);
-    expect(body.syndication.length).toBeGreaterThan(0);
+    expect.soft(Array.isArray(body.syndication)).toBe(true);
+    expect.soft(body.syndication.length).toBeGreaterThan(0);
   });
 
   it("contains /api/articles endpoint", async () => {
@@ -79,8 +79,8 @@ describe("GET /api", () => {
   it("name and version fields are present", async () => {
     const res = await SELF.fetch("https://example.com/api");
     const body = (await res.json()) as { name: string; version: string };
-    expect(typeof body.name).toBe("string");
-    expect(body.name.length).toBeGreaterThan(0);
-    expect(typeof body.version).toBe("string");
+    expect.soft(typeof body.name).toBe("string");
+    expect.soft(body.name.length).toBeGreaterThan(0);
+    expect.soft(typeof body.version).toBe("string");
   });
 });

--- a/apps/web/tests/worker/api/openapi.test.ts
+++ b/apps/web/tests/worker/api/openapi.test.ts
@@ -4,13 +4,14 @@ import { SELF } from "cloudflare:test";
 describe("/api/openapi.json", () => {
   it("returns 200 with valid JSON and openapi 3.1.0", async () => {
     const res = await SELF.fetch("https://example.com/api/openapi.json");
-    expect.soft(res.status).toBe(200);
+    expect(res.status).toBe(200);
     const body = (await res.json()) as { openapi: string };
     expect.soft(body.openapi).toBe("3.1.0");
   });
 
   it("contains expected paths", async () => {
     const res = await SELF.fetch("https://example.com/api/openapi.json");
+    expect(res.status).toBe(200);
     const body = (await res.json()) as { paths: Record<string, unknown> };
     const paths = Object.keys(body.paths);
     expect.soft(paths).toContain("/api/articles");
@@ -25,7 +26,7 @@ describe("/api/openapi.json", () => {
 describe("/api/docs", () => {
   it("returns 200 with text/html", async () => {
     const res = await SELF.fetch("https://example.com/api/docs");
-    expect.soft(res.status).toBe(200);
+    expect(res.status).toBe(200);
     expect.soft(res.headers.get("Content-Type")).toContain("text/html");
   });
 

--- a/apps/web/tests/worker/api/openapi.test.ts
+++ b/apps/web/tests/worker/api/openapi.test.ts
@@ -4,36 +4,36 @@ import { SELF } from "cloudflare:test";
 describe("/api/openapi.json", () => {
   it("returns 200 with valid JSON and openapi 3.1.0", async () => {
     const res = await SELF.fetch("https://example.com/api/openapi.json");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = (await res.json()) as { openapi: string };
-    expect(body.openapi).toBe("3.1.0");
+    expect.soft(body.openapi).toBe("3.1.0");
   });
 
   it("contains expected paths", async () => {
     const res = await SELF.fetch("https://example.com/api/openapi.json");
     const body = (await res.json()) as { paths: Record<string, unknown> };
     const paths = Object.keys(body.paths);
-    expect(paths).toContain("/api/articles");
-    expect(paths).toContain("/api/feeds");
-    expect(paths).toContain("/api/stats");
-    expect(paths).toContain("/api/health");
-    expect(paths).toContain("/feed.json");
-    expect(paths).toContain("/feed.xml");
+    expect.soft(paths).toContain("/api/articles");
+    expect.soft(paths).toContain("/api/feeds");
+    expect.soft(paths).toContain("/api/stats");
+    expect.soft(paths).toContain("/api/health");
+    expect.soft(paths).toContain("/feed.json");
+    expect.soft(paths).toContain("/feed.xml");
   });
 });
 
 describe("/api/docs", () => {
   it("returns 200 with text/html", async () => {
     const res = await SELF.fetch("https://example.com/api/docs");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Content-Type")).toContain("text/html");
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Content-Type")).toContain("text/html");
   });
 
   it("HTML contains swagger-ui div and bundle script", async () => {
     const res = await SELF.fetch("https://example.com/api/docs");
     const body = await res.text();
-    expect(body).toContain('id="swagger-ui"');
-    expect(body).toContain("swagger-ui-bundle.js");
+    expect.soft(body).toContain('id="swagger-ui"');
+    expect.soft(body).toContain("swagger-ui-bundle.js");
   });
 
   it("spec URL points to /api/openapi.json", async () => {

--- a/apps/web/tests/worker/api/opml.test.ts
+++ b/apps/web/tests/worker/api/opml.test.ts
@@ -7,8 +7,8 @@ import { SELF } from "cloudflare:test";
 describe("GET /feeds.opml", () => {
   it("returns 200 with text/x-opml Content-Type", async () => {
     const res = await SELF.fetch("https://example.com/feeds.opml");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Content-Type")).toContain("text/x-opml");
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Content-Type")).toContain("text/x-opml");
   });
 
   it('body contains <opml version="2.0">', async () => {
@@ -26,30 +26,30 @@ describe("GET /feeds.opml", () => {
   it("contains all 4 category outlines", async () => {
     const res = await SELF.fetch("https://example.com/feeds.opml");
     const text = await res.text();
-    expect(text).toContain('text="Big Tech"');
-    expect(text).toContain('text="AI Labs"');
-    expect(text).toContain('text="国内エンジニアリング"');
-    expect(text).toContain('text="個人ブログ"');
+    expect.soft(text).toContain('text="Big Tech"');
+    expect.soft(text).toContain('text="AI Labs"');
+    expect.soft(text).toContain('text="国内エンジニアリング"');
+    expect.soft(text).toContain('text="個人ブログ"');
   });
 
   it("contains outline elements with type=rss, xmlUrl and htmlUrl", async () => {
     const res = await SELF.fetch("https://example.com/feeds.opml");
     const text = await res.text();
     // type="rss" の outline が存在すること
-    expect(text).toContain('type="rss"');
+    expect.soft(text).toContain('type="rss"');
     // xmlUrl はこのサービスの /feeds/<id>.xml を指すこと
-    expect(text).toMatch(/xmlUrl="https:\/\/example\.com\/feeds\/[^"]+\.xml"/);
+    expect.soft(text).toMatch(/xmlUrl="https:\/\/example\.com\/feeds\/[^"]+\.xml"/);
     // htmlUrl は元の feed URL を指すこと
-    expect(text).toContain('htmlUrl="');
+    expect.soft(text).toContain('htmlUrl="');
   });
 
   it("xmlUrl points to this service origin with /feeds/<id>.xml path", async () => {
     const res = await SELF.fetch("https://example.com/feeds.opml");
     const text = await res.text();
     // google-developers フィードの xmlUrl がサービス自身のオリジンを使っていること
-    expect(text).toContain('xmlUrl="https://example.com/feeds/google-developers.xml"');
+    expect.soft(text).toContain('xmlUrl="https://example.com/feeds/google-developers.xml"');
     // htmlUrl は feeds.yaml の元 URL を指すこと
-    expect(text).toContain('htmlUrl="https://developers.googleblog.com/feeds/posts/default"');
+    expect.soft(text).toContain('htmlUrl="https://developers.googleblog.com/feeds/posts/default"');
   });
 
   it("enabled: false feeds are excluded", async () => {
@@ -57,24 +57,24 @@ describe("GET /feeds.opml", () => {
     // 現状は全フィードが enabled: true のため、
     // 存在するフィードが XML に含まれることのみ確認する。
     const res = await SELF.fetch("https://example.com/feeds.opml");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const text = await res.text();
     // 少なくとも 1 つ以上の type="rss" outline が含まれること
     const matches = text.match(/type="rss"/g);
-    expect(matches).not.toBeNull();
-    expect((matches ?? []).length).toBeGreaterThan(0);
+    expect.soft(matches).not.toBeNull();
+    expect.soft((matches ?? []).length).toBeGreaterThan(0);
   });
 
   it("ETag round-trip returns 304 on If-None-Match", async () => {
     const first = await SELF.fetch("https://example.com/feeds.opml");
     expect(first.status).toBe(200);
     const etag = first.headers.get("ETag");
-    expect(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
+    expect.soft(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
 
     const second = await SELF.fetch("https://example.com/feeds.opml", {
       headers: { "If-None-Match": etag! },
     });
-    expect(second.status).toBe(304);
+    expect.soft(second.status).toBe(304);
   });
 
   it("ETag changes when If-None-Match does not match", async () => {

--- a/apps/web/tests/worker/api/opml.test.ts
+++ b/apps/web/tests/worker/api/opml.test.ts
@@ -69,7 +69,7 @@ describe("GET /feeds.opml", () => {
     const first = await SELF.fetch("https://example.com/feeds.opml");
     expect(first.status).toBe(200);
     const etag = first.headers.get("ETag");
-    expect.soft(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
+    expect(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
 
     const second = await SELF.fetch("https://example.com/feeds.opml", {
       headers: { "If-None-Match": etag! },

--- a/apps/web/tests/worker/api/reports-public.test.ts
+++ b/apps/web/tests/worker/api/reports-public.test.ts
@@ -52,8 +52,8 @@ describe("GET /api/reports (公開一覧)", () => {
     const res = await SELF.fetch("https://example.com/api/reports");
     expect(res.status).toBe(200);
     const body = (await res.json()) as AdminReportListResponse;
-    expect(Array.isArray(body.reports)).toBe(true);
-    expect(body.reports.length).toBeGreaterThanOrEqual(1);
+    expect.soft(Array.isArray(body.reports)).toBe(true);
+    expect.soft(body.reports.length).toBeGreaterThanOrEqual(1);
   });
 
   it("200: kind フィルタが効く", async () => {
@@ -89,8 +89,8 @@ describe("GET /api/reports (公開一覧)", () => {
     const res = await SELF.fetch("https://example.com/api/reports", {
       headers: { origin: allowedOrigin },
     });
-    expect(res.status).toBe(200);
-    expect(res.headers.get("access-control-allow-origin")).toBe(allowedOrigin);
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("access-control-allow-origin")).toBe(allowedOrigin);
   });
 });
 
@@ -101,7 +101,7 @@ describe("GET /api/reports/:id (公開詳細)", () => {
     const res = await SELF.fetch(`https://example.com/api/reports/${id}`);
     expect(res.status).toBe(200);
     const body = (await res.json()) as AdminReportDetailResponse;
-    expect(body.report.content).toBe("detail content");
+    expect.soft(body.report.content).toBe("detail content");
   });
 
   it("404: 存在しない id", async () => {
@@ -121,7 +121,7 @@ describe("GET /api/reports/:id (公開詳細)", () => {
     const res = await SELF.fetch(`https://example.com/api/reports/${id}`, {
       headers: { origin: allowedOrigin },
     });
-    expect(res.status).toBe(200);
-    expect(res.headers.get("access-control-allow-origin")).toBe(allowedOrigin);
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("access-control-allow-origin")).toBe(allowedOrigin);
   });
 });

--- a/apps/web/tests/worker/api/sitemap.test.ts
+++ b/apps/web/tests/worker/api/sitemap.test.ts
@@ -4,11 +4,11 @@ import { SELF } from "cloudflare:test";
 describe("/robots.txt", () => {
   it("returns 200 with Content-Type text/plain", async () => {
     const res = await SELF.fetch("https://example.com/robots.txt");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Content-Type")).toContain("text/plain");
-    expect(res.headers.get("Cache-Control")).toBe(
-      "public, max-age=3600, stale-while-revalidate=86400",
-    );
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Content-Type")).toContain("text/plain");
+    expect
+      .soft(res.headers.get("Cache-Control"))
+      .toBe("public, max-age=3600, stale-while-revalidate=86400");
   });
 
   it("contains User-agent: *", async () => {
@@ -33,28 +33,28 @@ describe("/robots.txt", () => {
 describe("/sitemap.xml", () => {
   it("returns 200 with Content-Type application/xml", async () => {
     const res = await SELF.fetch("https://example.com/sitemap.xml");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Content-Type")).toContain("application/xml");
-    expect(res.headers.get("Cache-Control")).toBe(
-      "public, max-age=3600, stale-while-revalidate=86400",
-    );
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Content-Type")).toContain("application/xml");
+    expect
+      .soft(res.headers.get("Cache-Control"))
+      .toBe("public, max-age=3600, stale-while-revalidate=86400");
   });
 
   it("contains root URL <loc>", async () => {
     const res = await SELF.fetch("https://example.com/sitemap.xml");
     const text = await res.text();
-    expect(text).toContain("<loc>https://example.com/</loc>");
-    expect(text).toContain("<priority>1.0</priority>");
-    expect(text).toContain("<changefreq>hourly</changefreq>");
+    expect.soft(text).toContain("<loc>https://example.com/</loc>");
+    expect.soft(text).toContain("<priority>1.0</priority>");
+    expect.soft(text).toContain("<changefreq>hourly</changefreq>");
   });
 
   it("contains enabled feed_id URL (google-developers)", async () => {
     const res = await SELF.fetch("https://example.com/sitemap.xml");
     const text = await res.text();
     // feeds.yaml で enabled: true のフィードが含まれること
-    expect(text).toContain("/?feed_id=google-developers");
-    expect(text).toContain("<changefreq>daily</changefreq>");
-    expect(text).toContain("<priority>0.6</priority>");
+    expect.soft(text).toContain("/?feed_id=google-developers");
+    expect.soft(text).toContain("<changefreq>daily</changefreq>");
+    expect.soft(text).toContain("<priority>0.6</priority>");
   });
 
   it("does not include /api/openapi.json (not a content page)", async () => {

--- a/apps/web/tests/worker/db/retention.test.ts
+++ b/apps/web/tests/worker/db/retention.test.ts
@@ -53,11 +53,11 @@ describe("pruneOldArticles", () => {
 
     const result = await pruneOldArticles(env.DB, 90);
 
-    expect(result.deleted).toBe(1);
+    expect.soft(result.deleted).toBe(1);
     const remaining = await env.DB.prepare("SELECT guid FROM articles ORDER BY guid").all<{
       guid: string;
     }>();
-    expect(remaining.results?.map((r) => r.guid)).toEqual(["g-recent"]);
+    expect.soft(remaining.results?.map((r) => r.guid)).toEqual(["g-recent"]);
   });
 
   it("is a no-op when days is 0", async () => {


### PR DESCRIPTION
## Summary

Wave 4 アンブレラ issue #387 の機械的置換パート。8 つの worker テストファイルで、独立した複数観点を assert している箇所を `expect.soft(...)` に置換した。

## 変更ファイルと判断

- **admin-cron-health.test.ts**
  - `"200: データなし"` — body の 7 フィールドを soft 化
  - `"カウントが正しい"` — 4 カウントを soft 化
  - `"top_failing_feeds が failures 降順"` — `length >= 2` は guard (plain)、`[0]`/`[1]` の各フィールドを soft 化
  - `"days=30 で含まれる"` — window_days + runs_total を soft 化
  - `"Cache-Control"` — private + max-age=60 を soft 化

- **catalog.test.ts**
  - `"returns 200 with JSON body"` — status + Content-Type を soft 化
  - `"response has ... fields"` — 6 フィールドの typeof を soft 化
  - `"syndication includes ... formats"` — 4 フォーマットの真偽を soft 化
  - for ループ内の expect は密結合のため plain のまま

- **index-page.test.ts**
  - `"endpoints array is non-empty"` — Array.isArray + length > 0 を soft 化
  - `"syndication array is non-empty"` — 同上
  - `"name and version fields are present"` — 3 観点を soft 化
  - 単独 assert の it は触らない

- **openapi.test.ts**
  - 全 it を soft 化（guard なし）

- **opml.test.ts**
  - `"returns 200 with text/x-opml Content-Type"` — status + Content-Type を soft 化
  - `"contains all 4 category outlines"` — 4 観点を soft 化
  - `"contains outline elements"` — 3 観点を soft 化
  - `"xmlUrl points to ..."` — 2 観点を soft 化
  - `"enabled: false feeds are excluded"` — status + matches の 3 観点を soft 化（`?? []` で回避済みなので guard 不要）
  - `"ETag round-trip"` — 最初の `status == 200` は etag 取得の前提のため **plain のまま guard**。etag の形式チェックと 304 を soft 化

- **reports-public.test.ts**
  - `"挿入したレポートが含まれる"` — Array.isArray + length >= 1 を soft 化
  - `"CORS ヘッダが付く"` (一覧) — status + allow-origin を soft 化
  - `"200: 認証なしでアクセスできる"` (詳細) — status は guard (plain)、content を soft 化
  - `"CORS ヘッダが付く"` (詳細) — status + allow-origin を soft 化

- **sitemap.test.ts**
  - `"returns 200 with Content-Type text/plain"` — 3 観点を soft 化
  - `"returns 200 with Content-Type application/xml"` — 3 観点を soft 化
  - `"contains root URL <loc>"` — 3 観点を soft 化
  - `"contains enabled feed_id URL"` — 3 観点を soft 化
  - 既存の soft はそのまま

- **db/retention.test.ts**
  - `"removes articles older than the retention window"` — result.deleted と remaining.map の独立 2 観点を soft 化（`?.` でアクセスしているので guard 不要）

## テスト結果

`pnpm test` (worker テスト) 全 753 件 pass

Refs #387