### PR TITLE
refactor(collector): extract fetcher and feedWriter from collector index

### DIFF
--- a/apps/web/tests/worker/collector/feedWriter.test.ts
+++ b/apps/web/tests/worker/collector/feedWriter.test.ts
@@ -1,0 +1,355 @@
+/**
+ * feedWriter.ts の単体テスト
+ *
+ * handleNotModified / handleSuccess / handleError の各ブランチを独立して検証する。
+ * 古典派: 実 D1 (miniflare) を使い、過剰モックを避ける。
+ * fetch のみ vi.spyOn でモックして外部アクセスを抑止する。
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { env } from "cloudflare:test";
+import {
+  handleError,
+  handleNotModified,
+  handleSuccess,
+} from "../../../worker/collector/feedWriter";
+import { D1CostAccumulator } from "../../../worker/collector/metrics";
+import { syncFeeds } from "../../../worker/db/feeds";
+import { startRun } from "../../../worker/db/runs";
+import type { FeedConfig } from "../../../worker/types";
+
+const FEED: FeedConfig = {
+  id: "fw-test-feed",
+  name: "FeedWriter Test Feed",
+  url: "https://example.com/fw.xml",
+  category: "bigtech",
+  lang: "en",
+  enabled: true,
+};
+
+const VALID_RSS = `<?xml version="1.0"?>
+<rss version="2.0">
+  <channel>
+    <title>FW Test</title>
+    <item>
+      <title>Article 1</title>
+      <link>https://example.com/a1</link>
+      <guid>https://example.com/a1</guid>
+      <pubDate>Thu, 01 Jan 2026 00:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>Article 2</title>
+      <link>https://example.com/a2</link>
+      <guid>https://example.com/a2</guid>
+      <pubDate>Thu, 02 Jan 2026 00:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>`;
+
+beforeEach(async () => {
+  await syncFeeds(env.DB, [FEED]);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// テスト用にパラメータを組み立てるヘルパー
+function makeParams(runId: number | null = null) {
+  return {
+    env,
+    feed: FEED,
+    fetchedAt: new Date().toISOString(),
+    runId,
+    feedStart: Date.now(),
+    t0: performance.now(),
+    d1Acc: new D1CostAccumulator(),
+  };
+}
+
+// -----------------------------------------------------------------------
+// handleNotModified
+// -----------------------------------------------------------------------
+describe("handleNotModified", () => {
+  it("returns not_modified result with inserted=0 and parsed=0", async () => {
+    const p = makeParams();
+    const result = await handleNotModified(
+      p.env,
+      FEED.id,
+      p.fetchedAt,
+      p.runId,
+      p.feedStart,
+      p.t0,
+      p.d1Acc,
+    );
+
+    expect.soft(result.status).toBe("not_modified");
+    expect.soft(result.inserted).toBe(0);
+    expect.soft(result.parsed).toBe(0);
+    expect.soft(result.feedId).toBe(FEED.id);
+  });
+
+  it("records last_fetched_at in feeds table", async () => {
+    const p = makeParams();
+    await handleNotModified(p.env, FEED.id, p.fetchedAt, p.runId, p.feedStart, p.t0, p.d1Acc);
+
+    const row = await env.DB.prepare("SELECT last_fetched_at, last_status FROM feeds WHERE id = ?1")
+      .bind(FEED.id)
+      .first<{ last_fetched_at: string; last_status: string }>();
+
+    expect.soft(row?.last_fetched_at).toBe(p.fetchedAt);
+    expect.soft(row?.last_status).toBe("not_modified");
+  });
+
+  it("records run feed entry as 'skipped' when runId is provided", async () => {
+    const { run_id } = await startRun(env.DB, new Date().toISOString(), 1);
+    const p = makeParams(run_id);
+    await handleNotModified(p.env, FEED.id, p.fetchedAt, run_id, p.feedStart, p.t0, p.d1Acc);
+
+    const row = await env.DB.prepare(
+      "SELECT status, articles_inserted FROM collector_run_feeds WHERE run_id = ?1 AND feed_id = ?2",
+    )
+      .bind(run_id, FEED.id)
+      .first<{ status: string; articles_inserted: number }>();
+
+    expect.soft(row?.status).toBe("skipped");
+    expect.soft(row?.articles_inserted).toBe(0);
+  });
+
+  it("skips run feed recording when runId is null", async () => {
+    const p = makeParams(null);
+    await handleNotModified(p.env, FEED.id, p.fetchedAt, null, p.feedStart, p.t0, p.d1Acc);
+
+    // collector_run_feeds には何も挿入されていない
+    const count = await env.DB.prepare("SELECT COUNT(*) AS n FROM collector_run_feeds").first<{
+      n: number;
+    }>();
+    expect(count?.n).toBe(0);
+  });
+});
+
+// -----------------------------------------------------------------------
+// handleSuccess
+// -----------------------------------------------------------------------
+describe("handleSuccess", () => {
+  it("returns ok result with correct inserted and parsed counts", async () => {
+    const p = makeParams();
+    const result = await handleSuccess(
+      p.env,
+      FEED,
+      VALID_RSS,
+      '"etag-v1"',
+      "Thu, 01 Jan 2026 00:00:00 GMT",
+      p.fetchedAt,
+      500,
+      p.runId,
+      p.feedStart,
+      p.t0,
+      p.d1Acc,
+    );
+
+    expect.soft(result.status).toBe("ok");
+    expect.soft(result.feedId).toBe(FEED.id);
+    expect.soft(result.inserted).toBe(2);
+    expect.soft(result.parsed).toBe(2);
+  });
+
+  it("inserts articles into the DB", async () => {
+    const p = makeParams();
+    await handleSuccess(
+      p.env,
+      FEED,
+      VALID_RSS,
+      null,
+      null,
+      p.fetchedAt,
+      500,
+      p.runId,
+      p.feedStart,
+      p.t0,
+      p.d1Acc,
+    );
+
+    const count = await env.DB.prepare("SELECT COUNT(*) AS n FROM articles WHERE feed_id = ?1")
+      .bind(FEED.id)
+      .first<{ n: number }>();
+    expect(count?.n).toBe(2);
+  });
+
+  it("saves etag and last_modified in feeds table", async () => {
+    const p = makeParams();
+    const etag = '"etag-abc"';
+    const lastModified = "Mon, 05 Jan 2026 12:00:00 GMT";
+    await handleSuccess(
+      p.env,
+      FEED,
+      VALID_RSS,
+      etag,
+      lastModified,
+      p.fetchedAt,
+      500,
+      p.runId,
+      p.feedStart,
+      p.t0,
+      p.d1Acc,
+    );
+
+    const row = await env.DB.prepare("SELECT last_etag, last_modified FROM feeds WHERE id = ?1")
+      .bind(FEED.id)
+      .first<{ last_etag: string; last_modified: string }>();
+
+    expect.soft(row?.last_etag).toBe(etag);
+    expect.soft(row?.last_modified).toBe(lastModified);
+  });
+
+  it("does not insert duplicate articles on second call", async () => {
+    const p = makeParams();
+    await handleSuccess(
+      p.env,
+      FEED,
+      VALID_RSS,
+      null,
+      null,
+      p.fetchedAt,
+      500,
+      p.runId,
+      p.feedStart,
+      p.t0,
+      p.d1Acc,
+    );
+
+    // 2 回目は重複のため inserted=0
+    const p2 = makeParams();
+    const result2 = await handleSuccess(
+      p2.env,
+      FEED,
+      VALID_RSS,
+      null,
+      null,
+      p2.fetchedAt,
+      500,
+      p2.runId,
+      p2.feedStart,
+      p2.t0,
+      p2.d1Acc,
+    );
+
+    expect.soft(result2.inserted).toBe(0);
+    expect.soft(result2.parsed).toBe(2);
+  });
+
+  it("records run feed entry as 'ok' with inserted count when runId is provided", async () => {
+    const { run_id } = await startRun(env.DB, new Date().toISOString(), 1);
+    const p = makeParams(run_id);
+    await handleSuccess(
+      p.env,
+      FEED,
+      VALID_RSS,
+      null,
+      null,
+      p.fetchedAt,
+      500,
+      run_id,
+      p.feedStart,
+      p.t0,
+      p.d1Acc,
+    );
+
+    const row = await env.DB.prepare(
+      "SELECT status, articles_inserted FROM collector_run_feeds WHERE run_id = ?1 AND feed_id = ?2",
+    )
+      .bind(run_id, FEED.id)
+      .first<{ status: string; articles_inserted: number }>();
+
+    expect.soft(row?.status).toBe("ok");
+    expect.soft(row?.articles_inserted).toBe(2);
+  });
+});
+
+// -----------------------------------------------------------------------
+// handleError
+// -----------------------------------------------------------------------
+describe("handleError", () => {
+  it("returns error result with correct error message and errorKind", async () => {
+    const p = makeParams();
+    const err = new Error("HTTP 503 Service Unavailable");
+    const result = await handleError(
+      p.env,
+      FEED.id,
+      err,
+      p.fetchedAt,
+      p.runId,
+      p.feedStart,
+      p.t0,
+      p.d1Acc,
+    );
+
+    expect.soft(result.status).toBe("error");
+    expect.soft(result.feedId).toBe(FEED.id);
+    expect.soft(result.inserted).toBe(0);
+    expect.soft(result.parsed).toBe(0);
+    if (result.status === "error") {
+      expect.soft(result.error).toContain("HTTP 503");
+      expect.soft(result.errorKind).toBe("http_server");
+    }
+  });
+
+  it("classifies network error correctly", async () => {
+    const p = makeParams();
+    const err = new TypeError("Failed to fetch");
+    const result = await handleError(
+      p.env,
+      FEED.id,
+      err,
+      p.fetchedAt,
+      p.runId,
+      p.feedStart,
+      p.t0,
+      p.d1Acc,
+    );
+
+    if (result.status === "error") {
+      expect(result.errorKind).toBe("network");
+    }
+  });
+
+  it("records consecutive_failures increment in feeds table", async () => {
+    const p = makeParams();
+    const err = new Error("HTTP 500 Internal Server Error");
+    await handleError(p.env, FEED.id, err, p.fetchedAt, p.runId, p.feedStart, p.t0, p.d1Acc);
+
+    const row = await env.DB.prepare(
+      "SELECT consecutive_failures, last_status FROM feeds WHERE id = ?1",
+    )
+      .bind(FEED.id)
+      .first<{ consecutive_failures: number; last_status: string }>();
+
+    expect.soft(row?.consecutive_failures).toBe(1);
+    expect.soft(row?.last_status).toBe("error");
+  });
+
+  it("records run feed entry as 'failed' when runId is provided", async () => {
+    const { run_id } = await startRun(env.DB, new Date().toISOString(), 1);
+    const p = makeParams(run_id);
+    const err = new Error("HTTP 404 Not Found");
+    await handleError(p.env, FEED.id, err, p.fetchedAt, run_id, p.feedStart, p.t0, p.d1Acc);
+
+    const row = await env.DB.prepare(
+      "SELECT status FROM collector_run_feeds WHERE run_id = ?1 AND feed_id = ?2",
+    )
+      .bind(run_id, FEED.id)
+      .first<{ status: string }>();
+
+    expect(row?.status).toBe("failed");
+  });
+
+  it("skips run feed recording when runId is null", async () => {
+    const p = makeParams(null);
+    const err = new Error("HTTP 503 Service Unavailable");
+    await handleError(p.env, FEED.id, err, p.fetchedAt, null, p.feedStart, p.t0, p.d1Acc);
+
+    const count = await env.DB.prepare("SELECT COUNT(*) AS n FROM collector_run_feeds").first<{
+      n: number;
+    }>();
+    expect(count?.n).toBe(0);
+  });
+});

--- a/apps/web/tests/worker/collector/feedWriter.test.ts
+++ b/apps/web/tests/worker/collector/feedWriter.test.ts
@@ -3,7 +3,8 @@
  *
  * handleNotModified / handleSuccess / handleError の各ブランチを独立して検証する。
  * 古典派: 実 D1 (miniflare) を使い、過剰モックを避ける。
- * fetch のみ vi.spyOn でモックして外部アクセスを抑止する。
+ * handleSuccess / handleNotModified は XML を直接受け取るため fetch は呼ばれない。
+ * handleError も fetch を発行しないため、ここでは外部アクセスのモックは不要。
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { env } from "cloudflare:test";
@@ -287,10 +288,9 @@ describe("handleError", () => {
     expect.soft(result.feedId).toBe(FEED.id);
     expect.soft(result.inserted).toBe(0);
     expect.soft(result.parsed).toBe(0);
-    if (result.status === "error") {
-      expect.soft(result.error).toContain("HTTP 503");
-      expect.soft(result.errorKind).toBe("http_server");
-    }
+    if (result.status !== "error") throw new Error("expected status error");
+    expect.soft(result.error).toContain("HTTP 503");
+    expect.soft(result.errorKind).toBe("http_server");
   });
 
   it("classifies network error correctly", async () => {
@@ -307,9 +307,9 @@ describe("handleError", () => {
       p.d1Acc,
     );
 
-    if (result.status === "error") {
-      expect(result.errorKind).toBe("network");
-    }
+    expect(result.status).toBe("error");
+    if (result.status !== "error") throw new Error("expected status error");
+    expect.soft(result.errorKind).toBe("network");
   });
 
   it("records consecutive_failures increment in feeds table", async () => {

--- a/apps/web/worker/collector/collectTypes.ts
+++ b/apps/web/worker/collector/collectTypes.ts
@@ -1,0 +1,59 @@
+/**
+ * collector モジュール共通の型定義とエラー分類ロジック。
+ * feedWriter / index の双方から import できるよう循環依存を避けて独立させた。
+ */
+
+/**
+ * エラーの種別。alert や監視ダッシュボードでエラーをフィルタリングできるよう型で区別する。
+ * - timeout: AbortError (fetchFeed のタイムアウト)
+ * - network: TypeError (DNS 解決失敗・接続拒否など)
+ * - http_client: HTTP 4xx (404, 403 など恒久エラー)
+ * - http_server: HTTP 5xx / 429 (一時障害。リトライ後も失敗した場合)
+ * - parse: XML パース失敗または空フィード
+ * - unknown: 上記に分類できないエラー
+ */
+export type CollectErrorKind =
+  | "timeout"
+  | "network"
+  | "http_client"
+  | "http_server"
+  | "parse"
+  | "unknown";
+
+/** discriminated union: status に応じて error / errorKind フィールドの有無が変わる */
+export type CollectResult =
+  | { feedId: string; status: "ok"; inserted: number; parsed: number }
+  | { feedId: string; status: "not_modified"; inserted: number; parsed: number }
+  | {
+      feedId: string;
+      status: "error";
+      inserted: number;
+      parsed: number;
+      error: string;
+      errorKind: CollectErrorKind;
+    };
+
+export interface CollectAllResult {
+  total: number;
+  inserted: number;
+  pruned: number;
+  results: CollectResult[];
+  durationMs: number;
+}
+
+/**
+ * 例外からエラー種別を分類する。
+ * isRetryableError と対になる分類で、同じ判定ロジックを使う。
+ */
+export function classifyError(err: unknown): CollectErrorKind {
+  if (!(err instanceof Error)) return "unknown";
+  if (err.name === "AbortError") return "timeout";
+  if (err instanceof TypeError) return "network";
+  const m = /^HTTP (\d+)/.exec(err.message);
+  if (m) {
+    const code = Number(m[1]);
+    if (code === 429 || (code >= 500 && code < 600)) return "http_server";
+    if (code >= 400 && code < 500) return "http_client";
+  }
+  return "unknown";
+}

--- a/apps/web/worker/collector/feedWriter.ts
+++ b/apps/web/worker/collector/feedWriter.ts
@@ -1,0 +1,239 @@
+import type { Env, FeedConfig } from "../types";
+import { parseFeed } from "./rssParser";
+import { buildGuids } from "./deduplicator";
+import { D1CostAccumulator, writeCollectorEvent } from "./metrics";
+import {
+  buildInsertArticleStmts,
+  findExistingArticleGuids,
+  type InsertableArticle,
+} from "../db/articles";
+import {
+  buildRecordFetchErrorStmt,
+  buildRecordFetchSuccessStmt,
+  buildUpdateFeedHeadersStmt,
+  type FeedHeaders,
+} from "../db/feeds";
+import { buildRecordRunFeedStmt } from "../db/runs";
+import { classifyError, type CollectResult } from "./collectTypes";
+import { fetchFeed } from "./fetcher";
+
+const MAX_ITEMS_PER_FEED = 50;
+const ALLOWED_URL_PREFIXES = ["http://", "https://"];
+
+function isSafeUrl(url: string): boolean {
+  return ALLOWED_URL_PREFIXES.some((p) => url.toLowerCase().startsWith(p));
+}
+
+/**
+ * 304 Not Modified パス: last_fetched_at だけ更新して "not_modified" を返す。
+ * batch stmts を組み立てて env.DB.batch() を呼ぶ。
+ */
+export async function handleNotModified(
+  env: Env,
+  feedId: string,
+  fetchedAt: string,
+  runId: number | null,
+  feedStart: number,
+  t0: number,
+  d1Acc: D1CostAccumulator,
+): Promise<CollectResult> {
+  const stmts: D1PreparedStatement[] = [
+    buildRecordFetchSuccessStmt(env.DB, feedId, fetchedAt, 0, "not_modified"),
+  ];
+  if (runId !== null) {
+    stmts.push(buildRecordRunFeedStmt(env.DB, runId, feedId, "skipped", 0, Date.now() - feedStart));
+  }
+  const batchResults = await env.DB.batch(stmts);
+  for (const r of batchResults) d1Acc.add(r.meta);
+  writeCollectorEvent(env, {
+    feedId,
+    status: "not_modified",
+    ms: Math.round(performance.now() - t0),
+    statusCode: 304,
+  });
+  return { feedId, status: "not_modified", inserted: 0, parsed: 0 };
+}
+
+/**
+ * 200 OK パス: XML パース → 重複排除 → INSERT batch → fetchSuccess 記録。
+ * SELECT existing guids (1 subrequest) + batch (1 subrequest) の計 2 を消費する。
+ */
+export async function handleSuccess(
+  env: Env,
+  feed: FeedConfig,
+  xml: string,
+  etag: string | null,
+  lastModified: string | null,
+  fetchedAt: string,
+  summaryMax: number,
+  runId: number | null,
+  feedStart: number,
+  t0: number,
+  d1Acc: D1CostAccumulator,
+): Promise<CollectResult> {
+  const allItems = parseFeed(xml, {
+    summaryMaxLength: summaryMax,
+    fallbackPublishedAt: fetchedAt,
+  });
+
+  const items = allItems.filter((i) => i.url && isSafeUrl(i.url)).slice(0, MAX_ITEMS_PER_FEED);
+
+  const guids = await buildGuids(
+    items.map((i) => ({
+      feedId: feed.id,
+      rawGuid: i.rawGuid,
+      url: i.url,
+      title: i.title,
+      publishedAt: i.publishedAt,
+    })),
+  );
+
+  const rows: InsertableArticle[] = items.map((item, idx) => ({
+    guid: guids[idx],
+    feed_id: feed.id,
+    title: item.title.slice(0, 500),
+    url: item.url!.slice(0, 1000),
+    summary: item.summary,
+    author: item.author ? item.author.slice(0, 200) : null,
+    published_at: item.publishedAt,
+    category: feed.category,
+    lang: feed.lang,
+  }));
+
+  // FTS トリガが INSERT OR IGNORE の changes() を変動させるため事前に既存 guid を引いて
+  // 新規行のみ INSERT する。SELECT は 1 subrequest だが per-feed batch とは独立して実行する。
+  const existingSet = await findExistingArticleGuids(
+    env.DB,
+    rows.map((r) => r.guid),
+  );
+  const newRows = rows.filter((r) => !existingSet.has(r.guid));
+  const inserted = newRows.length;
+
+  // header 更新 + INSERT 群 + recordFetchSuccess + recordRunFeed を 1 batch に集約。
+  // MAX_ITEMS_PER_FEED=50 + 3 = 53 stmts なので D1 batch 上限 100 を超えない。
+  const stmts: D1PreparedStatement[] = [
+    buildUpdateFeedHeadersStmt(env.DB, feed.id, etag, lastModified),
+    ...buildInsertArticleStmts(env.DB, newRows),
+    buildRecordFetchSuccessStmt(env.DB, feed.id, fetchedAt, inserted),
+  ];
+  if (runId !== null) {
+    stmts.push(
+      buildRecordRunFeedStmt(env.DB, runId, feed.id, "ok", inserted, Date.now() - feedStart),
+    );
+  }
+  const batchResults = await env.DB.batch(stmts);
+  for (const r of batchResults) d1Acc.add(r.meta);
+
+  writeCollectorEvent(env, {
+    feedId: feed.id,
+    status: "ok",
+    ms: Math.round(performance.now() - t0),
+    statusCode: 200,
+  });
+  return { feedId: feed.id, status: "ok", inserted, parsed: allItems.length };
+}
+
+/**
+ * エラーパス: fetchError を記録して "error" 結果を返す。
+ * batch (1 subrequest) を消費する。
+ */
+export async function handleError(
+  env: Env,
+  feedId: string,
+  err: unknown,
+  fetchedAt: string,
+  runId: number | null,
+  feedStart: number,
+  t0: number,
+  d1Acc: D1CostAccumulator,
+): Promise<CollectResult> {
+  const message = err instanceof Error ? err.message : String(err);
+  const errorKind = classifyError(err);
+  try {
+    const stmts: D1PreparedStatement[] = [
+      buildRecordFetchErrorStmt(env.DB, feedId, fetchedAt, message),
+    ];
+    if (runId !== null) {
+      stmts.push(
+        buildRecordRunFeedStmt(env.DB, runId, feedId, "failed", 0, Date.now() - feedStart, message),
+      );
+    }
+    const batchResults = await env.DB.batch(stmts);
+    for (const r of batchResults) d1Acc.add(r.meta);
+  } catch (logErr) {
+    console.error(`Failed to record error for ${feedId}`, logErr);
+  }
+  // HTTP エラーコードをメッセージから抽出する (例: "HTTP 503 ...")
+  const statusMatch = /^HTTP (\d+)/.exec(message);
+  const statusCode = statusMatch ? Number(statusMatch[1]) : 0;
+  writeCollectorEvent(env, {
+    feedId,
+    status: "error",
+    ms: Math.round(performance.now() - t0),
+    statusCode,
+  });
+  return {
+    feedId,
+    status: "error",
+    inserted: 0,
+    parsed: 0,
+    error: message,
+    errorKind,
+  };
+}
+
+/**
+ * 1 feed 分の収集。per-feed の D1 書き込みを 1 batch にまとめて
+ * Worker の subrequest 上限を圧迫しないようにする。
+ *
+ * Subrequest 内訳 (Cloudflare Workers の subrequest 上限対策):
+ * - 304:    fetch (1) + batch[recordFetchSuccess + recordRunFeed?] (1) = 2
+ * - 200:    fetch (1) + SELECT existing guids (1) + batch[updateHeaders + INSERTs + recordFetchSuccess + recordRunFeed?] (1) = 3
+ * - error:  fetch (1) + batch[recordFetchError + recordRunFeed?] (1) = 2
+ *
+ * runId が null なら recordRunFeed は省略 (テスト等で run tracking 無効時)。
+ */
+export async function collectFeed(
+  env: Env,
+  feed: FeedConfig,
+  savedHeaders: FeedHeaders,
+  summaryMax: number,
+  timeoutMs: number,
+  maxRetries: number,
+  runId: number | null,
+  d1Acc: D1CostAccumulator,
+): Promise<CollectResult> {
+  const fetchedAt = new Date().toISOString();
+  const t0 = performance.now();
+  const feedStart = Date.now();
+  try {
+    // savedHeaders は collectAll 冒頭で全 enabled feed 分を 1 query でまとめて取得済み。
+    // feed あたり 1 read を消費しないので Worker の subrequest 上限対策になる。
+    const result = await fetchFeed(feed.url, timeoutMs, maxRetries, {
+      etag: savedHeaders.last_etag,
+      lastModified: savedHeaders.last_modified,
+    });
+
+    // 304 Not Modified: parse/insert をスキップし last_fetched_at だけ更新する
+    if (result.notModified) {
+      return handleNotModified(env, feed.id, fetchedAt, runId, feedStart, t0, d1Acc);
+    }
+
+    // 200 OK path
+    return handleSuccess(
+      env,
+      feed,
+      result.xml!,
+      result.etag,
+      result.lastModified,
+      fetchedAt,
+      summaryMax,
+      runId,
+      feedStart,
+      t0,
+      d1Acc,
+    );
+  } catch (err) {
+    return handleError(env, feed.id, err, fetchedAt, runId, feedStart, t0, d1Acc);
+  }
+}

--- a/apps/web/worker/collector/fetcher.ts
+++ b/apps/web/worker/collector/fetcher.ts
@@ -1,0 +1,136 @@
+// backoff: 500ms, 1000ms の 2 回まで。並列度 4 × max 1.5s = 6s < 30s cron 制限
+const BACKOFF_BASE_MS = 500;
+const MAX_FEED_BYTES = 4 * 1024 * 1024; // 4MB
+
+// 一部のブログ (mercari-engineering 等) は WAF が "bot" 名を含む UA を 403 で弾くため、
+// Mozilla 互換プレフィックスを付ける。Feedly / NewsBlur など主要 RSS リーダも同様の手法。
+const USER_AGENT =
+  "Mozilla/5.0 (compatible; tech-news-bot/0.1; +https://github.com/rikeda71/tech-news-bot)";
+
+/** fetchFeedOnce の戻り値。304 の場合は xml が null になる。 */
+export interface FetchFeedResult {
+  xml: string | null;
+  etag: string | null;
+  lastModified: string | null;
+  notModified: boolean;
+}
+
+/** 一時障害とみなしてリトライすべき HTTP ステータスかどうか */
+function isTransientStatus(status: number): boolean {
+  return status === 429 || (status >= 500 && status < 600);
+}
+
+/**
+ * リトライ対象かどうかを判定する。
+ * - AbortError: タイムアウト
+ * - TypeError: ネットワーク接続失敗 ("Failed to fetch" 等)
+ * - HTTP 5xx / 429: 一時的なサーバー障害
+ * - HTTP 4xx (429 除く): 恒久エラーのためリトライしない
+ * テスト用に export する
+ */
+export function isRetryableError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  if (err.name === "AbortError") return true;
+  if (err instanceof TypeError) return true;
+  const m = /^HTTP (\d+)/.exec(err.message);
+  if (m) return isTransientStatus(Number(m[1]));
+  // HTTP エラー以外の予期しないエラーはリトライしない
+  return false;
+}
+
+/**
+ * 1 回の HTTP fetch を試みる。失敗時は呼び出し元でリトライを判断する。
+ * - 4xx (429 除く) は恒久エラーなので Error をそのまま throw
+ * - 5xx / 429 / AbortError / ネットワークエラーは throw して呼び出し元がリトライ
+ * - 304 Not Modified は notModified=true で返す (リトライしない)
+ */
+async function fetchFeedOnce(
+  url: string,
+  timeoutMs: number,
+  conditionalHeaders: { etag: string | null; lastModified: string | null },
+): Promise<FetchFeedResult> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const reqHeaders: Record<string, string> = {
+      "User-Agent": USER_AGENT,
+      Accept: "application/atom+xml, application/rss+xml, application/xml;q=0.9, */*;q=0.5",
+    };
+    if (conditionalHeaders.etag) {
+      reqHeaders["if-none-match"] = conditionalHeaders.etag;
+    }
+    if (conditionalHeaders.lastModified) {
+      reqHeaders["if-modified-since"] = conditionalHeaders.lastModified;
+    }
+
+    const res = await fetch(url, {
+      headers: reqHeaders,
+      signal: controller.signal,
+      redirect: "follow",
+    });
+
+    // 304: サーバが変更なしと判断。parse/insert をスキップする。
+    if (res.status === 304) {
+      return { xml: null, etag: null, lastModified: null, notModified: true };
+    }
+
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status} ${res.statusText}`);
+    }
+
+    const contentLength = Number(res.headers.get("content-length") ?? 0);
+    if (contentLength > MAX_FEED_BYTES) {
+      throw new Error(`Feed too large: ${contentLength} bytes`);
+    }
+    const text = await res.text();
+    if (text.length > MAX_FEED_BYTES) {
+      throw new Error(`Feed body too large: ${text.length} bytes`);
+    }
+
+    return {
+      xml: text,
+      etag: res.headers.get("etag"),
+      lastModified: res.headers.get("last-modified"),
+      notModified: false,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * 一時障害 (5xx / 429 / AbortError / ネットワークエラー) に対して
+ * 指数バックオフ + jitter でリトライする。4xx / 304 は即 return。
+ * sleep は wallclock のみ消費するため Worker の CPU 制限に影響しない。
+ * テスト用に export する
+ */
+export async function fetchFeed(
+  url: string,
+  timeoutMs: number,
+  maxRetries: number,
+  conditionalHeaders: { etag: string | null; lastModified: string | null } = {
+    etag: null,
+    lastModified: null,
+  },
+): Promise<FetchFeedResult> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fetchFeedOnce(url, timeoutMs, conditionalHeaders);
+    } catch (err) {
+      lastError = err;
+
+      const isRetryable = isRetryableError(err);
+
+      if (!isRetryable || attempt >= maxRetries) break;
+
+      // base * 2^attempt + jitter(0..base)
+      const delayMs = BACKOFF_BASE_MS * 2 ** attempt + Math.random() * BACKOFF_BASE_MS;
+      console.warn(
+        `[collector] fetchFeed attempt ${attempt + 1} failed for ${url}: ${err instanceof Error ? err.message : String(err)}. Retrying in ${Math.round(delayMs)}ms`,
+      );
+      await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+  throw lastError;
+}

--- a/apps/web/worker/collector/index.ts
+++ b/apps/web/worker/collector/index.ts
@@ -1,401 +1,27 @@
-import type { Env, FeedConfig } from "../types";
+import type { Env } from "../types";
 import { loadEnabledFeeds } from "../feed-config";
-import { parseFeed } from "./rssParser";
 import { parseXml, pickText, asArray } from "../utils/xml";
 import { checkUrlSafety } from "./url-safety";
-import { buildGuids } from "./deduplicator";
-import { D1CostAccumulator, writeCollectorEvent, writeD1CostEvent } from "./metrics";
+import { D1CostAccumulator, writeD1CostEvent } from "./metrics";
 import { maybeAlert, sendAlert } from "./alert";
 import {
-  buildInsertArticleStmts,
-  findExistingArticleGuids,
-  type InsertableArticle,
-} from "../db/articles";
-import {
-  buildRecordFetchErrorStmt,
-  buildRecordFetchSuccessStmt,
-  buildUpdateFeedHeadersStmt,
-  type FeedHeaders,
   getFeedStreaks,
   loadEnabledFeedIdsAndHeaders,
   syncFeeds,
+  type FeedHeaders,
 } from "../db/feeds";
-import { buildRecordRunFeedStmt, finishRun, startRun } from "../db/runs";
+import { finishRun, startRun } from "../db/runs";
+import {
+  classifyError,
+  type CollectAllResult,
+  type CollectErrorKind,
+  type CollectResult,
+} from "./collectTypes";
+import { fetchFeed, isRetryableError } from "./fetcher";
+import { collectFeed } from "./feedWriter";
 
-const MAX_FEED_BYTES = 4 * 1024 * 1024; // 4MB
-const MAX_ITEMS_PER_FEED = 50;
-const ALLOWED_URL_PREFIXES = ["http://", "https://"];
-// backoff: 500ms, 1000ms の 2 回まで。並列度 4 × max 1.5s = 6s < 30s cron 制限
-const BACKOFF_BASE_MS = 500;
-
-/**
- * エラーの種別。alert や監視ダッシュボードでエラーをフィルタリングできるよう型で区別する。
- * - timeout: AbortError (fetchFeed のタイムアウト)
- * - network: TypeError (DNS 解決失敗・接続拒否など)
- * - http_client: HTTP 4xx (404, 403 など恒久エラー)
- * - http_server: HTTP 5xx / 429 (一時障害。リトライ後も失敗した場合)
- * - parse: XML パース失敗または空フィード
- * - unknown: 上記に分類できないエラー
- */
-export type CollectErrorKind =
-  | "timeout"
-  | "network"
-  | "http_client"
-  | "http_server"
-  | "parse"
-  | "unknown";
-
-/** discriminated union: status に応じて error / errorKind フィールドの有無が変わる */
-export type CollectResult =
-  | { feedId: string; status: "ok"; inserted: number; parsed: number }
-  | { feedId: string; status: "not_modified"; inserted: number; parsed: number }
-  | {
-      feedId: string;
-      status: "error";
-      inserted: number;
-      parsed: number;
-      error: string;
-      errorKind: CollectErrorKind;
-    };
-
-/**
- * 例外からエラー種別を分類する。
- * isRetryableError と対になる分類で、同じ判定ロジックを使う。
- */
-export function classifyError(err: unknown): CollectErrorKind {
-  if (!(err instanceof Error)) return "unknown";
-  if (err.name === "AbortError") return "timeout";
-  if (err instanceof TypeError) return "network";
-  const m = /^HTTP (\d+)/.exec(err.message);
-  if (m) {
-    const code = Number(m[1]);
-    if (code === 429 || (code >= 500 && code < 600)) return "http_server";
-    if (code >= 400 && code < 500) return "http_client";
-  }
-  return "unknown";
-}
-
-export interface CollectAllResult {
-  total: number;
-  inserted: number;
-  pruned: number;
-  results: CollectResult[];
-  durationMs: number;
-}
-
-// 一部のブログ (mercari-engineering 等) は WAF が "bot" 名を含む UA を 403 で弾くため、
-// Mozilla 互換プレフィックスを付ける。Feedly / NewsBlur など主要 RSS リーダも同様の手法。
-const USER_AGENT =
-  "Mozilla/5.0 (compatible; tech-news-bot/0.1; +https://github.com/rikeda71/tech-news-bot)";
-
-/** 一時障害とみなしてリトライすべき HTTP ステータスかどうか */
-function isTransientStatus(status: number): boolean {
-  return status === 429 || (status >= 500 && status < 600);
-}
-
-/**
- * リトライ対象かどうかを判定する。
- * - AbortError: タイムアウト
- * - TypeError: ネットワーク接続失敗 ("Failed to fetch" 等)
- * - HTTP 5xx / 429: 一時的なサーバー障害
- * - HTTP 4xx (429 除く): 恒久エラーのためリトライしない
- * テスト用に export する
- */
-export function isRetryableError(err: unknown): boolean {
-  if (!(err instanceof Error)) return false;
-  if (err.name === "AbortError") return true;
-  if (err instanceof TypeError) return true;
-  const m = /^HTTP (\d+)/.exec(err.message);
-  if (m) return isTransientStatus(Number(m[1]));
-  // HTTP エラー以外の予期しないエラーはリトライしない
-  return false;
-}
-
-/** fetchFeedOnce の戻り値。304 の場合は xml が null になる。 */
-interface FetchFeedResult {
-  xml: string | null;
-  etag: string | null;
-  lastModified: string | null;
-  notModified: boolean;
-}
-
-/**
- * 1 回の HTTP fetch を試みる。失敗時は呼び出し元でリトライを判断する。
- * - 4xx (429 除く) は恒久エラーなので Error をそのまま throw
- * - 5xx / 429 / AbortError / ネットワークエラーは throw して呼び出し元がリトライ
- * - 304 Not Modified は notModified=true で返す (リトライしない)
- */
-async function fetchFeedOnce(
-  url: string,
-  timeoutMs: number,
-  conditionalHeaders: { etag: string | null; lastModified: string | null },
-): Promise<FetchFeedResult> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    const reqHeaders: Record<string, string> = {
-      "User-Agent": USER_AGENT,
-      Accept: "application/atom+xml, application/rss+xml, application/xml;q=0.9, */*;q=0.5",
-    };
-    if (conditionalHeaders.etag) {
-      reqHeaders["if-none-match"] = conditionalHeaders.etag;
-    }
-    if (conditionalHeaders.lastModified) {
-      reqHeaders["if-modified-since"] = conditionalHeaders.lastModified;
-    }
-
-    const res = await fetch(url, {
-      headers: reqHeaders,
-      signal: controller.signal,
-      redirect: "follow",
-    });
-
-    // 304: サーバが変更なしと判断。parse/insert をスキップする。
-    if (res.status === 304) {
-      return { xml: null, etag: null, lastModified: null, notModified: true };
-    }
-
-    if (!res.ok) {
-      throw new Error(`HTTP ${res.status} ${res.statusText}`);
-    }
-
-    const contentLength = Number(res.headers.get("content-length") ?? 0);
-    if (contentLength > MAX_FEED_BYTES) {
-      throw new Error(`Feed too large: ${contentLength} bytes`);
-    }
-    const text = await res.text();
-    if (text.length > MAX_FEED_BYTES) {
-      throw new Error(`Feed body too large: ${text.length} bytes`);
-    }
-
-    return {
-      xml: text,
-      etag: res.headers.get("etag"),
-      lastModified: res.headers.get("last-modified"),
-      notModified: false,
-    };
-  } finally {
-    clearTimeout(timer);
-  }
-}
-
-/**
- * 一時障害 (5xx / 429 / AbortError / ネットワークエラー) に対して
- * 指数バックオフ + jitter でリトライする。4xx / 304 は即 return。
- * sleep は wallclock のみ消費するため Worker の CPU 制限に影響しない。
- * テスト用に export する
- */
-export async function fetchFeed(
-  url: string,
-  timeoutMs: number,
-  maxRetries: number,
-  conditionalHeaders: { etag: string | null; lastModified: string | null } = {
-    etag: null,
-    lastModified: null,
-  },
-): Promise<FetchFeedResult> {
-  let lastError: unknown;
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    try {
-      return await fetchFeedOnce(url, timeoutMs, conditionalHeaders);
-    } catch (err) {
-      lastError = err;
-
-      const isRetryable = isRetryableError(err);
-
-      if (!isRetryable || attempt >= maxRetries) break;
-
-      // base * 2^attempt + jitter(0..base)
-      const delayMs = BACKOFF_BASE_MS * 2 ** attempt + Math.random() * BACKOFF_BASE_MS;
-      console.warn(
-        `[collector] fetchFeed attempt ${attempt + 1} failed for ${url}: ${err instanceof Error ? err.message : String(err)}. Retrying in ${Math.round(delayMs)}ms`,
-      );
-      await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
-    }
-  }
-  throw lastError;
-}
-
-function isSafeUrl(url: string): boolean {
-  return ALLOWED_URL_PREFIXES.some((p) => url.toLowerCase().startsWith(p));
-}
-
-/**
- * 1 feed 分の収集。per-feed の D1 書き込みを 1 batch にまとめて
- * Worker の subrequest 上限を圧迫しないようにする。
- *
- * Subrequest 内訳 (Cloudflare Workers の subrequest 上限対策):
- * - 304:    fetch (1) + batch[recordFetchSuccess + recordRunFeed?] (1) = 2
- * - 200:    fetch (1) + SELECT existing guids (1) + batch[updateHeaders + INSERTs + recordFetchSuccess + recordRunFeed?] (1) = 3
- * - error:  fetch (1) + batch[recordFetchError + recordRunFeed?] (1) = 2
- *
- * runId が null なら recordRunFeed は省略 (テスト等で run tracking 無効時)。
- */
-async function collectFeed(
-  env: Env,
-  feed: FeedConfig,
-  savedHeaders: FeedHeaders,
-  summaryMax: number,
-  timeoutMs: number,
-  maxRetries: number,
-  runId: number | null,
-  d1Acc: D1CostAccumulator,
-): Promise<CollectResult> {
-  const fetchedAt = new Date().toISOString();
-  const t0 = performance.now();
-  const feedStart = Date.now();
-  try {
-    // savedHeaders は collectAll 冒頭で全 enabled feed 分を 1 query でまとめて取得済み。
-    // feed あたり 1 read を消費しないので Worker の subrequest 上限対策になる。
-    const result = await fetchFeed(feed.url, timeoutMs, maxRetries, {
-      etag: savedHeaders.last_etag,
-      lastModified: savedHeaders.last_modified,
-    });
-
-    // 304 Not Modified: parse/insert をスキップし last_fetched_at だけ更新する
-    if (result.notModified) {
-      const stmts: D1PreparedStatement[] = [
-        buildRecordFetchSuccessStmt(env.DB, feed.id, fetchedAt, 0, "not_modified"),
-      ];
-      if (runId !== null) {
-        stmts.push(
-          buildRecordRunFeedStmt(env.DB, runId, feed.id, "skipped", 0, Date.now() - feedStart),
-        );
-      }
-      const batchResults = await env.DB.batch(stmts);
-      for (const r of batchResults) d1Acc.add(r.meta);
-      writeCollectorEvent(env, {
-        feedId: feed.id,
-        status: "not_modified",
-        ms: Math.round(performance.now() - t0),
-        statusCode: 304,
-      });
-      return { feedId: feed.id, status: "not_modified", inserted: 0, parsed: 0 };
-    }
-
-    // 200 OK path
-    const allItems = parseFeed(result.xml!, {
-      summaryMaxLength: summaryMax,
-      fallbackPublishedAt: fetchedAt,
-    });
-
-    const items = allItems.filter((i) => i.url && isSafeUrl(i.url)).slice(0, MAX_ITEMS_PER_FEED);
-
-    const guids = await buildGuids(
-      items.map((i) => ({
-        feedId: feed.id,
-        rawGuid: i.rawGuid,
-        url: i.url,
-        title: i.title,
-        publishedAt: i.publishedAt,
-      })),
-    );
-
-    const rows: InsertableArticle[] = items.map((item, idx) => ({
-      guid: guids[idx],
-      feed_id: feed.id,
-      title: item.title.slice(0, 500),
-      url: item.url!.slice(0, 1000),
-      summary: item.summary,
-      author: item.author ? item.author.slice(0, 200) : null,
-      published_at: item.publishedAt,
-      category: feed.category,
-      lang: feed.lang,
-    }));
-
-    // FTS トリガが INSERT OR IGNORE の changes() を変動させるため事前に既存 guid を引いて
-    // 新規行のみ INSERT する。SELECT は 1 subrequest だが per-feed batch とは独立して実行する。
-    const existingSet = await findExistingArticleGuids(
-      env.DB,
-      rows.map((r) => r.guid),
-    );
-    const newRows = rows.filter((r) => !existingSet.has(r.guid));
-    const inserted = newRows.length;
-
-    // header 更新 + INSERT 群 + recordFetchSuccess + recordRunFeed を 1 batch に集約。
-    // MAX_ITEMS_PER_FEED=50 + 3 = 53 stmts なので D1 batch 上限 100 を超えない。
-    const stmts: D1PreparedStatement[] = [
-      buildUpdateFeedHeadersStmt(env.DB, feed.id, result.etag, result.lastModified),
-      ...buildInsertArticleStmts(env.DB, newRows),
-      buildRecordFetchSuccessStmt(env.DB, feed.id, fetchedAt, inserted),
-    ];
-    if (runId !== null) {
-      stmts.push(
-        buildRecordRunFeedStmt(env.DB, runId, feed.id, "ok", inserted, Date.now() - feedStart),
-      );
-    }
-    const batchResults = await env.DB.batch(stmts);
-    for (const r of batchResults) d1Acc.add(r.meta);
-
-    writeCollectorEvent(env, {
-      feedId: feed.id,
-      status: "ok",
-      ms: Math.round(performance.now() - t0),
-      statusCode: 200,
-    });
-    return { feedId: feed.id, status: "ok", inserted, parsed: allItems.length };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    const errorKind = classifyError(err);
-    try {
-      const stmts: D1PreparedStatement[] = [
-        buildRecordFetchErrorStmt(env.DB, feed.id, fetchedAt, message),
-      ];
-      if (runId !== null) {
-        stmts.push(
-          buildRecordRunFeedStmt(
-            env.DB,
-            runId,
-            feed.id,
-            "failed",
-            0,
-            Date.now() - feedStart,
-            message,
-          ),
-        );
-      }
-      const batchResults = await env.DB.batch(stmts);
-      for (const r of batchResults) d1Acc.add(r.meta);
-    } catch (logErr) {
-      console.error(`Failed to record error for ${feed.id}`, logErr);
-    }
-    // HTTP エラーコードをメッセージから抽出する (例: "HTTP 503 ...")
-    const statusMatch = /^HTTP (\d+)/.exec(message);
-    const statusCode = statusMatch ? Number(statusMatch[1]) : 0;
-    writeCollectorEvent(env, {
-      feedId: feed.id,
-      status: "error",
-      ms: Math.round(performance.now() - t0),
-      statusCode,
-    });
-    return {
-      feedId: feed.id,
-      status: "error",
-      inserted: 0,
-      parsed: 0,
-      error: message,
-      errorKind,
-    };
-  }
-}
-
-async function runWithConcurrency<T, R>(
-  items: T[],
-  concurrency: number,
-  worker: (item: T) => Promise<R>,
-): Promise<R[]> {
-  const results: R[] = Array.from({ length: items.length });
-  let cursor = 0;
-  const runners = Array.from({ length: Math.max(1, concurrency) }, async () => {
-    while (true) {
-      const idx = cursor++;
-      if (idx >= items.length) return;
-      results[idx] = await worker(items[idx]);
-    }
-  });
-  await Promise.all(runners);
-  return results;
-}
+export type { CollectErrorKind, CollectResult, CollectAllResult };
+export { classifyError, isRetryableError, fetchFeed };
 
 export type ValidateFeedResult =
   | { ok: true; title: string; lang: string | null; item_count: number }
@@ -474,6 +100,24 @@ export async function validateFeedUrl(url: string): Promise<ValidateFeedResult> 
   }
 
   return { ok: false, error: "not a valid RSS or Atom feed" };
+}
+
+async function runWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = Array.from({ length: items.length });
+  let cursor = 0;
+  const runners = Array.from({ length: Math.max(1, concurrency) }, async () => {
+    while (true) {
+      const idx = cursor++;
+      if (idx >= items.length) return;
+      results[idx] = await worker(items[idx]);
+    }
+  });
+  await Promise.all(runners);
+  return results;
 }
 
 export async function collectAll(


### PR DESCRIPTION
## Summary

- `apps/web/worker/collector/index.ts` (627 行) を責務ごとに分割し 271 行に縮小
- 新規ファイル: `collectTypes.ts` (59) / `fetcher.ts` (136) / `feedWriter.ts` (239)
- `collectFeed` の 304 / 200 / error 3 ブランチを `handleNotModified` / `handleSuccess` / `handleError` に分離
- 新規テスト `tests/worker/collector/feedWriter.test.ts` (14 ケース、AAA + expect.soft + 古典派)

## 構成変更

| ファイル | 行数 | 責務 |
| --- | --- | --- |
| collectTypes.ts | 59 | CollectErrorKind / CollectResult / CollectAllResult / classifyError |
| fetcher.ts | 136 | fetchFeed / fetchFeedOnce / isRetryableError + 定数 |
| feedWriter.ts | 239 | collectFeed + handleNotModified / handleSuccess / handleError |
| index.ts | 271 (was 627) | collectAll / collectFeeds / validateFeedUrl / runWithConcurrency + re-export |

## 動作変更

ゼロ。リトライ / conditional GET / error counting / 304 ハンドリング / log 出力すべて従前どおり。

## subrequest 数

304 / 200 / error 各パスの `fetchFeed` 呼び出しパターンは未変更 (#396 で削減した状態を維持)。

## Test plan
- [x] pnpm test 全 767 件 pass (55 files)
- [x] 新規 feedWriter.test.ts 14 ケースが緑
- [x] 既存 collector テスト (retry / conditionalGet) が緑

Closes #400