### PR TITLE
refactor(d1-client): add JSDoc types and enable checkJs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,15 @@ importers:
         specifier: ^4.86.0
         version: 4.86.0(@cloudflare/workers-types@4.20260426.1)
 
+  tools/d1-client:
+    devDependencies:
+      '@types/node':
+        specifier: ^24.0.0
+        version: 24.12.2
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
 packages:
 
   '@babel/code-frame@7.29.0':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - "apps/*"
+  - "tools/*"
 catalog:
   vite: npm:@voidzero-dev/vite-plus-core@^0.1.20
   vite-plus: ^0.1.20

--- a/tools/d1-client/merge-overlapping-reports.mjs
+++ b/tools/d1-client/merge-overlapping-reports.mjs
@@ -34,7 +34,48 @@ const DB_NAME = "tech-news-bot-db";
 
 const VALID_KINDS = new Set(["daily", "weekly", "monthly"]);
 
+/**
+ * @typedef {"local" | "remote"} Target
+ */
+
+/**
+ * @typedef {Object} ParsedArgs
+ * @property {Target} target - D1 ターゲット
+ * @property {boolean} apply - true の場合は実際に DB 変更を実行
+ * @property {string[] | null} kinds - 対象 kind の配列。null は全 kind
+ */
+
+/**
+ * @typedef {Object} ReportRow
+ * @property {number} id
+ * @property {string} kind
+ * @property {string} period_start
+ * @property {string} period_end
+ * @property {string} cat - COALESCE(category, '__all__') の値
+ * @property {string} lng - COALESCE(lang, '__all__') の値
+ * @property {string | null} category
+ * @property {string | null} lang
+ * @property {string} generated_at
+ */
+
+/**
+ * @typedef {Object} ClusterResult
+ * @property {number} keep_id
+ * @property {number[]} dropped_ids
+ * @property {string} period_start
+ * @property {string} period_end
+ * @property {string} kind
+ * @property {string | null} category
+ * @property {string | null} lang
+ */
+
+/**
+ * コマンドライン引数をパースする。
+ * @param {string[]} argv - process.argv
+ * @returns {ParsedArgs}
+ */
 function parseArgs(argv) {
+  /** @type {ParsedArgs} */
   const out = { target: "local", apply: false, kinds: null };
   for (const arg of argv.slice(2)) {
     if (arg === "--apply") {
@@ -44,7 +85,7 @@ function parseArgs(argv) {
     const m = arg.match(/^--([\w-]+)=(.+)$/);
     if (!m) continue;
     const [, k, v] = m;
-    if (k === "target") out.target = v;
+    if (k === "target") out.target = /** @type {Target} */ (v);
     else if (k === "kind") {
       out.kinds = v
         .split(",")
@@ -57,6 +98,12 @@ function parseArgs(argv) {
 
 // ---- wrangler helper (inline from recent.mjs) ----
 
+/**
+ * wrangler d1 execute を実行して results 配列を返す。
+ * @param {string} sql - 実行する SQL
+ * @param {Target} target - D1 ターゲット
+ * @returns {ReportRow[]}
+ */
 function execWrangler(sql, target) {
   const args = [
     "exec",
@@ -80,6 +127,7 @@ function execWrangler(sql, target) {
   if (start < 0 || end < 0 || end <= start) {
     throw new Error(`wrangler stdout did not contain JSON array:\n${stdout}`);
   }
+  /** @type {Array<{ results?: ReportRow[] }>} */
   const parsed = JSON.parse(stdout.slice(start, end + 1));
   return parsed[0]?.results ?? [];
 }
@@ -95,15 +143,34 @@ FROM reports
 ORDER BY kind, cat, lng, period_start;
 `.trim();
 
-// 半開区間 [a_start, a_end) と [b_start, b_end) が overlap するか判定
-// 完全一致は UNIQUE 制約で重複しないはずだが、念のため除外しない (merge 対象にする)。
+/**
+ * 半開区間 [a.period_start, a.period_end) と [b.period_start, b.period_end) が overlap するか判定。
+ * 完全一致は UNIQUE 制約で重複しないはずだが、念のため除外しない (merge 対象にする)。
+ * @param {ReportRow} a
+ * @param {ReportRow} b
+ * @returns {boolean}
+ */
 function overlaps(a, b) {
   return a.period_start < b.period_end && a.period_end > b.period_start;
 }
 
-// Union-Find
+/**
+ * @typedef {Object} UnionFind
+ * @property {(x: number) => number} find
+ * @property {(x: number, y: number) => void} union
+ */
+
+/**
+ * Union-Find データ構造を生成する。
+ * @param {number} n - 要素数
+ * @returns {UnionFind}
+ */
 function makeUF(n) {
   const parent = Array.from({ length: n }, (_, i) => i);
+  /**
+   * @param {number} x
+   * @returns {number}
+   */
   function find(x) {
     while (parent[x] !== x) {
       parent[x] = parent[parent[x]];
@@ -111,22 +178,33 @@ function makeUF(n) {
     }
     return x;
   }
+  /**
+   * @param {number} x
+   * @param {number} y
+   * @returns {void}
+   */
   function union(x, y) {
     parent[find(x)] = find(y);
   }
   return { find, union };
 }
 
-// 同 (kind, cat, lng) グループ内で overlap するペアを Union-Find でクラスタ化
+/**
+ * 同 (kind, cat, lng) グループ内で overlap するペアを Union-Find でクラスタ化する。
+ * @param {ReportRow[]} rows
+ * @returns {ReportRow[][]} overlap するメンバーが 2 件以上のクラスタ配列
+ */
 function clusterRows(rows) {
   // グループ化
+  /** @type {Map<string, ReportRow[]>} */
   const groups = new Map();
   for (const row of rows) {
     const key = `${row.kind}|${row.cat}|${row.lng}`;
     if (!groups.has(key)) groups.set(key, []);
-    groups.get(key).push(row);
+    /** @type {ReportRow[]} */ (groups.get(key)).push(row);
   }
 
+  /** @type {ReportRow[][]} */
   const clusters = [];
   for (const group of groups.values()) {
     if (group.length < 2) continue;
@@ -139,11 +217,12 @@ function clusterRows(rows) {
       }
     }
     // クラスタごとに集約
+    /** @type {Map<number, ReportRow[]>} */
     const clusterMap = new Map();
     for (let i = 0; i < group.length; i++) {
       const root = uf.find(i);
       if (!clusterMap.has(root)) clusterMap.set(root, []);
-      clusterMap.get(root).push(group[i]);
+      /** @type {ReportRow[]} */ (clusterMap.get(root)).push(group[i]);
     }
     for (const members of clusterMap.values()) {
       if (members.length < 2) continue; // overlap なし
@@ -179,11 +258,14 @@ function main() {
     }
   }
 
+  /** @type {ReportRow[]} */
   let rows;
   try {
     rows = execWrangler(FETCH_ROWS_SQL, opts.target);
   } catch (err) {
-    process.stderr.write(`Failed to fetch rows: ${err.message}\n`);
+    process.stderr.write(
+      `Failed to fetch rows: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
     process.exit(1);
   }
 
@@ -194,6 +276,7 @@ function main() {
 
   const clusters = clusterRows(rows);
 
+  /** @type {{ target: Target; dry_run: boolean; clusters: ClusterResult[]; total_dropped: number }} */
   const output = {
     target: opts.target,
     dry_run: !opts.apply,
@@ -240,7 +323,9 @@ function main() {
       try {
         execWrangler(mergeSQL, opts.target);
       } catch (err) {
-        process.stderr.write(`Failed to apply merge for keep_id=${keep.id}: ${err.message}\n`);
+        process.stderr.write(
+          `Failed to apply merge for keep_id=${keep.id}: ${err instanceof Error ? err.message : String(err)}\n`,
+        );
         process.exit(1);
       }
     }

--- a/tools/d1-client/package.json
+++ b/tools/d1-client/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@tnb/d1-client",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "typescript": "^6.0.3"
+  }
+}

--- a/tools/d1-client/recent.mjs
+++ b/tools/d1-client/recent.mjs
@@ -49,11 +49,6 @@ const DB_NAME = "tech-news-bot-db";
  */
 
 /**
- * @typedef {Object} AggregateMap
- * @type {Record<string, number>}
- */
-
-/**
  * コマンドライン引数をパースする。
  * @param {string[]} argv - process.argv
  * @returns {ParsedArgs}

--- a/tools/d1-client/recent.mjs
+++ b/tools/d1-client/recent.mjs
@@ -24,14 +24,49 @@ const REPO_ROOT = path.resolve(path.dirname(__filename), "..", "..");
 const WRANGLER_DIR = path.join(REPO_ROOT, "apps", "web");
 const DB_NAME = "tech-news-bot-db";
 
+/**
+ * @typedef {Object} ParsedArgs
+ * @property {string | null} since - 期間指定 (today|week|month|<N>)
+ * @property {"local" | "remote"} target - D1 ターゲット
+ * @property {string | null} category - カテゴリフィルタ (カンマ区切り可)
+ * @property {string | null} lang - 言語フィルタ (ja|en)
+ * @property {number} limit - 取得上限件数
+ */
+
+/**
+ * @typedef {Object} Article
+ * @property {number} id
+ * @property {string} guid
+ * @property {number} feed_id
+ * @property {string | null} feed_name
+ * @property {string} title
+ * @property {string} url
+ * @property {string | null} summary
+ * @property {string | null} author
+ * @property {string} published_at
+ * @property {string | null} category
+ * @property {string | null} lang
+ */
+
+/**
+ * @typedef {Object} AggregateMap
+ * @type {Record<string, number>}
+ */
+
+/**
+ * コマンドライン引数をパースする。
+ * @param {string[]} argv - process.argv
+ * @returns {ParsedArgs}
+ */
 function parseArgs(argv) {
+  /** @type {ParsedArgs} */
   const out = { since: null, target: "local", category: null, lang: null, limit: 200 };
   for (const arg of argv.slice(2)) {
     const m = arg.match(/^--([\w-]+)=(.+)$/);
     if (!m) continue;
     const [, k, v] = m;
     if (k === "since") out.since = v;
-    else if (k === "target") out.target = v;
+    else if (k === "target") out.target = /** @type {"local" | "remote"} */ (v);
     else if (k === "category") out.category = v;
     else if (k === "lang") out.lang = v;
     else if (k === "limit") out.limit = Number.parseInt(v, 10) || 200;
@@ -39,6 +74,11 @@ function parseArgs(argv) {
   return out;
 }
 
+/**
+ * 期間指定文字列を ISO 8601 日時文字列に変換する。
+ * @param {string} spec - today|week|this-week|month|this-month|<N>
+ * @returns {string} ISO 8601 形式の日時文字列
+ */
 function sinceToISO(spec) {
   const now = new Date();
   let ms;
@@ -53,9 +93,22 @@ function sinceToISO(spec) {
   return new Date(now.getTime() - ms).toISOString();
 }
 
-const VALID_CATEGORIES = ["bigtech", "ai", "jp", "personal"];
-const VALID_LANGS = ["ja", "en"];
+const VALID_CATEGORIES = /** @type {readonly string[]} */ (["bigtech", "ai", "jp", "personal"]);
+const VALID_LANGS = /** @type {readonly string[]} */ (["ja", "en"]);
 
+/**
+ * @typedef {Object} BuildSQLParams
+ * @property {string} since - ISO 8601 日時文字列 (既変換済み)
+ * @property {string | null} category - カテゴリフィルタ
+ * @property {string | null} lang - 言語フィルタ
+ * @property {number} limit - 取得上限
+ */
+
+/**
+ * D1 クエリ SQL を構築する。
+ * @param {BuildSQLParams} params
+ * @returns {string}
+ */
 function buildSQL({ since, category, lang, limit }) {
   const where = [`a.published_at > '${since.replace(/'/g, "''")}'`];
   if (category) {
@@ -92,6 +145,12 @@ LIMIT ${Math.max(1, Math.min(limit, 1000))};
   `.trim();
 }
 
+/**
+ * wrangler d1 execute を実行して results 配列を返す。
+ * @param {string} sql - 実行する SQL
+ * @param {"local" | "remote"} target - D1 ターゲット
+ * @returns {Article[]}
+ */
 function execWrangler(sql, target) {
   const args = [
     "exec",
@@ -116,15 +175,23 @@ function execWrangler(sql, target) {
   if (start < 0 || end < 0 || end <= start) {
     throw new Error(`wrangler stdout did not contain JSON array:\n${stdout}`);
   }
+  /** @type {Array<{ results?: Article[] }>} */
   const parsed = JSON.parse(stdout.slice(start, end + 1));
   // wrangler --json: [{ results: [...], success: true, meta: {...} }]
   return parsed[0]?.results ?? [];
 }
 
+/**
+ * 記事配列を指定キーで集計して Record を返す。
+ * @param {Article[]} articles
+ * @param {keyof Article} key
+ * @returns {Record<string, number>}
+ */
 function aggregate(articles, key) {
+  /** @type {Record<string, number>} */
   const out = {};
   for (const a of articles) {
-    const k = a[key] ?? "unknown";
+    const k = String(a[key] ?? "unknown");
     out[k] = (out[k] ?? 0) + 1;
   }
   return out;
@@ -138,17 +205,19 @@ function main() {
   }
   const sinceISO = sinceToISO(opts.since);
   const sql = buildSQL({ ...opts, since: sinceISO });
+  /** @type {Article[]} */
   let articles;
   try {
     articles = execWrangler(sql, opts.target);
   } catch (err) {
-    process.stderr.write(`${err.message}\n`);
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
     process.exit(1);
   }
   // URL による de-dup: 同一記事が複数フィード間で重複することがあるため、
   // 最も古い published_at のものを 1 件だけ残す。
   const sorted = articles.toSorted((a, b) => a.published_at.localeCompare(b.published_at));
   const seen = new Set();
+  /** @type {Article[]} */
   const deduped = [];
   for (const a of sorted) {
     if (!seen.has(a.url)) {

--- a/tools/d1-client/reports.mjs
+++ b/tools/d1-client/reports.mjs
@@ -112,9 +112,10 @@ function parseArgs(argv) {
 
 /**
  * wrangler d1 execute を実行して results 配列を返す。
+ * @template {object} T
  * @param {string} sql - 実行する SQL
  * @param {Target} target - D1 ターゲット
- * @returns {ReportRow[]}
+ * @returns {T[]}
  */
 function execWrangler(sql, target) {
   const args = [
@@ -140,7 +141,7 @@ function execWrangler(sql, target) {
   if (start < 0 || end < 0 || end <= start) {
     throw new Error(`wrangler stdout did not contain JSON array:\n${stdout}`);
   }
-  /** @type {Array<{ results?: ReportRow[] }>} */
+  /** @type {Array<{ results?: T[] }>} */
   const parsed = JSON.parse(stdout.slice(start, end + 1));
   // wrangler --json: [{ results: [...], success: true, meta: {...} }]
   return parsed[0]?.results ?? [];
@@ -416,9 +417,7 @@ ORDER BY a.kind, a.period_start, a.id, b.id;
   /** @type {OverlapRow[]} */
   let rows;
   try {
-    // execWrangler の戻り値は ReportRow[] 型だが、find-overlaps は JOIN 結果を返すため
-    // OverlapRow[] にキャストする。JOIN 結果のカラム構造は上記 SQL が保証する。
-    rows = /** @type {OverlapRow[]} */ (/** @type {unknown} */ (execWrangler(sql, opts.target)));
+    rows = /** @type {OverlapRow[]} */ (execWrangler(sql, opts.target));
   } catch (err) {
     process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
     process.exit(1);

--- a/tools/d1-client/reports.mjs
+++ b/tools/d1-client/reports.mjs
@@ -20,19 +20,68 @@ const REPO_ROOT = path.resolve(path.dirname(__filename), "..", "..");
 const WRANGLER_DIR = path.join(REPO_ROOT, "apps", "web");
 const DB_NAME = "tech-news-bot-db";
 
+/** @type {readonly string[]} */
 const VALID_KINDS = ["daily", "weekly", "monthly"];
+/** @type {readonly string[]} */
 const VALID_TARGETS = ["local", "remote"];
 const ISO_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})$/;
 const POS_INT_RE = /^\d+$/;
 
+/**
+ * @typedef {"daily" | "weekly" | "monthly"} ReportKind
+ * @typedef {"local" | "remote"} Target
+ */
+
+/**
+ * @typedef {Object} ReportRow
+ * @property {number} id
+ * @property {ReportKind} kind
+ * @property {string} period_start
+ * @property {string} period_end
+ * @property {string | null} category
+ * @property {string | null} lang
+ * @property {string | null} source_skill
+ * @property {string} generated_at
+ * @property {number} [content_len]
+ * @property {string} [content]
+ * @property {string | null} [meta_json]
+ */
+
+/**
+ * @typedef {Object} ParsedOpts
+ * @property {string | null} kind
+ * @property {string | null} from
+ * @property {string | null} to
+ * @property {number} limit
+ * @property {Target} target
+ * @property {boolean} apply
+ */
+
+/**
+ * @typedef {Object} ParsedArgs
+ * @property {string[]} positional
+ * @property {ParsedOpts} opts
+ */
+
 // SQL リテラルへ文字列を埋め込む際の escape。validate* と二重防御。
 // 値は事前に allowlist / regex で検証済みなので通常はシングルクォート escape で十分。
+/**
+ * SQL シングルクォート文字列として安全にエスケープする。
+ * @param {string} s
+ * @returns {string}
+ */
 function sqlQuote(s) {
   return `'${s.replace(/'/g, "''")}'`;
 }
 
+/**
+ * コマンドライン引数をパースする。
+ * @param {string[]} argv - process.argv
+ * @returns {ParsedArgs}
+ */
 function parseArgs(argv) {
-  const positional = [];
+  const positional = /** @type {string[]} */ ([]);
+  /** @type {ParsedOpts} */
   const opts = {
     kind: null,
     from: null,
@@ -53,7 +102,7 @@ function parseArgs(argv) {
       else if (k === "from") opts.from = v;
       else if (k === "to") opts.to = v;
       else if (k === "limit") opts.limit = Number.parseInt(v, 10) || 50;
-      else if (k === "target") opts.target = v;
+      else if (k === "target") opts.target = /** @type {Target} */ (v);
     } else {
       positional.push(arg);
     }
@@ -61,6 +110,12 @@ function parseArgs(argv) {
   return { positional, opts };
 }
 
+/**
+ * wrangler d1 execute を実行して results 配列を返す。
+ * @param {string} sql - 実行する SQL
+ * @param {Target} target - D1 ターゲット
+ * @returns {ReportRow[]}
+ */
 function execWrangler(sql, target) {
   const args = [
     "exec",
@@ -85,11 +140,17 @@ function execWrangler(sql, target) {
   if (start < 0 || end < 0 || end <= start) {
     throw new Error(`wrangler stdout did not contain JSON array:\n${stdout}`);
   }
+  /** @type {Array<{ results?: ReportRow[] }>} */
   const parsed = JSON.parse(stdout.slice(start, end + 1));
   // wrangler --json: [{ results: [...], success: true, meta: {...} }]
   return parsed[0]?.results ?? [];
 }
 
+/**
+ * kind の値が有効か検証する。無効なら stderr に書いて exit(2)。
+ * @param {string | null} kind
+ * @returns {void}
+ */
 function validateKind(kind) {
   if (kind !== null && !VALID_KINDS.includes(kind)) {
     process.stderr.write(`Invalid --kind value: ${kind}. Allowed: ${VALID_KINDS.join(", ")}\n`);
@@ -97,6 +158,11 @@ function validateKind(kind) {
   }
 }
 
+/**
+ * target の値が有効か検証する。無効なら stderr に書いて exit(2)。
+ * @param {string} target
+ * @returns {void}
+ */
 function validateTarget(target) {
   if (!VALID_TARGETS.includes(target)) {
     process.stderr.write(
@@ -106,6 +172,12 @@ function validateTarget(target) {
   }
 }
 
+/**
+ * ISO 8601 日時文字列として有効か検証する。無効なら stderr に書いて exit(2)。
+ * @param {string | null} value
+ * @param {string} name - フラグ名 (エラーメッセージ用)
+ * @returns {void}
+ */
 function validateIso(value, name) {
   if (value !== null && !ISO_RE.test(value)) {
     process.stderr.write(
@@ -115,6 +187,11 @@ function validateIso(value, name) {
   }
 }
 
+/**
+ * カンマ区切りの ID 文字列を正の整数配列に変換する。無効なら stderr に書いて exit(2)。
+ * @param {string} rawIds - カンマ区切りの ID 文字列
+ * @returns {number[]}
+ */
 function validateIds(rawIds) {
   const tokens = rawIds
     .split(",")
@@ -133,6 +210,11 @@ function validateIds(rawIds) {
   return ids;
 }
 
+/**
+ * list サブコマンドを実行する。
+ * @param {ParsedOpts} opts
+ * @returns {void}
+ */
 function cmdList(opts) {
   validateKind(opts.kind);
   validateTarget(opts.target);
@@ -148,11 +230,12 @@ function cmdList(opts) {
 
   const sql = `SELECT id, kind, period_start, period_end, category, lang, source_skill, generated_at, length(content) AS content_len FROM reports WHERE ${where.join(" AND ")} ORDER BY generated_at DESC LIMIT ${limit};`;
 
+  /** @type {ReportRow[]} */
   let reports;
   try {
     reports = execWrangler(sql, opts.target);
   } catch (err) {
-    process.stderr.write(`${err.message}\n`);
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
     process.exit(1);
   }
 
@@ -169,15 +252,22 @@ function cmdList(opts) {
   process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
 }
 
+/**
+ * show サブコマンドを実行する。
+ * @param {number} id - レポート ID
+ * @param {ParsedOpts} opts
+ * @returns {void}
+ */
 function cmdShow(id, opts) {
   validateTarget(opts.target);
   const sql = `SELECT id, kind, period_start, period_end, category, lang, content, meta_json, source_skill, generated_at FROM reports WHERE id = ${id};`;
 
+  /** @type {ReportRow[]} */
   let rows;
   try {
     rows = execWrangler(sql, opts.target);
   } catch (err) {
-    process.stderr.write(`${err.message}\n`);
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
     process.exit(1);
   }
 
@@ -193,6 +283,12 @@ function cmdShow(id, opts) {
   process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
 }
 
+/**
+ * delete サブコマンドを実行する。
+ * @param {number[]} ids - 削除対象の ID 配列
+ * @param {ParsedOpts} opts
+ * @returns {void}
+ */
 function cmdDelete(ids, opts) {
   validateTarget(opts.target);
   const idList = ids.join(", ");
@@ -200,11 +296,12 @@ function cmdDelete(ids, opts) {
   // dry-run: SELECT して対象行を確認
   const selectSql = `SELECT id, kind, period_start, period_end, category, lang, source_skill, generated_at FROM reports WHERE id IN (${idList});`;
 
+  /** @type {ReportRow[]} */
   let found;
   try {
     found = execWrangler(selectSql, opts.target);
   } catch (err) {
-    process.stderr.write(`${err.message}\n`);
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
     process.exit(1);
   }
 
@@ -241,7 +338,7 @@ function cmdDelete(ids, opts) {
   try {
     execWrangler(deleteSql, opts.target);
   } catch (err) {
-    process.stderr.write(`${err.message}\n`);
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
     process.exit(1);
   }
 
@@ -255,6 +352,31 @@ function cmdDelete(ids, opts) {
   process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
 }
 
+/**
+ * @typedef {Object} OverlapRow
+ * @property {number} a_id
+ * @property {ReportKind} a_kind
+ * @property {string} a_period_start
+ * @property {string} a_period_end
+ * @property {string | null} a_category
+ * @property {string | null} a_lang
+ * @property {string | null} a_source_skill
+ * @property {string} a_generated_at
+ * @property {number} b_id
+ * @property {ReportKind} b_kind
+ * @property {string} b_period_start
+ * @property {string} b_period_end
+ * @property {string | null} b_category
+ * @property {string | null} b_lang
+ * @property {string | null} b_source_skill
+ * @property {string} b_generated_at
+ */
+
+/**
+ * find-overlaps サブコマンドを実行する。
+ * @param {ParsedOpts} opts
+ * @returns {void}
+ */
 function cmdFindOverlaps(opts) {
   validateKind(opts.kind);
   validateTarget(opts.target);
@@ -291,11 +413,14 @@ ${kindClause}
 ORDER BY a.kind, a.period_start, a.id, b.id;
   `.trim();
 
+  /** @type {OverlapRow[]} */
   let rows;
   try {
-    rows = execWrangler(sql, opts.target);
+    // execWrangler の戻り値は ReportRow[] 型だが、find-overlaps は JOIN 結果を返すため
+    // OverlapRow[] にキャストする。JOIN 結果のカラム構造は上記 SQL が保証する。
+    rows = /** @type {OverlapRow[]} */ (/** @type {unknown} */ (execWrangler(sql, opts.target)));
   } catch (err) {
-    process.stderr.write(`${err.message}\n`);
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
     process.exit(1);
   }
 

--- a/tools/d1-client/search.mjs
+++ b/tools/d1-client/search.mjs
@@ -23,8 +23,35 @@ const VALID_CATEGORIES = new Set(["bigtech", "ai", "jp", "personal"]);
 const VALID_LANGS = new Set(["ja", "en"]);
 
 /**
+ * @typedef {Object} ParsedArgs
+ * @property {string | null} q - 検索クエリ
+ * @property {string} since - 期間指定 (today|week|month|<N>)
+ * @property {"local" | "remote"} target - D1 ターゲット
+ * @property {string | null} category - カテゴリフィルタ
+ * @property {string | null} lang - 言語フィルタ (ja|en)
+ * @property {number} limit - 取得上限件数
+ */
+
+/**
+ * @typedef {Object} Article
+ * @property {number} id
+ * @property {string} guid
+ * @property {number} feed_id
+ * @property {string | null} feed_name
+ * @property {string} title
+ * @property {string} url
+ * @property {string | null} summary
+ * @property {string | null} author
+ * @property {string} published_at
+ * @property {string | null} category
+ * @property {string | null} lang
+ */
+
+/**
  * FTS5 オペレータ汚染を防ぐため入力をサニタイズする。
  * ダブルクォートと FTS5 特殊文字を除去し、各トークンを quoted phrase として再構築する。
+ * @param {string} q - 生の検索クエリ
+ * @returns {string} FTS5 MATCH 式
  */
 function sanitizeFtsQuery(q) {
   // ダブルクォートを除去し、FTS5 特殊文字 (* ^ ( ) : - ;) をスペースに置換
@@ -39,7 +66,13 @@ function sanitizeFtsQuery(q) {
   return tokens.map((t) => `"${t}"`).join(" ");
 }
 
+/**
+ * コマンドライン引数をパースする。
+ * @param {string[]} argv - process.argv
+ * @returns {ParsedArgs}
+ */
 function parseArgs(argv) {
+  /** @type {ParsedArgs} */
   const out = { q: null, since: "month", target: "local", category: null, lang: null, limit: 100 };
   for (const arg of argv.slice(2)) {
     const m = arg.match(/^--([\w-]+)=(.+)$/);
@@ -47,7 +80,7 @@ function parseArgs(argv) {
     const [, k, v] = m;
     if (k === "q") out.q = v;
     else if (k === "since") out.since = v;
-    else if (k === "target") out.target = v;
+    else if (k === "target") out.target = /** @type {"local" | "remote"} */ (v);
     else if (k === "category") out.category = v;
     else if (k === "lang") out.lang = v;
     else if (k === "limit") out.limit = Number.parseInt(v, 10) || 100;
@@ -55,6 +88,11 @@ function parseArgs(argv) {
   return out;
 }
 
+/**
+ * 期間指定文字列を ISO 8601 日時文字列に変換する。
+ * @param {string} spec - today|week|this-week|month|this-month|<N>
+ * @returns {string} ISO 8601 形式の日時文字列
+ */
 function sinceToISO(spec) {
   const now = new Date();
   let ms;
@@ -69,6 +107,20 @@ function sinceToISO(spec) {
   return new Date(now.getTime() - ms).toISOString();
 }
 
+/**
+ * @typedef {Object} BuildSQLParams
+ * @property {string} q - サニタイズ前の検索クエリ
+ * @property {string} since - ISO 8601 日時文字列 (既変換済み)
+ * @property {string | null} category - カテゴリフィルタ
+ * @property {string | null} lang - 言語フィルタ
+ * @property {number} limit - 取得上限
+ */
+
+/**
+ * D1 FTS5 クエリ SQL を構築する。
+ * @param {BuildSQLParams} params
+ * @returns {string}
+ */
 function buildSQL({ q, since, category, lang, limit }) {
   // sanitizeFtsQuery で特殊文字を除去済みの quoted phrase を MATCH に渡す。
   const matchExpr = sanitizeFtsQuery(q);
@@ -94,6 +146,12 @@ LIMIT ${Math.max(1, Math.min(limit, 1000))};
   `.trim();
 }
 
+/**
+ * wrangler d1 execute を実行して results 配列を返す。
+ * @param {string} sql - 実行する SQL
+ * @param {"local" | "remote"} target - D1 ターゲット
+ * @returns {Article[]}
+ */
 function execWrangler(sql, target) {
   const args = [
     "exec",
@@ -118,15 +176,23 @@ function execWrangler(sql, target) {
   if (start < 0 || end < 0 || end <= start) {
     throw new Error(`wrangler stdout did not contain JSON array:\n${stdout}`);
   }
+  /** @type {Array<{ results?: Article[] }>} */
   const parsed = JSON.parse(stdout.slice(start, end + 1));
   // wrangler --json: [{ results: [...], success: true, meta: {...} }]
   return parsed[0]?.results ?? [];
 }
 
+/**
+ * 記事配列を指定キーで集計して Record を返す。
+ * @param {Article[]} articles
+ * @param {keyof Article} key
+ * @returns {Record<string, number>}
+ */
 function aggregate(articles, key) {
+  /** @type {Record<string, number>} */
   const out = {};
   for (const a of articles) {
-    const k = a[key] ?? "unknown";
+    const k = String(a[key] ?? "unknown");
     out[k] = (out[k] ?? 0) + 1;
   }
   return out;
@@ -139,24 +205,25 @@ function main() {
     process.exit(2);
   }
   if (opts.category !== null && !VALID_CATEGORIES.has(opts.category)) {
-    const cat = String(opts.category);
     process.stderr.write(
-      `Invalid --category=${cat}. Allowed: ${[...VALID_CATEGORIES].join("|")}\n`,
+      `Invalid --category=${opts.category}. Allowed: ${[...VALID_CATEGORIES].join("|")}\n`,
     );
     process.exit(2);
   }
   if (opts.lang !== null && !VALID_LANGS.has(opts.lang)) {
-    const lang = String(opts.lang);
-    process.stderr.write(`Invalid --lang=${lang}. Allowed: ${[...VALID_LANGS].join("|")}\n`);
+    process.stderr.write(`Invalid --lang=${opts.lang}. Allowed: ${[...VALID_LANGS].join("|")}\n`);
     process.exit(2);
   }
   const sinceISO = sinceToISO(opts.since);
-  const sql = buildSQL({ ...opts, since: sinceISO });
+  // opts.q は上の null チェックで保証済みだが型推論上 null が残るため明示的に代入する。
+  const q = /** @type {string} */ (opts.q);
+  const sql = buildSQL({ ...opts, q, since: sinceISO });
+  /** @type {Article[]} */
   let articles;
   try {
     articles = execWrangler(sql, opts.target);
   } catch (err) {
-    process.stderr.write(`${err.message}\n`);
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
     process.exit(1);
   }
   const result = {

--- a/tools/d1-client/tsconfig.json
+++ b/tools/d1-client/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "types": ["node"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "include": ["./*.mjs"]
+}


### PR DESCRIPTION
## Summary
- tools/d1-client/*.mjs に JSDoc 型アノテーション付与 (`@typedef` / `@param` / `@returns`)
- `tools/d1-client/tsconfig.json` を新規作成し `checkJs: true` + `allowJs: true` + `moduleResolution: NodeNext` を有効化
- `pnpm-workspace.yaml` に `tools/*` を追加し `pnpm typecheck` (`-r`) の対象に組み込み
- `any` 残存ゼロ (キャストが必要な箇所はコメント付きの `@type` キャストに限定)
- skill のコマンドは無変更 (案 A 採用)

Closes #413

## Test plan
- [x] `pnpm --filter @tnb/d1-client typecheck` pass
- [x] `pnpm check` で d1-client 固有のエラー・警告ゼロ (既存 apps/web の警告は別 issue)
- [x] `node tools/d1-client/recent.mjs` → `Missing --since` でエラー終了 (引数パース動作確認)
- [x] `node tools/d1-client/search.mjs` → `Missing --q` でエラー終了
- [x] `node tools/d1-client/reports.mjs` → `Usage: reports.mjs <list|show|delete|find-overlaps>` でエラー終了
- [x] `node tools/d1-client/merge-overlapping-reports.mjs` → wrangler 経由で DB アクセスを試みて実行 (local DB に reports テーブルなしのため SQL エラーだが引数パースは正常)