### PR TITLE
refactor(api): extract parseListQuery from articles handler

### DIFF
--- a/apps/web/tests/worker/api/articles-parse.test.ts
+++ b/apps/web/tests/worker/api/articles-parse.test.ts
@@ -65,6 +65,15 @@ describe("decodeCursor", () => {
     const result = decodeCursor(encoded);
     expect(result).toEqual(cursor);
   });
+
+  it("strips extraneous fields and returns only publishedAt and id", () => {
+    const encoded = btoa(
+      JSON.stringify({ publishedAt: "2024-04-01T00:00:00.000Z", id: 1, foo: "bar" }),
+    );
+    const result = decodeCursor(encoded);
+    expect(result).not.toBeNull();
+    expect(Object.keys(result!).toSorted()).toEqual(["id", "publishedAt"]);
+  });
 });
 
 // ---- encodeCursor ----
@@ -74,10 +83,10 @@ describe("encodeCursor", () => {
     expect(encodeCursor(null)).toBeNull();
   });
 
-  it("returns a string for a valid cursor", () => {
+  it("returns the exact base64 encoding of the cursor JSON", () => {
     const cursor = { publishedAt: "2024-04-01T00:00:00.000Z", id: 42 };
     const result = encodeCursor(cursor);
-    expect(typeof result).toBe("string");
+    expect(result).toBe(btoa(JSON.stringify(cursor)));
   });
 
   it("round-trips: encodeCursor -> decodeCursor returns original value", () => {

--- a/apps/web/tests/worker/api/articles-parse.test.ts
+++ b/apps/web/tests/worker/api/articles-parse.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from "vite-plus/test";
+import { SELF } from "cloudflare:test";
+import { decodeCursor, encodeCursor, isValidDateRange } from "../../../worker/api/articles-parse";
+
+// ---- decodeCursor ----
+
+describe("decodeCursor", () => {
+  it("returns null when input is undefined", () => {
+    expect(decodeCursor(undefined)).toBeNull();
+  });
+
+  it("returns null when input is empty string", () => {
+    expect(decodeCursor("")).toBeNull();
+  });
+
+  it("returns null for invalid base64", () => {
+    expect(decodeCursor("not-valid-base64!!!")).toBeNull();
+  });
+
+  it("returns null when base64 decodes to non-JSON", () => {
+    // btoa("not json")
+    expect(decodeCursor(btoa("not json"))).toBeNull();
+  });
+
+  it("returns null when publishedAt field is missing", () => {
+    const encoded = btoa(JSON.stringify({ id: 1 }));
+    expect(decodeCursor(encoded)).toBeNull();
+  });
+
+  it("returns null when id field is missing", () => {
+    const encoded = btoa(JSON.stringify({ publishedAt: "2024-04-01T00:00:00Z" }));
+    expect(decodeCursor(encoded)).toBeNull();
+  });
+
+  it("returns null when publishedAt is not ISO datetime format", () => {
+    const encoded = btoa(JSON.stringify({ publishedAt: "2024-04-01", id: 1 }));
+    expect(decodeCursor(encoded)).toBeNull();
+  });
+
+  it("returns null when id is negative", () => {
+    const encoded = btoa(JSON.stringify({ publishedAt: "2024-04-01T00:00:00.000Z", id: -1 }));
+    expect(decodeCursor(encoded)).toBeNull();
+  });
+
+  it("returns null when id is non-integer (float)", () => {
+    const encoded = btoa(JSON.stringify({ publishedAt: "2024-04-01T00:00:00.000Z", id: 1.5 }));
+    expect(decodeCursor(encoded)).toBeNull();
+  });
+
+  it("returns null when id is a string", () => {
+    const encoded = btoa(JSON.stringify({ publishedAt: "2024-04-01T00:00:00.000Z", id: "1" }));
+    expect(decodeCursor(encoded)).toBeNull();
+  });
+
+  it("returns Cursor for a valid encoded cursor", () => {
+    const cursor = { publishedAt: "2024-04-01T00:00:00.000Z", id: 42 };
+    const encoded = btoa(JSON.stringify(cursor));
+    const result = decodeCursor(encoded);
+    expect(result).toEqual(cursor);
+  });
+
+  it("returns Cursor when id is 0 (boundary)", () => {
+    const cursor = { publishedAt: "2024-04-01T00:00:00.000Z", id: 0 };
+    const encoded = btoa(JSON.stringify(cursor));
+    const result = decodeCursor(encoded);
+    expect(result).toEqual(cursor);
+  });
+});
+
+// ---- encodeCursor ----
+
+describe("encodeCursor", () => {
+  it("returns null when cursor is null", () => {
+    expect(encodeCursor(null)).toBeNull();
+  });
+
+  it("returns a string for a valid cursor", () => {
+    const cursor = { publishedAt: "2024-04-01T00:00:00.000Z", id: 42 };
+    const result = encodeCursor(cursor);
+    expect(typeof result).toBe("string");
+  });
+
+  it("round-trips: encodeCursor -> decodeCursor returns original value", () => {
+    const cursor = { publishedAt: "2024-04-01T12:34:56.000Z", id: 99 };
+    const encoded = encodeCursor(cursor);
+    expect(encoded).not.toBeNull();
+    const decoded = decodeCursor(encoded ?? undefined);
+    expect(decoded).toEqual(cursor);
+  });
+});
+
+// ---- isValidDateRange ----
+
+describe("isValidDateRange", () => {
+  it("returns true when input is undefined", () => {
+    expect(isValidDateRange(undefined)).toBe(true);
+  });
+
+  it("returns true when input is empty string (treated as absent)", () => {
+    expect(isValidDateRange("")).toBe(true);
+  });
+
+  it("returns true for a valid YYYY-MM-DD date", () => {
+    expect(isValidDateRange("2024-04-01")).toBe(true);
+  });
+
+  it("returns true for a valid ISO datetime string", () => {
+    expect(isValidDateRange("2024-04-01T00:00:00.000Z")).toBe(true);
+  });
+
+  it("returns false for invalid format (no dashes)", () => {
+    expect(isValidDateRange("20240401")).toBe(false);
+  });
+
+  it("returns false for invalid format (extra characters after date)", () => {
+    expect(isValidDateRange("2024-04-01foo")).toBe(false);
+  });
+
+  it("returns false for 9999-99-99 (invalid month/day)", () => {
+    expect(isValidDateRange("9999-99-99")).toBe(false);
+  });
+
+  it("returns false for 2024-02-30 (non-existent date)", () => {
+    expect(isValidDateRange("2024-02-30")).toBe(false);
+  });
+
+  it("returns false for 2024-13-01 (invalid month)", () => {
+    expect(isValidDateRange("2024-13-01")).toBe(false);
+  });
+});
+
+// ---- parseListQuery (HTTP integration via SELF.fetch) ----
+
+describe("parseListQuery via GET /api/articles/by-author/:author", () => {
+  // parseListQuery は Context に依存するため HTTP 経由でテストする。
+  // by-author endpoint は parseListQuery(c) をデフォルトオプション (limit 1-50) で呼ぶ。
+
+  it("returns 400 when limit=0 (below minimum)", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/by-author/someone?limit=0");
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toMatch(/limit/);
+  });
+
+  it("returns 400 when limit exceeds maxLimit (51)", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/by-author/someone?limit=51");
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toMatch(/limit/);
+  });
+
+  it("returns 400 when limit is non-numeric", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/by-author/someone?limit=abc");
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toMatch(/limit/);
+  });
+
+  it("accepts limit=1 (minimum boundary)", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/by-author/someone?limit=1");
+    // 記事がなくても limit 自体は valid なので 200 が返る
+    expect(res.status).toBe(200);
+  });
+
+  it("accepts limit=50 (maximum boundary)", async () => {
+    const res = await SELF.fetch("https://example.com/api/articles/by-author/someone?limit=50");
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 400 when cursor is malformed (invalid base64)", async () => {
+    const res = await SELF.fetch(
+      "https://example.com/api/articles/by-author/someone?cursor=!!!invalid!!!",
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toMatch(/cursor/);
+  });
+
+  it("returns 400 when cursor decodes to valid base64 but invalid JSON shape", async () => {
+    const malformed = btoa(JSON.stringify({ bad: "shape" }));
+    const res = await SELF.fetch(
+      `https://example.com/api/articles/by-author/someone?cursor=${malformed}`,
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toMatch(/cursor/);
+  });
+});

--- a/apps/web/worker/api/articles-parse.ts
+++ b/apps/web/worker/api/articles-parse.ts
@@ -1,11 +1,9 @@
 /**
- * articles.ts handler で使う parse / validation ヘルパー。
- * HTTP リクエストから値を取り出す純粋ロジックを集約し、handler を薄く保つ。
+ * articles.ts handler で使う HTTP request parse helper (Context 依存あり)。
+ * limit / cursor などのクエリパラメータ parse と validation を集約し、handler を薄く保つ。
  *
- * NOTE: _guards.ts (PR #404 でマージ予定) が存在しないため、
- *       isCategory / isLang の guard と VALID_CATEGORIES / VALID_LANGS は
- *       articles.ts 内の既存定義から import して再利用する。
- *       _guards.ts マージ後に import 元を切り替えること。
+ * isCategory / isLang の guard は _guards.ts に集約されている。
+ * articles.ts では _guards.ts から import して利用する。
  */
 import type { Context } from "hono";
 import type { Env } from "../types";
@@ -68,7 +66,7 @@ export function decodeCursor(input: string | undefined): Cursor | null {
     const decoded = atob(input);
     const parsed: unknown = JSON.parse(decoded);
     if (isCursorShape(parsed)) {
-      return parsed;
+      return { publishedAt: parsed.publishedAt, id: parsed.id };
     }
   } catch {
     return null;

--- a/apps/web/worker/api/articles-parse.ts
+++ b/apps/web/worker/api/articles-parse.ts
@@ -1,0 +1,120 @@
+/**
+ * articles.ts handler で使う parse / validation ヘルパー。
+ * HTTP リクエストから値を取り出す純粋ロジックを集約し、handler を薄く保つ。
+ *
+ * NOTE: _guards.ts (PR #404 でマージ予定) が存在しないため、
+ *       isCategory / isLang の guard と VALID_CATEGORIES / VALID_LANGS は
+ *       articles.ts 内の既存定義から import して再利用する。
+ *       _guards.ts マージ後に import 元を切り替えること。
+ */
+import type { Context } from "hono";
+import type { Env } from "../types";
+import type { Cursor } from "../db/articles";
+
+// ISO 8601 の日時部分 (時刻まで)。decodeCursor の publishedAt 検証と
+// since/until の ISO 形式チェック (時刻部分以降は内部で 10 文字に切り詰めて検証) に共用する。
+export const ISO_DATETIME_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
+// YYYY-MM-DD 形式のみ受け付ける (末尾 anchor で `9999-99-99foo` のような余剰文字を排除)
+const DATE_RANGE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+// 実日付として妥当か検証する。Date が内部で繰り上げる (9999-99-99 → 3000-03-09 等) ことを
+// 再フォーマットして入力文字列と比較することで検出する。
+function isValidDate(s: string): boolean {
+  const t = Date.parse(`${s}T00:00:00Z`);
+  if (Number.isNaN(t)) return false;
+  const d = new Date(t);
+  const y = d.getUTCFullYear().toString().padStart(4, "0");
+  const m = (d.getUTCMonth() + 1).toString().padStart(2, "0");
+  const day = d.getUTCDate().toString().padStart(2, "0");
+  return `${y}-${m}-${day}` === s;
+}
+
+/**
+ * 日付範囲パラメータの形式 + 実日付チェック。
+ * 未指定 (undefined) は OK として true を返す。
+ * YYYY-MM-DD / YYYY-MM-DDTHH:MM:SS... 形式のみ受け付ける。
+ */
+export function isValidDateRange(s: string | undefined): boolean {
+  if (!s) return true; // 未指定は OK
+  // YYYY-MM-DD 形式: 実日付として妥当かチェック
+  if (DATE_RANGE_RE.test(s)) return isValidDate(s);
+  // YYYY-MM-DDTHH:MM:SS... 形式: 先頭の日付部分のみ抽出して検証
+  if (ISO_DATETIME_RE.test(s)) return isValidDate(s.slice(0, 10));
+  return false;
+}
+
+/**
+ * unknown 値が Cursor 形状を持つか検証する type guard。
+ * publishedAt / id それぞれを narrow して型を保証する。
+ */
+function isCursorShape(v: unknown): v is Cursor {
+  if (v === null || typeof v !== "object") return false;
+  const rec = v as Record<string, unknown>;
+  if (typeof rec.publishedAt !== "string") return false;
+  if (!ISO_DATETIME_RE.test(rec.publishedAt)) return false;
+  if (typeof rec.id !== "number") return false;
+  if (!Number.isInteger(rec.id)) return false;
+  if (rec.id < 0) return false;
+  return true;
+}
+
+/**
+ * Base64 エンコードされた cursor 文字列を Cursor オブジェクトに変換する。
+ * 不正な入力 (不正 base64 / JSON / 必須フィールド欠落 / 型不正) の場合は null を返す。
+ */
+export function decodeCursor(input: string | undefined): Cursor | null {
+  if (!input) return null;
+  try {
+    const decoded = atob(input);
+    const parsed: unknown = JSON.parse(decoded);
+    if (isCursorShape(parsed)) {
+      return parsed;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+/**
+ * Cursor オブジェクトを Base64 エンコードした文字列に変換する。
+ * null が渡された場合は null を返す。
+ */
+export function encodeCursor(cursor: { publishedAt: string; id: number } | null): string | null {
+  if (!cursor) return null;
+  return btoa(JSON.stringify(cursor));
+}
+
+export type ParsedListQuery =
+  | { ok: true; limit: number; cursor: Cursor | null }
+  | { ok: false; response: Response };
+
+/**
+ * limit / cursor の parse + 400 チェックを共通化。
+ * エラーメッセージ・ステータスコードは各 endpoint の仕様に揃える。
+ */
+export function parseListQuery(
+  c: Context<{ Bindings: Env }>,
+  opts: { defaultLimit?: number; maxLimit?: number } = {},
+): ParsedListQuery {
+  const defaultLimit = opts.defaultLimit ?? 20;
+  const maxLimit = opts.maxLimit ?? 50;
+
+  const limitRaw = c.req.query("limit") ?? String(defaultLimit);
+  const limitNum = Number(limitRaw);
+  if (!Number.isInteger(limitNum) || limitNum < 1 || limitNum > maxLimit) {
+    return {
+      ok: false,
+      response: c.json({ error: `limit must be an integer between 1 and ${maxLimit}` }, 400),
+    };
+  }
+
+  const cursorRaw = c.req.query("cursor");
+  const cursor = decodeCursor(cursorRaw);
+  // cursor が指定されているのに decode に失敗した場合は 400
+  if (cursorRaw && !cursor) {
+    return { ok: false, response: c.json({ error: "invalid cursor" }, 400) };
+  }
+
+  return { ok: true, limit: limitNum, cursor };
+}

--- a/apps/web/worker/api/articles.ts
+++ b/apps/web/worker/api/articles.ts
@@ -1,5 +1,4 @@
 import { Hono } from "hono";
-import type { Context } from "hono";
 import type { Env } from "../types";
 import { loadAllFeeds } from "../feed-config";
 import {
@@ -18,7 +17,6 @@ import {
   listArticles,
   searchArticles,
 } from "../db/articles";
-import type { Cursor } from "../db/articles";
 import { computeArticlesEtag } from "../utils/etag";
 import feedsYaml from "../feeds.yaml";
 import type { FeedsFile } from "../types";
@@ -36,6 +34,7 @@ import type {
   ArticleSearchResponse,
 } from "./types";
 import { isCategory, isLang } from "./_guards";
+import { decodeCursor, encodeCursor, isValidDateRange, parseListQuery } from "./articles-parse";
 
 const FEEDS_VERSION = (feedsYaml as FeedsFile).version;
 
@@ -45,92 +44,6 @@ const VALID_FEED_IDS = new Set(loadAllFeeds().map((f) => f.id));
 const VALID_CALENDAR_DAYS = [7, 30, 90, 365] as const;
 // URL パラメータの長さ上限。意図せず長い文字列が D1 クエリに流れ込むのを防ぐ
 const MAX_PARAM_LENGTH = 200;
-
-// ISO 8601 の日時部分 (時刻まで)。decodeCursor の publishedAt 検証と
-// since/until の ISO 形式チェック (時刻部分以降は内部で 10 文字に切り詰めて検証) に共用する。
-const ISO_DATETIME_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
-// YYYY-MM-DD 形式のみ受け付ける (末尾 anchor で `9999-99-99foo` のような余剰文字を排除)
-const DATE_RANGE_RE = /^\d{4}-\d{2}-\d{2}$/;
-
-// 実日付として妥当か検証する。Date が内部で繰り上げる (9999-99-99 → 3000-03-09 等) ことを
-// 再フォーマットして入力文字列と比較することで検出する。
-function isValidDate(s: string): boolean {
-  const t = Date.parse(`${s}T00:00:00Z`);
-  if (Number.isNaN(t)) return false;
-  const d = new Date(t);
-  const y = d.getUTCFullYear().toString().padStart(4, "0");
-  const m = (d.getUTCMonth() + 1).toString().padStart(2, "0");
-  const day = d.getUTCDate().toString().padStart(2, "0");
-  return `${y}-${m}-${day}` === s;
-}
-
-function isValidDateRange(s: string | undefined): boolean {
-  if (!s) return true; // 未指定は OK
-  // YYYY-MM-DD 形式: 実日付として妥当かチェック
-  if (DATE_RANGE_RE.test(s)) return isValidDate(s);
-  // YYYY-MM-DDTHH:MM:SS... 形式: 先頭の日付部分のみ抽出して検証
-  if (ISO_DATETIME_RE.test(s)) return isValidDate(s.slice(0, 10));
-  return false;
-}
-
-function decodeCursor(input: string | undefined): Cursor | null {
-  if (!input) return null;
-  try {
-    const decoded = atob(input);
-    const parsed = JSON.parse(decoded);
-    if (
-      parsed &&
-      typeof parsed === "object" &&
-      typeof parsed.publishedAt === "string" &&
-      ISO_DATETIME_RE.test(parsed.publishedAt) &&
-      typeof parsed.id === "number" &&
-      Number.isInteger(parsed.id) &&
-      parsed.id >= 0
-    ) {
-      return { publishedAt: parsed.publishedAt, id: parsed.id };
-    }
-  } catch {
-    return null;
-  }
-  return null;
-}
-
-function encodeCursor(cursor: { publishedAt: string; id: number } | null): string | null {
-  if (!cursor) return null;
-  return btoa(JSON.stringify(cursor));
-}
-
-type ParsedListQuery =
-  | { ok: true; limit: number; cursor: Cursor | null }
-  | { ok: false; response: Response };
-
-// limit / cursor の parse + 400 チェックを共通化。
-// エラーメッセージ・ステータスコードは各 endpoint の仕様に揃える。
-function parseListQuery(
-  c: Context<{ Bindings: Env }>,
-  opts: { defaultLimit?: number; maxLimit?: number } = {},
-): ParsedListQuery {
-  const defaultLimit = opts.defaultLimit ?? 20;
-  const maxLimit = opts.maxLimit ?? 50;
-
-  const limitRaw = c.req.query("limit") ?? String(defaultLimit);
-  const limitNum = Number(limitRaw);
-  if (!Number.isInteger(limitNum) || limitNum < 1 || limitNum > maxLimit) {
-    return {
-      ok: false,
-      response: c.json({ error: `limit must be an integer between 1 and ${maxLimit}` }, 400),
-    };
-  }
-
-  const cursorRaw = c.req.query("cursor");
-  const cursor = decodeCursor(cursorRaw);
-  // cursor が指定されているのに decode に失敗した場合は 400
-  if (cursorRaw && !cursor) {
-    return { ok: false, response: c.json({ error: "invalid cursor" }, 400) };
-  }
-
-  return { ok: true, limit: limitNum, cursor };
-}
 
 app.get("/", async (c) => {
   const { req } = c;


### PR DESCRIPTION
## Summary
- worker/api/articles.ts から parse helper を articles-parse.ts に切り出し
- decodeCursor / encodeCursor / parseListQuery / isValidDateRange を集約
- 単体テスト追加 (boundary cases)
- 動作変更なし

Closes #411

## Test plan
- [x] vp check pass
- [x] vp test run pass (worker)
- [x] vp test run --config vitest.client.config.ts pass (client)