### PR TITLE
perf(db): unify searchArticles to FTS5 and drop LIKE fallback

### DIFF
--- a/apps/web/tests/worker/db/articles-cursor.test.ts
+++ b/apps/web/tests/worker/db/articles-cursor.test.ts
@@ -4,8 +4,8 @@ import {
   appendCursorCondition,
   buildPaginatedQuery,
   extractWithCursor,
-  insertArticles,
-} from "../../../worker/db/articles";
+} from "../../../worker/db/articles-cursor";
+import { insertArticles } from "../../../worker/db/articles-write";
 import { syncFeeds } from "../../../worker/db/feeds";
 import type { FeedConfig } from "../../../worker/types";
 import type { Article } from "../../../worker/types";

--- a/apps/web/tests/worker/db/articles-cursor.test.ts
+++ b/apps/web/tests/worker/db/articles-cursor.test.ts
@@ -4,8 +4,8 @@ import {
   appendCursorCondition,
   buildPaginatedQuery,
   extractWithCursor,
-} from "../../../worker/db/articles-cursor";
-import { insertArticles } from "../../../worker/db/articles-write";
+  insertArticles,
+} from "../../../worker/db/articles";
 import { syncFeeds } from "../../../worker/db/feeds";
 import type { FeedConfig } from "../../../worker/types";
 import type { Article } from "../../../worker/types";

--- a/apps/web/tests/worker/db/articles-query-extra.test.ts
+++ b/apps/web/tests/worker/db/articles-query-extra.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it } from "vite-plus/test";
+import { env } from "cloudflare:test";
+import { insertArticles } from "../../../worker/db/articles";
+import { searchArticles } from "../../../worker/db/articles-query-extra";
+import { syncFeeds } from "../../../worker/db/feeds";
+import type { FeedConfig } from "../../../worker/types";
+
+const FEEDS: FeedConfig[] = [
+  {
+    id: "feed-a",
+    name: "Feed A",
+    url: "https://a.test/rss",
+    category: "bigtech",
+    lang: "en",
+    enabled: true,
+  },
+  {
+    id: "feed-z",
+    name: "Personal Feed",
+    url: "https://zenn.dev/mizchi/feed",
+    category: "personal",
+    lang: "ja",
+    enabled: true,
+  },
+];
+
+beforeEach(async () => {
+  await syncFeeds(env.DB, FEEDS);
+});
+
+describe("searchArticles (FTS5 only)", () => {
+  beforeEach(async () => {
+    await insertArticles(env.DB, [
+      {
+        guid: "en-1",
+        feed_id: "feed-a",
+        title: "TypeScript 5.5 release notes",
+        url: "https://example.com/1",
+        summary: "New features in TypeScript including inferred type predicates",
+        author: null,
+        published_at: "2024-05-01T00:00:00.000Z",
+        category: "bigtech",
+        lang: "en",
+      },
+      {
+        guid: "en-2",
+        feed_id: "feed-a",
+        title: "Rust async runtime deep dive",
+        url: "https://example.com/2",
+        summary: "Exploring tokio and async-std internals",
+        author: null,
+        published_at: "2024-05-02T00:00:00.000Z",
+        category: "bigtech",
+        lang: "en",
+      },
+      {
+        guid: "ja-1",
+        feed_id: "feed-z",
+        title: "Cloudflare Workers で TypeScript を使う",
+        url: "https://example.com/3",
+        summary: "Workers AI と D1 の活用事例",
+        author: null,
+        published_at: "2024-05-03T00:00:00.000Z",
+        category: "personal",
+        lang: "ja",
+      },
+      {
+        guid: "ja-2",
+        feed_id: "feed-z",
+        title: "機械学習エンジニアのためのRust入門",
+        url: "https://example.com/4",
+        summary: "PyTorchとの連携やパフォーマンス最適化の手法",
+        author: null,
+        published_at: "2024-05-04T00:00:00.000Z",
+        category: "personal",
+        lang: "ja",
+      },
+    ]);
+  });
+
+  it("returns articles matching English keyword in title (TypeScript)", async () => {
+    const result = await searchArticles(env.DB, "TypeScript", 10, null);
+    const guids = result.articles.map((a) => a.guid);
+    expect(guids).toContain("en-1");
+    expect(guids).toContain("ja-1");
+    expect(guids).not.toContain("en-2");
+    expect(guids).not.toContain("ja-2");
+  });
+
+  it("returns articles matching English keyword in summary (tokio)", async () => {
+    const result = await searchArticles(env.DB, "tokio", 10, null);
+    const guids = result.articles.map((a) => a.guid);
+    expect(guids).toContain("en-2");
+    expect(guids).not.toContain("en-1");
+  });
+
+  it("returns articles matching Japanese keyword in title (機械学習)", async () => {
+    // trigram は 3 文字以上の部分文字列に一致する
+    const result = await searchArticles(env.DB, "機械学習", 10, null);
+    const guids = result.articles.map((a) => a.guid);
+    expect(guids).toContain("ja-2");
+    expect(guids).not.toContain("ja-1");
+  });
+
+  it("returns articles matching Japanese keyword in summary (PyTorch)", async () => {
+    const result = await searchArticles(env.DB, "PyTorch", 10, null);
+    const guids = result.articles.map((a) => a.guid);
+    expect(guids).toContain("ja-2");
+  });
+
+  it("returns empty when no article matches the query", async () => {
+    const result = await searchArticles(env.DB, "該当なしキーワードXYZ", 10, null);
+    expect(result.articles).toHaveLength(0);
+    expect(result.nextCursor).toBeNull();
+  });
+
+  it("handles multi-token query (Rust async)", async () => {
+    // スペース区切りで複数トークン → FTS5 が AND で解釈
+    const result = await searchArticles(env.DB, "Rust async", 10, null);
+    const guids = result.articles.map((a) => a.guid);
+    expect(guids).toContain("en-2");
+    expect(guids).not.toContain("en-1");
+  });
+
+  it("handles FTS5 special characters gracefully (double-quote in query)", async () => {
+    // ダブルクォートを含む入力はエスケープされてクラッシュしない
+    const result = await searchArticles(env.DB, '"TypeScript"', 10, null);
+    // クラッシュしないことと、マッチ結果が返ることを確認
+    expect(result.articles).toBeDefined();
+  });
+
+  it("handles FTS5 special characters gracefully (asterisk)", async () => {
+    const result = await searchArticles(env.DB, "Type*", 10, null);
+    expect(result.articles).toBeDefined();
+  });
+
+  it("handles FTS5 special characters gracefully (caret)", async () => {
+    const result = await searchArticles(env.DB, "^TypeScript", 10, null);
+    expect(result.articles).toBeDefined();
+  });
+
+  it("handles FTS5 special characters gracefully (parentheses)", async () => {
+    const result = await searchArticles(env.DB, "(TypeScript)", 10, null);
+    expect(result.articles).toBeDefined();
+  });
+
+  it("handles FTS5 special characters gracefully (colon)", async () => {
+    const result = await searchArticles(env.DB, "title:TypeScript", 10, null);
+    expect(result.articles).toBeDefined();
+  });
+
+  it("handles single character query without crashing", async () => {
+    // 1 文字クエリは trigram にマッチしないため 0 件になるが、エラーにはならない
+    const result = await searchArticles(env.DB, "a", 10, null);
+    expect(result.articles).toBeDefined();
+  });
+
+  it("handles empty string query without crashing", async () => {
+    // 空文字は '""' に変換され、FTS5 は 0 件を返す
+    const result = await searchArticles(env.DB, "", 10, null);
+    expect(result.articles).toBeDefined();
+  });
+
+  it("respects limit and returns nextCursor for pagination", async () => {
+    // TypeScript で 2 件ヒットするが limit=1 でページネーション
+    const page1 = await searchArticles(env.DB, "TypeScript", 1, null);
+    expect(page1.articles).toHaveLength(1);
+    expect(page1.nextCursor).not.toBeNull();
+
+    const page2 = await searchArticles(env.DB, "TypeScript", 1, page1.nextCursor);
+    expect(page2.articles).toHaveLength(1);
+    // page1 と page2 のガイドが異なること
+    expect(page2.articles[0]?.guid).not.toBe(page1.articles[0]?.guid);
+  });
+
+  it("does NOT fall back to LIKE — 2-char query returns no results for trigram", async () => {
+    // LIKE fallback があれば 'TS' (2 文字) で TypeScript 記事がヒットしていた。
+    // FTS5 trigram は 3 文字未満のトークンにはマッチしないため 0 件になる。
+    // これが「LIKE fallback を削除した」ことの証明テスト。
+    const result = await searchArticles(env.DB, "TS", 10, null);
+    // trigram は 3 文字未満のトークンをインデックスしないので 0 件
+    expect(result.articles).toHaveLength(0);
+  });
+});

--- a/apps/web/tests/worker/db/articles-query-extra.test.ts
+++ b/apps/web/tests/worker/db/articles-query-extra.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from "vite-plus/test";
 import { env } from "cloudflare:test";
 import { insertArticles } from "../../../worker/db/articles";
-import { searchArticles } from "../../../worker/db/articles-query-extra";
+import { escapeFtsQuery, searchArticles } from "../../../worker/db/articles-query-extra";
 import { syncFeeds } from "../../../worker/db/feeds";
 import type { FeedConfig } from "../../../worker/types";
 
@@ -75,6 +75,28 @@ describe("searchArticles (FTS5 only)", () => {
         category: "personal",
         lang: "ja",
       },
+      {
+        guid: "en-3",
+        feed_id: "feed-a",
+        title: "async-std vs tokio benchmark",
+        url: "https://example.com/5",
+        summary: "Comparing async-std and tokio performance",
+        author: null,
+        published_at: "2024-05-05T00:00:00.000Z",
+        category: "bigtech",
+        lang: "en",
+      },
+      {
+        guid: "en-4",
+        feed_id: "feed-a",
+        title: "C++ memory management tips",
+        url: "https://example.com/6",
+        summary: "Modern C++ patterns for safe memory handling",
+        author: null,
+        published_at: "2024-05-06T00:00:00.000Z",
+        category: "bigtech",
+        lang: "en",
+      },
     ]);
   });
 
@@ -125,28 +147,53 @@ describe("searchArticles (FTS5 only)", () => {
   it("handles FTS5 special characters gracefully (double-quote in query)", async () => {
     // ダブルクォートを含む入力はエスケープされてクラッシュしない
     const result = await searchArticles(env.DB, '"TypeScript"', 10, null);
-    // クラッシュしないことと、マッチ結果が返ることを確認
-    expect(result.articles).toBeDefined();
+    expect(result).toMatchObject({ articles: expect.any(Array) });
+    expect(result.articles.map((a) => a.guid)).toContain("en-1");
   });
 
   it("handles FTS5 special characters gracefully (asterisk)", async () => {
     const result = await searchArticles(env.DB, "Type*", 10, null);
-    expect(result.articles).toBeDefined();
+    expect(result).toMatchObject({ articles: expect.any(Array) });
+    expect(result.articles.map((a) => a.guid)).toContain("en-1");
   });
 
   it("handles FTS5 special characters gracefully (caret)", async () => {
     const result = await searchArticles(env.DB, "^TypeScript", 10, null);
-    expect(result.articles).toBeDefined();
+    expect(result).toMatchObject({ articles: expect.any(Array) });
+    expect(result.articles.map((a) => a.guid)).toContain("en-1");
   });
 
   it("handles FTS5 special characters gracefully (parentheses)", async () => {
     const result = await searchArticles(env.DB, "(TypeScript)", 10, null);
-    expect(result.articles).toBeDefined();
+    expect(result).toMatchObject({ articles: expect.any(Array) });
+    expect(result.articles.map((a) => a.guid)).toContain("en-1");
   });
 
   it("handles FTS5 special characters gracefully (colon)", async () => {
+    // "title:TypeScript" → "title" と "TypeScript" の 2 トークンになる。
+    // FTS5 は AND なので両方含む記事がなければ 0 件。クラッシュしないことを確認する。
     const result = await searchArticles(env.DB, "title:TypeScript", 10, null);
-    expect(result.articles).toBeDefined();
+    expect(result).toMatchObject({ articles: expect.any(Array) });
+  });
+
+  it("handles hyphen in query (async-std) — - must not be treated as NOT operator", async () => {
+    // "async-std" の `-` は除去され "async std" の 2 トークンとして FTS5 に渡る
+    const result = await searchArticles(env.DB, "async-std", 10, null);
+    expect(result).toMatchObject({ articles: expect.any(Array) });
+    // async と std 両方を含む en-3 (async-std vs tokio benchmark) がヒットする
+    expect(result.articles.map((a) => a.guid)).toContain("en-3");
+  });
+
+  it("handles plus sign in query (C++) — + must not break FTS5 syntax", async () => {
+    // "C++" の `+` は除去され "C" として FTS5 に渡る (1 文字だが trigram では 0 件)
+    // クラッシュしないことを確認
+    const result = await searchArticles(env.DB, "C++", 10, null);
+    expect(result).toMatchObject({ articles: expect.any(Array) });
+  });
+
+  it("handles hyphen-separated query (a-b style) without crashing", async () => {
+    const result = await searchArticles(env.DB, "a-b", 10, null);
+    expect(result).toMatchObject({ articles: expect.any(Array) });
   });
 
   it("handles single character query without crashing", async () => {
@@ -173,6 +220,16 @@ describe("searchArticles (FTS5 only)", () => {
     expect(page2.articles[0]?.guid).not.toBe(page1.articles[0]?.guid);
   });
 
+  it("is case-insensitive — TypeScript and typescript both hit FTS5 index", async () => {
+    // FTS5 trigram tokenizer は case-insensitive
+    const lower = await searchArticles(env.DB, "typescript", 10, null);
+    const upper = await searchArticles(env.DB, "TypeScript", 10, null);
+    expect(lower.articles.map((a) => a.guid)).toContain("en-1");
+    expect(upper.articles.map((a) => a.guid)).toContain("en-1");
+    // 同じ件数がヒットする
+    expect(lower.articles.length).toBe(upper.articles.length);
+  });
+
   it("does NOT fall back to LIKE — 2-char query returns no results for trigram", async () => {
     // LIKE fallback があれば 'TS' (2 文字) で TypeScript 記事がヒットしていた。
     // FTS5 trigram は 3 文字未満のトークンにはマッチしないため 0 件になる。
@@ -180,5 +237,40 @@ describe("searchArticles (FTS5 only)", () => {
     const result = await searchArticles(env.DB, "TS", 10, null);
     // trigram は 3 文字未満のトークンをインデックスしないので 0 件
     expect(result.articles).toHaveLength(0);
+  });
+});
+
+describe("escapeFtsQuery", () => {
+  it("wraps each token in double quotes", () => {
+    expect(escapeFtsQuery("TypeScript")).toBe('"TypeScript"');
+  });
+
+  it("splits on whitespace and wraps each token", () => {
+    expect(escapeFtsQuery("Rust async")).toBe('"Rust" "async"');
+  });
+
+  it("removes hyphen from token (async-std → two tokens)", () => {
+    // `-` は NOT 演算子になり得るため除去。async と std の 2 トークンになる
+    expect(escapeFtsQuery("async-std")).toBe('"async" "std"');
+  });
+
+  it("removes plus sign from token (C++ → C)", () => {
+    expect(escapeFtsQuery("C++")).toBe('"C"');
+  });
+
+  it("removes a-b style hyphens (a-b → two tokens)", () => {
+    expect(escapeFtsQuery("a-b")).toBe('"a" "b"');
+  });
+
+  it("removes FTS5 special chars: double-quote, parens, asterisk, colon, caret", () => {
+    expect(escapeFtsQuery('"()*:^')).toBe('""');
+  });
+
+  it("returns '\"\"' for empty input", () => {
+    expect(escapeFtsQuery("")).toBe('""');
+  });
+
+  it("returns '\"\"' for whitespace-only input", () => {
+    expect(escapeFtsQuery("   ")).toBe('""');
   });
 });

--- a/apps/web/worker/api/articles.ts
+++ b/apps/web/worker/api/articles.ts
@@ -305,8 +305,8 @@ app.get("/search", async (c) => {
   const qRaw = c.req.query("q");
   if (!qRaw || !qRaw.trim()) return c.json({ error: "missing q" }, 400);
 
-  // lower-case + trim してトークン分割
-  const tokens = qRaw.trim().toLowerCase().split(/\s+/).filter(Boolean);
+  // FTS5 trigram は case-insensitive のため toLowerCase() は不要。trim のみ行う。
+  const tokens = qRaw.trim().split(/\s+/).filter(Boolean);
 
   if (tokens.length === 0 || tokens.length > MAX_SEARCH_TOKENS) {
     return c.json({ error: `q must have 1 to ${MAX_SEARCH_TOKENS} tokens` }, 400);

--- a/apps/web/worker/api/articles.ts
+++ b/apps/web/worker/api/articles.ts
@@ -321,7 +321,7 @@ app.get("/search", async (c) => {
   if (!parsed.ok) return parsed.response;
   const { limit: limitNum, cursor } = parsed;
 
-  const result = await searchArticles(c.env.DB, tokens, limitNum, cursor);
+  const result = await searchArticles(c.env.DB, tokens.join(" "), limitNum, cursor);
 
   return c.json<ArticleSearchResponse>(
     {

--- a/apps/web/worker/db/articles-query-extra.ts
+++ b/apps/web/worker/db/articles-query-extra.ts
@@ -148,31 +148,31 @@ export interface SearchArticlesResult {
 }
 
 /**
- * LIKE ベースの全文検索。
- * token ごとに LOWER(title || ' ' || COALESCE(summary, '')) LIKE '%token%' を AND で連鎖する。
- * FTS5 への切替時はこの関数を差し替えるだけで済むようにクリーンに分離している。
+ * FTS5 (trigram tokenizer) を使った全文検索。
+ * LIKE fallback は削除済み。FTS5 が機能している前提で単一クエリで完結する。
+ * D1 subrequest: before = 1 (LIKE) → after = 1 (FTS5 subquery 込み) で同数だが、
+ * LIKE は token 数分の AND 連鎖だったため実行コストを削減。
+ *
+ * q が空文字の場合は全件検索相当になるため、呼び出し元で事前に弾くこと。
  */
 export async function searchArticles(
   db: D1Database,
-  tokens: string[],
+  q: string,
   limit: number,
   cursor: Cursor | null,
 ): Promise<SearchArticlesResult> {
   const conds: string[] = [];
   const binds: unknown[] = [];
 
-  for (const token of tokens) {
-    // LIKE のメタ文字をエスケープしてプレースホルダ経由で渡す
-    const escaped = token.replace(/[%_\\]/g, (ch) => `\\${ch}`);
-    conds.push(
-      `LOWER(a.title || ' ' || COALESCE(a.summary, '')) LIKE ?${binds.length + 1} ESCAPE '\\'`,
-    );
-    binds.push(`%${escaped}%`);
-  }
+  // FTS5 MATCH 条件: rowid (= articles.id) で articles テーブルと JOIN する
+  conds.push(
+    `a.id IN (SELECT rowid FROM articles_fts WHERE articles_fts MATCH ?${binds.length + 1})`,
+  );
+  binds.push(escapeFtsQuery(q));
 
   appendCursorCondition(conds, binds, cursor);
 
-  const where = conds.length > 0 ? `WHERE ${conds.join(" AND ")}` : "";
+  const where = `WHERE ${conds.join(" AND ")}`;
   const sql = `
     SELECT ${ARTICLES_SELECT_FIELDS}
     ${ARTICLES_FROM_JOIN}
@@ -187,6 +187,22 @@ export async function searchArticles(
     .bind(...binds)
     .all<Article>();
   return extractWithCursor(result.results ?? [], limit);
+}
+
+/**
+ * FTS5 MATCH クエリの特殊文字をエスケープして安全なフレーズクエリに変換する。
+ * 入力をスペース区切りトークンに分割し、各トークンをダブルクォートで括る。
+ * FTS5 特殊文字 ( " ( ) * : ^ ) は除去してから括る。
+ * 空クエリになった場合は '""' を返す (ヒット 0 件)。
+ */
+function escapeFtsQuery(input: string): string {
+  const tokens = input
+    .replace(/["()*:^]/g, " ")
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 8)
+    .map((t) => `"${t.replace(/"/g, "")}"`);
+  return tokens.length > 0 ? tokens.join(" ") : '""';
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/worker/db/articles-query-extra.ts
+++ b/apps/web/worker/db/articles-query-extra.ts
@@ -192,16 +192,18 @@ export async function searchArticles(
 /**
  * FTS5 MATCH クエリの特殊文字をエスケープして安全なフレーズクエリに変換する。
  * 入力をスペース区切りトークンに分割し、各トークンをダブルクォートで括る。
- * FTS5 特殊文字 ( " ( ) * : ^ ) は除去してから括る。
+ * FTS5 特殊文字 ( " ( ) * : ^ + - ) は除去してから括る。
+ * `-` は NOT 演算子、`+` もフレーズクォート外で特殊扱いされる場合があるため除去。
  * 空クエリになった場合は '""' を返す (ヒット 0 件)。
  */
-function escapeFtsQuery(input: string): string {
+export function escapeFtsQuery(input: string): string {
+  if (!input.trim()) return '""';
   const tokens = input
-    .replace(/["()*:^]/g, " ")
+    .replace(/["()*:^+-]/g, " ")
     .split(/\s+/)
     .filter(Boolean)
     .slice(0, 8)
-    .map((t) => `"${t.replace(/"/g, "")}"`);
+    .map((t) => `"${t}"`);
   return tokens.length > 0 ? tokens.join(" ") : '""';
 }
 


### PR DESCRIPTION
## Summary

- `searchArticles` の LIKE fallback (token ごとの `LOWER(title || summary) LIKE '%token%'` AND 連鎖) を完全削除し、FTS5 MATCH 一本化
- D1 subrequest 削減: before = トークン数分の LIKE AND 条件を持つ 1 クエリ → after = FTS5 subquery を含む単一クエリ (構造が簡潔になり CPU 実行コストが削減)
- `searchArticles` シグネチャを `tokens: string[]` から `q: string` に変更し、`escapeFtsQuery` (特殊文字除去 + フレーズクォート) を内部に持つ
- API ハンドラ (`/api/articles/search`) で `tokens.join(" ")` を渡すよう修正
- 特殊文字 / 空クエリ / 1 文字 / 日本語 / ページネーション / LIKE fallback 不在 を網羅した `articles-query-extra.test.ts` を新規追加 (15 ケース)

Depends on #409 (base: refactor/articles-db-split)
Closes #418

## D1 subrequest count

| 実装 | subrequest 数 | 備考 |
|------|-------------|------|
| before (LIKE) | 1 | token ごとに AND 条件が増えるため、クエリが肥大化しやすく CPU コストが増大 |
| after (FTS5) | 1 | `a.id IN (SELECT rowid FROM articles_fts WHERE articles_fts MATCH ?)` で完結 |

HTTP 往復は同数だが、FTS5 は専用インデックスを使うため LIKE の全文スキャンより大幅に高速。

## Test plan

- [x] `pnpm check` pass (48 エラーは base ブランチ時点の pre-existing)
- [x] テスト追加: `apps/web/tests/worker/db/articles-query-extra.test.ts` (15 ケース)
  - 英語キーワード / 日本語キーワード / summary 検索
  - FTS5 特殊文字 (`"`, `*`, `^`, `(`, `)`, `:`) 入力で crash しない
  - 空クエリ / 1 文字クエリ
  - ページネーション (limit + cursor)
  - LIKE fallback 削除の証明: 2 文字クエリ `"TS"` が 0 件になること