### PR TITLE
test(worker): adopt soft assertions in api specs requiring guard judgement

### DIFF
--- a/apps/web/tests/worker/api/admin-feeds-diagnostics.test.ts
+++ b/apps/web/tests/worker/api/admin-feeds-diagnostics.test.ts
@@ -62,8 +62,8 @@ describe("GET /api/admin/feeds/diagnostics", () => {
     });
     expect(res.status).toBe(200);
     const cc = res.headers.get("cache-control") ?? "";
-    expect(cc).toContain("private");
-    expect(cc).toContain("max-age=30");
+    expect.soft(cc).toContain("private");
+    expect.soft(cc).toContain("max-age=30");
   });
 
   it("200: enabled / disabled 両方のフィードが含まれる", async () => {
@@ -79,12 +79,12 @@ describe("GET /api/admin/feeds/diagnostics", () => {
     };
     expect(body.count).toBe(2);
     const ids = body.feeds.map((f) => f.id);
-    expect(ids).toContain("feed-alpha");
-    expect(ids).toContain("feed-beta");
+    expect.soft(ids).toContain("feed-alpha");
+    expect.soft(ids).toContain("feed-beta");
     const alpha = body.feeds.find((f) => f.id === "feed-alpha");
     const beta = body.feeds.find((f) => f.id === "feed-beta");
-    expect(alpha!.enabled).toBe(true);
-    expect(beta!.enabled).toBe(false);
+    expect.soft(alpha!.enabled).toBe(true);
+    expect.soft(beta!.enabled).toBe(false);
   });
 
   it("200: 各フィールドが正しく返る (last_fetched_at, last_etag, last_status, last_error)", async () => {
@@ -121,21 +121,21 @@ describe("GET /api/admin/feeds/diagnostics", () => {
     };
     expect(body.count).toBe(1);
     const f = body.feeds[0];
-    expect(f.id).toBe("feed-alpha");
-    expect(f.name).toBe("Feed Alpha");
-    expect(f.url).toBe("https://example.com/alpha.xml");
-    expect(f.category).toBe("bigtech");
-    expect(f.lang).toBe("en");
-    expect(f.enabled).toBe(true);
-    expect(f.last_fetched_at).toBe(fetchedAt);
-    expect(f.last_status).toBe("ok:5");
-    expect(f.last_error).toBeNull();
-    expect(f.last_etag).toBe("etag-abc");
-    expect(f.last_modified).toBe("Mon, 01 Apr 2026 00:00:00 GMT");
-    expect(f.fetch_error_count).toBe(0);
-    expect(f.articles_total).toBe(0); // articles は未挿入
-    expect(f.articles_30d).toBe(0);
-    expect(f.last_published_at).toBeNull();
+    expect.soft(f.id).toBe("feed-alpha");
+    expect.soft(f.name).toBe("Feed Alpha");
+    expect.soft(f.url).toBe("https://example.com/alpha.xml");
+    expect.soft(f.category).toBe("bigtech");
+    expect.soft(f.lang).toBe("en");
+    expect.soft(f.enabled).toBe(true);
+    expect.soft(f.last_fetched_at).toBe(fetchedAt);
+    expect.soft(f.last_status).toBe("ok:5");
+    expect.soft(f.last_error).toBeNull();
+    expect.soft(f.last_etag).toBe("etag-abc");
+    expect.soft(f.last_modified).toBe("Mon, 01 Apr 2026 00:00:00 GMT");
+    expect.soft(f.fetch_error_count).toBe(0);
+    expect.soft(f.articles_total).toBe(0); // articles は未挿入
+    expect.soft(f.articles_30d).toBe(0);
+    expect.soft(f.last_published_at).toBeNull();
   });
 
   it("200: エラー後は last_error / fetch_error_count が反映される", async () => {
@@ -157,9 +157,9 @@ describe("GET /api/admin/feeds/diagnostics", () => {
       }[];
     };
     const f = body.feeds[0];
-    expect(f.last_status).toBe("error");
-    expect(f.last_error).toBe("connection refused");
-    expect(f.fetch_error_count).toBe(1);
+    expect.soft(f.last_status).toBe("error");
+    expect.soft(f.last_error).toBe("connection refused");
+    expect.soft(f.fetch_error_count).toBe(1);
   });
 
   it("200: articles 投入後に articles_total / articles_30d / last_published_at が反映される", async () => {
@@ -210,8 +210,8 @@ describe("GET /api/admin/feeds/diagnostics", () => {
       }[];
     };
     const f = body.feeds[0];
-    expect(f.articles_total).toBe(2);
-    expect(f.articles_30d).toBe(1); // recentAt のみが 30d 以内
-    expect(f.last_published_at).toBe(recentAt);
+    expect.soft(f.articles_total).toBe(2);
+    expect.soft(f.articles_30d).toBe(1); // recentAt のみが 30d 以内
+    expect.soft(f.last_published_at).toBe(recentAt);
   });
 });

--- a/apps/web/tests/worker/api/admin-feeds-diagnostics.test.ts
+++ b/apps/web/tests/worker/api/admin-feeds-diagnostics.test.ts
@@ -156,6 +156,7 @@ describe("GET /api/admin/feeds/diagnostics", () => {
         fetch_error_count: number;
       }[];
     };
+    expect(body.feeds.length).toBeGreaterThan(0);
     const f = body.feeds[0];
     expect.soft(f.last_status).toBe("error");
     expect.soft(f.last_error).toBe("connection refused");

--- a/apps/web/tests/worker/api/admin-validate.test.ts
+++ b/apps/web/tests/worker/api/admin-validate.test.ts
@@ -98,7 +98,7 @@ describe("POST /api/admin/feeds/validate (integration)", () => {
       headers: { ...AUTH_HEADER, "content-type": "application/json" },
       body: JSON.stringify({ url: "https://example.com/feed.xml" }),
     });
-    expect.soft(res.status).toBe(200);
+    expect(res.status).toBe(200);
     const cacheControl = res.headers.get("cache-control") ?? "";
     expect.soft(cacheControl).toContain("no-store");
     const body = (await res.json()) as { ok: boolean };

--- a/apps/web/tests/worker/api/admin-validate.test.ts
+++ b/apps/web/tests/worker/api/admin-validate.test.ts
@@ -98,9 +98,9 @@ describe("POST /api/admin/feeds/validate (integration)", () => {
       headers: { ...AUTH_HEADER, "content-type": "application/json" },
       body: JSON.stringify({ url: "https://example.com/feed.xml" }),
     });
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const cacheControl = res.headers.get("cache-control") ?? "";
-    expect(cacheControl).toContain("no-store");
+    expect.soft(cacheControl).toContain("no-store");
     const body = (await res.json()) as { ok: boolean };
     // CI では外部 fetch が失敗するため ok:false。テスト環境の制約上、ok:true は下記ユニットテストで検証する。
     expect(typeof body.ok).toBe("boolean");
@@ -121,9 +121,9 @@ describe("validateFeedUrl (unit)", () => {
     const result = await validateFeedUrl("https://example.com/feed.xml");
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error("expected ok:true");
-    expect(result.title).toBe("Example Tech Blog");
-    expect(result.lang).toBe("en");
-    expect(result.item_count).toBe(3);
+    expect.soft(result.title).toBe("Example Tech Blog");
+    expect.soft(result.lang).toBe("en");
+    expect.soft(result.item_count).toBe(3);
   });
 
   it("ok:true: valid Atom XML (日本語) → lang が ja", async () => {
@@ -137,9 +137,9 @@ describe("validateFeedUrl (unit)", () => {
     const result = await validateFeedUrl("https://example.com/feed.atom");
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error("expected ok:true");
-    expect(result.title).toBe("日本語テックブログ");
-    expect(result.lang).toBe("ja");
-    expect(result.item_count).toBe(2);
+    expect.soft(result.title).toBe("日本語テックブログ");
+    expect.soft(result.lang).toBe("ja");
+    expect.soft(result.item_count).toBe(2);
   });
 
   it("ok:false: fetch が 404 → ok:false と error を含む", async () => {

--- a/apps/web/tests/worker/api/api.test.ts
+++ b/apps/web/tests/worker/api/api.test.ts
@@ -265,11 +265,11 @@ describe("/api/stats", () => {
       by_lang: Record<string, number>;
       stale_feeds: { id: string }[];
     };
-    expect(body.total).toBe(3);
-    expect(body.by_category).toEqual({ bigtech: 1, ai: 1, jp: 1, personal: 0 });
-    expect(body.by_lang).toEqual({ en: 2, ja: 1 });
+    expect.soft(body.total).toBe(3);
+    expect.soft(body.by_category).toEqual({ bigtech: 1, ai: 1, jp: 1, personal: 0 });
+    expect.soft(body.by_lang).toEqual({ en: 2, ja: 1 });
     // 全フィードは未収集 (last_fetched_at NULL) なので stale 扱い
-    expect(body.stale_feeds.length).toBe(3);
+    expect.soft(body.stale_feeds.length).toBe(3);
   });
 
   it("flags only feeds with errors or no recent fetch", async () => {
@@ -309,12 +309,12 @@ describe("/api/health", () => {
       feeds: { total: number; enabled: number };
       articles: { total: number; last_24h: number };
     };
-    expect(body.ok).toBe(true);
-    expect(typeof body.now).toBe("string");
-    expect(body.articles.total).toBe(3);
+    expect.soft(body.ok).toBe(true);
+    expect.soft(typeof body.now).toBe("string");
+    expect.soft(body.articles.total).toBe(3);
     // feeds are synced via syncFeeds in beforeEach (FEEDS has 3 entries, all enabled)
-    expect(body.feeds.total).toBeGreaterThanOrEqual(3);
-    expect(body.feeds.enabled).toBeGreaterThanOrEqual(3);
+    expect.soft(body.feeds.total).toBeGreaterThanOrEqual(3);
+    expect.soft(body.feeds.enabled).toBeGreaterThanOrEqual(3);
   });
 });
 
@@ -371,8 +371,8 @@ describe("CORS headers on public /api/* endpoints", () => {
       },
     });
     expect(res.status).toBe(204);
-    expect(res.headers.get("Access-Control-Allow-Origin")).toBe(allowedOrigin);
-    expect(res.headers.get("Access-Control-Allow-Methods")).toMatch(/GET/);
+    expect.soft(res.headers.get("Access-Control-Allow-Origin")).toBe(allowedOrigin);
+    expect.soft(res.headers.get("Access-Control-Allow-Methods")).toMatch(/GET/);
   });
 
   it("returns Access-Control-Allow-Origin for /api/health GET", async () => {
@@ -427,9 +427,9 @@ describe("CORS headers on public /api/* endpoints", () => {
 describe("security headers", () => {
   it("sets X-Frame-Options and CSP on responses", async () => {
     const res = await SELF.fetch("https://example.com/api/health");
-    expect(res.headers.get("X-Frame-Options")).toBe("DENY");
-    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
-    expect(res.headers.get("Content-Security-Policy")).toContain("default-src 'self'");
+    expect.soft(res.headers.get("X-Frame-Options")).toBe("DENY");
+    expect.soft(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect.soft(res.headers.get("Content-Security-Policy")).toContain("default-src 'self'");
   });
 
   it("sets Strict-Transport-Security on /api/health", async () => {

--- a/apps/web/tests/worker/api/categories.test.ts
+++ b/apps/web/tests/worker/api/categories.test.ts
@@ -154,11 +154,11 @@ describe("GET /api/categories - テストデータあり", () => {
     const body = await res.json<CategoriesResponse>();
 
     const byCategory = Object.fromEntries(body.categories.map((c) => [c.id, c]));
-    expect(byCategory["ai"]!.feeds_count).toBe(2);
-    expect(byCategory["bigtech"]!.feeds_count).toBe(1);
-    expect(byCategory["personal"]!.feeds_count).toBe(1);
+    expect.soft(byCategory["ai"]!.feeds_count).toBe(2);
+    expect.soft(byCategory["bigtech"]!.feeds_count).toBe(1);
+    expect.soft(byCategory["personal"]!.feeds_count).toBe(1);
     // jp フィードは登録していないので 0
-    expect(byCategory["jp"]!.feeds_count).toBe(0);
+    expect.soft(byCategory["jp"]!.feeds_count).toBe(0);
   });
 
   it("articles_30d は 30 日以内の記事のみカウント (31d 前の記事は含まれない)", async () => {
@@ -167,8 +167,8 @@ describe("GET /api/categories - テストデータあり", () => {
 
     const byCategory = Object.fromEntries(body.categories.map((c) => [c.id, c]));
     // ai: daysAgo(5) + daysAgo(20) = 2件。daysAgo(31) は除外
-    expect(byCategory["ai"]!.articles_30d).toBe(2);
-    expect(byCategory["bigtech"]!.articles_30d).toBe(1);
+    expect.soft(byCategory["ai"]!.articles_30d).toBe(2);
+    expect.soft(byCategory["bigtech"]!.articles_30d).toBe(1);
   });
 
   it("articles_30d=0 のカテゴリは 0 で返る (jp と personal)", async () => {
@@ -176,8 +176,8 @@ describe("GET /api/categories - テストデータあり", () => {
     const body = await res.json<CategoriesResponse>();
 
     const byCategory = Object.fromEntries(body.categories.map((c) => [c.id, c]));
-    expect(byCategory["jp"]!.articles_30d).toBe(0);
-    expect(byCategory["personal"]!.articles_30d).toBe(0);
+    expect.soft(byCategory["jp"]!.articles_30d).toBe(0);
+    expect.soft(byCategory["personal"]!.articles_30d).toBe(0);
   });
 
   it("last_published_at は各カテゴリの MAX(published_at)", async () => {
@@ -190,14 +190,14 @@ describe("GET /api/categories - テストデータあり", () => {
     expect(byCategory["ai"]!.last_published_at).not.toBeNull();
     const aiLatest = new Date(byCategory["ai"]!.last_published_at!);
     const fiveDaysAgo = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000);
-    expect(aiLatest.getTime()).toBeGreaterThan(fiveDaysAgo.getTime() - 60_000);
+    expect.soft(aiLatest.getTime()).toBeGreaterThan(fiveDaysAgo.getTime() - 60_000);
 
     // bigtech: bt-1 (10d前)
     expect(byCategory["bigtech"]!.last_published_at).not.toBeNull();
 
     // 記事なし -> null
-    expect(byCategory["jp"]!.last_published_at).toBeNull();
-    expect(byCategory["personal"]!.last_published_at).toBeNull();
+    expect.soft(byCategory["jp"]!.last_published_at).toBeNull();
+    expect.soft(byCategory["personal"]!.last_published_at).toBeNull();
   });
 
   it("Cache-Control: public, max-age=300 が設定されている", async () => {

--- a/apps/web/tests/worker/api/etag.test.ts
+++ b/apps/web/tests/worker/api/etag.test.ts
@@ -46,8 +46,8 @@ describe("ETag - /api/articles", () => {
     expect(res.status).toBe(200);
     const etag = res.headers.get("ETag");
     expect(etag).not.toBeNull();
-    expect(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
-    expect(res.headers.get("Cache-Control")).toBe("public, max-age=60");
+    expect.soft(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
+    expect.soft(res.headers.get("Cache-Control")).toBe("public, max-age=60");
   });
 
   it("returns 304 when If-None-Match matches ETag", async () => {
@@ -58,8 +58,8 @@ describe("ETag - /api/articles", () => {
       headers: { "If-None-Match": etag },
     });
     expect(res2.status).toBe(304);
-    expect(res2.headers.get("ETag")).toBe(etag);
-    expect(res2.headers.get("Cache-Control")).toBe("public, max-age=60");
+    expect.soft(res2.headers.get("ETag")).toBe(etag);
+    expect.soft(res2.headers.get("Cache-Control")).toBe("public, max-age=60");
   });
 
   it("returns different ETag for different query params", async () => {
@@ -104,8 +104,8 @@ describe("ETag - /feed.json", () => {
     const res = await SELF.fetch("https://example.com/feed.json");
     expect(res.status).toBe(200);
     const etag = res.headers.get("ETag");
-    expect(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
-    expect(res.headers.get("Cache-Control")).toBe("public, max-age=60");
+    expect.soft(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
+    expect.soft(res.headers.get("Cache-Control")).toBe("public, max-age=60");
   });
 
   it("returns 304 when If-None-Match matches ETag", async () => {
@@ -116,7 +116,7 @@ describe("ETag - /feed.json", () => {
       headers: { "If-None-Match": etag },
     });
     expect(res2.status).toBe(304);
-    expect(res2.headers.get("ETag")).toBe(etag);
+    expect.soft(res2.headers.get("ETag")).toBe(etag);
   });
 });
 
@@ -125,8 +125,8 @@ describe("ETag - /feed.xml", () => {
     const res = await SELF.fetch("https://example.com/feed.xml");
     expect(res.status).toBe(200);
     const etag = res.headers.get("ETag");
-    expect(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
-    expect(res.headers.get("Cache-Control")).toBe("public, max-age=60");
+    expect.soft(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
+    expect.soft(res.headers.get("Cache-Control")).toBe("public, max-age=60");
   });
 
   it("returns 304 when If-None-Match matches ETag", async () => {
@@ -137,6 +137,6 @@ describe("ETag - /feed.xml", () => {
       headers: { "If-None-Match": etag },
     });
     expect(res2.status).toBe(304);
-    expect(res2.headers.get("ETag")).toBe(etag);
+    expect.soft(res2.headers.get("ETag")).toBe(etag);
   });
 });

--- a/apps/web/tests/worker/api/reports.test.ts
+++ b/apps/web/tests/worker/api/reports.test.ts
@@ -561,7 +561,7 @@ describe("GET /api/admin/reports", () => {
     });
     expect(res.status).toBe(200);
     const body = (await res.json()) as AdminReportListResponse;
-    expect.soft(body.reports.length).toBeGreaterThanOrEqual(2);
+    expect(body.reports.length).toBeGreaterThanOrEqual(2);
     expect.soft(body.reports[0].generated_at >= body.reports[1].generated_at).toBe(true);
   });
 

--- a/apps/web/tests/worker/api/reports.test.ts
+++ b/apps/web/tests/worker/api/reports.test.ts
@@ -60,9 +60,9 @@ describe("POST /api/admin/reports", () => {
     });
     expect(res.status).toBe(200);
     const body = (await res.json()) as AdminReportSaveResponse;
-    expect(body.ok).toBe(true);
-    expect(typeof body.id).toBe("number");
-    expect(body.id).toBeGreaterThan(0);
+    expect.soft(body.ok).toBe(true);
+    expect.soft(typeof body.id).toBe("number");
+    expect.soft(body.id).toBeGreaterThan(0);
   });
 
   it("200: accepts ADMIN_TOKEN_NEXT (rotation)", async () => {
@@ -561,8 +561,8 @@ describe("GET /api/admin/reports", () => {
     });
     expect(res.status).toBe(200);
     const body = (await res.json()) as AdminReportListResponse;
-    expect(body.reports.length).toBeGreaterThanOrEqual(2);
-    expect(body.reports[0].generated_at >= body.reports[1].generated_at).toBe(true);
+    expect.soft(body.reports.length).toBeGreaterThanOrEqual(2);
+    expect.soft(body.reports[0].generated_at >= body.reports[1].generated_at).toBe(true);
   });
 
   it("200: filters by kind", async () => {
@@ -621,7 +621,7 @@ describe("GET /api/admin/reports/:id", () => {
     });
     expect(res.status).toBe(200);
     const body = (await res.json()) as AdminReportDetailResponse;
-    expect(body.report.content).toBe("with meta");
-    expect(body.report.meta_json).toContain("dedup_total");
+    expect.soft(body.report.content).toBe("with meta");
+    expect.soft(body.report.meta_json).toContain("dedup_total");
   });
 });

--- a/apps/web/tests/worker/api/spa-shell.test.ts
+++ b/apps/web/tests/worker/api/spa-shell.test.ts
@@ -74,14 +74,14 @@ describe("SPA shell rewrite: GET /articles/:id", () => {
 
     const res = await SELF.fetch(`https://example.com/articles/${id}`);
     expect(res.status).toBe(200);
-    expect(res.headers.get("Cache-Control")).toContain("max-age=300");
+    expect.soft(res.headers.get("Cache-Control")).toContain("max-age=300");
   });
 
   it("falls back to static index.html for unknown article id", async () => {
     const res = await SELF.fetch("https://example.com/articles/99999999");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     // fallback の場合は no-cache
-    expect(res.headers.get("Cache-Control")).toContain("no-cache");
+    expect.soft(res.headers.get("Cache-Control")).toContain("no-cache");
   });
 });
 
@@ -99,8 +99,8 @@ describe("SPA shell rewrite: GET /feed/:feedId", () => {
 
   it("falls back to static index.html for unknown feedId", async () => {
     const res = await SELF.fetch("https://example.com/feed/nonexistent-feed-xyz");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Cache-Control")).toContain("no-cache");
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Cache-Control")).toContain("no-cache");
   });
 });
 
@@ -159,9 +159,9 @@ describe("SPA shell rewrite: static routes (no rewriting)", () => {
   it("does not rewrite /api/* routes", async () => {
     // /api/* は JSON を返すため HTML ではない
     const res = await SELF.fetch("https://example.com/api/articles?limit=1");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const ct = res.headers.get("Content-Type") ?? "";
-    expect(ct).toContain("application/json");
+    expect.soft(ct).toContain("application/json");
   });
 });
 


### PR DESCRIPTION
## Summary

Wave 4 アンブレラ issue #387 の PR 2。guard 判断が必要な 7 ファイルで `expect.soft(...)` を導入した。

## 変更ファイルと guard として plain を維持した観点

| ファイル | guard (plain のまま) の理由 |
|---|---|
| `admin-feeds-diagnostics.test.ts` | `expect(body.count).toBe(1)` — 後続の `body.feeds[0]` アクセスの前提 |
| `admin-validate.test.ts` | `expect(result.ok).toBe(true)` — `if (!result.ok) throw` narrowing guard |
| `api.test.ts` | `/api/health` `res.status`、CORS preflight `res.status`、`/api/stats` `res.status` — body/header アクセスの前提; pagination `nextCursor not.toBeNull()` — `encodeURIComponent(nextCursor!)` の前提 |
| `categories.test.ts` | `last_published_at not.toBeNull()` — 後続の `new Date(...)` パースの前提 |
| `etag.test.ts` | `/api/articles` の `etag not.toBeNull()` — 後続の `.toMatch(regexp)` の前提; 各エンドポイントの `res.status` |
| `reports.test.ts` | `res.status` — body のパース前提; `insertReport` ヘルパー内は変更なし |
| `spa-shell.test.ts` | `res.status` (HTML パース前の guard) — `res.text()` 後の rewrite 検証の前提; 既存 soft は変更なし |

## テスト結果

- `vp test run`: 753 tests passed (55 files)

Refs #387