### PR TITLE
refactor(client): consolidate feed category guards into shared module

### DIFF
--- a/apps/web/client/components/Stats.tsx
+++ b/apps/web/client/components/Stats.tsx
@@ -1,11 +1,10 @@
-import type { FeedActivity, Stats, TrendPoint } from "../hooks/useStats";
+import { FEED_CATEGORIES } from "../lib/feed-categories";
+import type { FeedActivity, Stats } from "../hooks/useStats";
 import { StatsChart } from "./StatsChart";
 
 interface StatsProps {
   stats: Stats;
 }
-
-const TREND_CATEGORIES: Array<keyof Omit<TrendPoint, "date">> = ["bigtech", "ai", "jp", "personal"];
 
 function formatDate(iso: string): string {
   const d = new Date(iso);
@@ -60,7 +59,7 @@ function FeedActivityTable({ rows }: { rows: FeedActivity[] }) {
 export function StatsPanel({ stats }: StatsProps) {
   const hasTrend =
     stats.category_trend_30d.length > 0 &&
-    stats.category_trend_30d.some((p) => TREND_CATEGORIES.some((c) => p[c] > 0));
+    stats.category_trend_30d.some((p) => FEED_CATEGORIES.some((c) => p[c] > 0));
 
   return (
     <section className="mb-[var(--space-6)] p-[var(--space-4)] bg-[var(--bg-elevated)] border border-[var(--border-subtle)] rounded-[var(--radius-lg)]">
@@ -68,7 +67,7 @@ export function StatsPanel({ stats }: StatsProps) {
         カテゴリ別 30 日トレンド
       </h2>
       {hasTrend ? (
-        <StatsChart data={stats.category_trend_30d} categories={TREND_CATEGORIES} />
+        <StatsChart data={stats.category_trend_30d} categories={FEED_CATEGORIES} />
       ) : (
         <p className="text-[var(--fg-muted)] text-[var(--font-size-sm)] m-0">
           過去 30 日のデータがありません

--- a/apps/web/client/components/StatsChart.tsx
+++ b/apps/web/client/components/StatsChart.tsx
@@ -2,7 +2,7 @@ import type { TrendPoint } from "../hooks/useStats";
 
 interface StatsChartProps {
   data: TrendPoint[];
-  categories: Array<keyof Omit<TrendPoint, "date">>;
+  categories: ReadonlyArray<keyof Omit<TrendPoint, "date">>;
 }
 
 // カテゴリごとの色 (CSS 変数が使えないため直値; ライト/ダーク両対応の中間色)

--- a/apps/web/client/hooks/useUrlState.ts
+++ b/apps/web/client/hooks/useUrlState.ts
@@ -1,4 +1,5 @@
 import { useCallback, useRef, useSyncExternalStore } from "react";
+import { isFeedCategory, isFeedLang } from "../lib/feed-categories";
 import type { FeedCategory, FeedLang } from "../types/api";
 
 export type FilterState = {
@@ -7,9 +8,6 @@ export type FilterState = {
   lang: FeedLang | "";
   bookmarksOnly: boolean;
 };
-
-const VALID_CATEGORIES = new Set<string>(["bigtech", "ai", "jp", "personal"]);
-const VALID_LANGS = new Set<string>(["ja", "en"]);
 
 const DEFAULT_STATE: FilterState = {
   q: "",
@@ -25,8 +23,8 @@ export function parseSearch(search: string): FilterState {
   const lang = params.get("lang") ?? "";
   return {
     q: params.get("q") ?? "",
-    category: VALID_CATEGORIES.has(category) ? (category as FeedCategory) : "",
-    lang: VALID_LANGS.has(lang) ? (lang as FeedLang) : "",
+    category: isFeedCategory(category) ? category : "",
+    lang: isFeedLang(lang) ? lang : "",
     bookmarksOnly: params.get("bookmarks") === "only",
   };
 }

--- a/apps/web/client/lib/feed-categories.ts
+++ b/apps/web/client/lib/feed-categories.ts
@@ -1,0 +1,29 @@
+import type { FeedCategory, FeedLang } from "../types/api";
+
+// カテゴリ / 言語の有効値を一元管理するモジュール。
+// worker 側の _guards.ts は依存方向の都合上 import できないため、
+// client 専用の集約モジュールとして定義する。
+
+export const FEED_CATEGORIES = [
+  "bigtech",
+  "ai",
+  "jp",
+  "personal",
+] as const satisfies readonly FeedCategory[];
+
+export const FEED_LANGS = ["ja", "en"] as const satisfies readonly FeedLang[];
+
+// readonly string[] 型にしてから includes で比較するため、
+// FeedCategory / FeedLang の string への拡張は satisfies で保証済みのため安全。
+const FEED_CATEGORIES_STR: readonly string[] = FEED_CATEGORIES;
+const FEED_LANGS_STR: readonly string[] = FEED_LANGS;
+
+/** 文字列が有効な FeedCategory かを判定する型ガード */
+export function isFeedCategory(value: unknown): value is FeedCategory {
+  return typeof value === "string" && FEED_CATEGORIES_STR.includes(value);
+}
+
+/** 文字列が有効な FeedLang かを判定する型ガード */
+export function isFeedLang(value: unknown): value is FeedLang {
+  return typeof value === "string" && FEED_LANGS_STR.includes(value);
+}

--- a/apps/web/client/lib/feed-categories.ts
+++ b/apps/web/client/lib/feed-categories.ts
@@ -11,12 +11,9 @@ export const FEED_CATEGORIES = [
   "personal",
 ] as const satisfies readonly FeedCategory[];
 
-export const FEED_LANGS = ["ja", "en"] as const satisfies readonly FeedLang[];
-
 // readonly string[] 型にしてから includes で比較するため、
-// FeedCategory / FeedLang の string への拡張は satisfies で保証済みのため安全。
+// FeedCategory の string への拡張は satisfies で保証済みのため安全。
 const FEED_CATEGORIES_STR: readonly string[] = FEED_CATEGORIES;
-const FEED_LANGS_STR: readonly string[] = FEED_LANGS;
 
 /** 文字列が有効な FeedCategory かを判定する型ガード */
 export function isFeedCategory(value: unknown): value is FeedCategory {
@@ -25,5 +22,6 @@ export function isFeedCategory(value: unknown): value is FeedCategory {
 
 /** 文字列が有効な FeedLang かを判定する型ガード */
 export function isFeedLang(value: unknown): value is FeedLang {
-  return typeof value === "string" && FEED_LANGS_STR.includes(value);
+  const FEED_LANGS: readonly string[] = ["ja", "en"] satisfies readonly FeedLang[];
+  return typeof value === "string" && FEED_LANGS.includes(value);
 }


### PR DESCRIPTION
## Summary
- client 側で重複していた VALID_CATEGORIES / VALID_LANGS / 型 guard を `client/lib/feed-categories.ts` に集約
- 重複削除箇所:
  - `apps/web/client/hooks/useUrlState.ts:11-12` — `VALID_CATEGORIES` / `VALID_LANGS` の Set 定義を削除、`isFeedCategory` / `isFeedLang` の import に置き換え
  - `apps/web/client/components/Stats.tsx:8` — `TREND_CATEGORIES` のインライン配列定義を削除、`FEED_CATEGORIES` の import に置き換え
- worker 側 (`worker/api/_guards.ts`) には触らず依存方向を維持

Closes #412

## Test plan
- [x] vp check pass
- [x] vp test run pass
- [x] vp test run --config vitest.client.config.ts pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated feed category and language configuration into a centralized module to improve consistency and maintainability across the application.
  * Strengthened URL parameter validation to ensure only valid categories and languages are processed, enhancing data integrity and application robustness.
  * Simplified component configuration by providing consistent category data across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->