### PR TITLE
refactor(db): tighten bind parameters to D1BindParameter[]

### DIFF
--- a/apps/web/tests/worker/db/articles-cursor.test.ts
+++ b/apps/web/tests/worker/db/articles-cursor.test.ts
@@ -7,6 +7,7 @@ import {
   insertArticles,
 } from "../../../worker/db/articles";
 import { syncFeeds } from "../../../worker/db/feeds";
+import type { D1BindParameter } from "../../../worker/db/types";
 import type { FeedConfig } from "../../../worker/types";
 import type { Article } from "../../../worker/types";
 
@@ -37,7 +38,7 @@ describe("appendCursorCondition", () => {
   it("cursor が null の場合は conds / binds を変更しない", () => {
     // Arrange
     const conds: string[] = ["a.category = ?1"];
-    const binds: unknown[] = ["bigtech"];
+    const binds: D1BindParameter[] = ["bigtech"];
 
     // Act
     appendCursorCondition(conds, binds, null);
@@ -50,7 +51,7 @@ describe("appendCursorCondition", () => {
   it("cursor が undefined の場合も conds / binds を変更しない", () => {
     // Arrange
     const conds: string[] = [];
-    const binds: unknown[] = [];
+    const binds: D1BindParameter[] = [];
 
     // Act
     appendCursorCondition(conds, binds, undefined);
@@ -63,7 +64,7 @@ describe("appendCursorCondition", () => {
   it("cursor が存在する場合、keyset pagination 条件を追記する", () => {
     // Arrange
     const conds: string[] = ["a.category = ?1"];
-    const binds: unknown[] = ["bigtech"];
+    const binds: D1BindParameter[] = ["bigtech"];
     const cursor = { publishedAt: "2024-04-01T00:00:00.000Z", id: 42 };
 
     // Act
@@ -79,7 +80,7 @@ describe("appendCursorCondition", () => {
   it("binds が空の状態から cursor を追記すると ?1 / ?2 から始まる", () => {
     // Arrange
     const conds: string[] = [];
-    const binds: unknown[] = [];
+    const binds: D1BindParameter[] = [];
     const cursor = { publishedAt: "2024-05-01T00:00:00.000Z", id: 10 };
 
     // Act

--- a/apps/web/worker/db/articles-cursor.ts
+++ b/apps/web/worker/db/articles-cursor.ts
@@ -1,4 +1,5 @@
 import type { Article } from "../types";
+import type { D1BindParameter } from "./types";
 
 // ---------------------------------------------------------------------------
 // 共通定数 (articles-query.ts と共有)
@@ -36,7 +37,7 @@ export interface CursorPage {
  */
 export function appendCursorCondition(
   conds: string[],
-  binds: unknown[],
+  binds: D1BindParameter[],
   cursor: Cursor | null | undefined,
 ): void {
   if (!cursor) return;
@@ -65,14 +66,14 @@ export function extractWithCursor(rows: Article[], limit: number): CursorPage {
 
 export type BuildPaginatedQueryInput = {
   baseConds: string[];
-  baseBinds: unknown[];
+  baseBinds: D1BindParameter[];
   limit: number;
   cursor: Cursor | null | undefined;
 };
 
 export type BuildPaginatedQueryOutput = {
   sql: string;
-  binds: unknown[];
+  binds: D1BindParameter[];
 };
 
 /**

--- a/apps/web/worker/db/articles-query-extra.ts
+++ b/apps/web/worker/db/articles-query-extra.ts
@@ -6,6 +6,7 @@ import {
   appendCursorCondition,
   extractWithCursor,
 } from "./articles-cursor";
+import type { D1BindParameter } from "./types";
 
 // ---------------------------------------------------------------------------
 // 月次系
@@ -28,7 +29,7 @@ export async function getArticlesByMonth(
   const limit = Math.min(Math.max(opts?.limit ?? 200, 1), 500);
 
   const conds: string[] = [`a.published_at >= ?1`, `a.published_at < ?2`];
-  const binds: unknown[] = [start, end];
+  const binds: D1BindParameter[] = [start, end];
 
   if (opts?.category) {
     conds.push(`a.category = ?${binds.length + 1}`);
@@ -71,7 +72,7 @@ export async function countArticlesByMonth(
   const end = new Date(Date.UTC(year, month, 1)).toISOString();
 
   const conds: string[] = [`published_at >= ?1`, `published_at < ?2`];
-  const binds: unknown[] = [start, end];
+  const binds: D1BindParameter[] = [start, end];
 
   if (opts?.category) {
     conds.push(`category = ?${binds.length + 1}`);
@@ -110,7 +111,7 @@ export async function getArticlesCalendar(
   category?: FeedCategory | null,
 ): Promise<CalendarItem[]> {
   const conds: string[] = [`published_at >= datetime('now', ?1)`];
-  const binds: unknown[] = [`-${days} days`];
+  const binds: D1BindParameter[] = [`-${days} days`];
 
   if (lang) {
     conds.push(`lang = ?${binds.length + 1}`);
@@ -159,7 +160,7 @@ export async function searchArticles(
   cursor: Cursor | null,
 ): Promise<SearchArticlesResult> {
   const conds: string[] = [];
-  const binds: unknown[] = [];
+  const binds: D1BindParameter[] = [];
 
   for (const token of tokens) {
     // LIKE のメタ文字をエスケープしてプレースホルダ経由で渡す

--- a/apps/web/worker/db/articles-query.ts
+++ b/apps/web/worker/db/articles-query.ts
@@ -7,6 +7,7 @@ import {
   buildPaginatedQuery,
   extractWithCursor,
 } from "./articles-cursor";
+import type { D1BindParameter } from "./types";
 
 // ---------------------------------------------------------------------------
 // 単純 read 系
@@ -64,7 +65,7 @@ export async function listArticles(
 ): Promise<ListArticlesResult> {
   const limit = Math.min(Math.max(params.limit, 1), 100);
   const conds: string[] = [];
-  const binds: unknown[] = [];
+  const binds: D1BindParameter[] = [];
 
   if (params.category) {
     conds.push(`a.category = ?${binds.length + 1}`);
@@ -124,7 +125,7 @@ export async function getRandomArticles(
   params: GetRandomArticlesParams,
 ): Promise<Article[]> {
   const conds: string[] = [];
-  const binds: unknown[] = [];
+  const binds: D1BindParameter[] = [];
 
   if (params.category) {
     conds.push(`a.category = ?${binds.length + 1}`);

--- a/apps/web/worker/db/articles-stats.ts
+++ b/apps/web/worker/db/articles-stats.ts
@@ -23,6 +23,13 @@ export interface CategoryTrendPoint {
   personal: number;
 }
 
+const CATEGORY_KEYS = ["ai", "bigtech", "jp", "personal"] as const;
+type CategoryKey = (typeof CATEGORY_KEYS)[number];
+
+function isCategoryKey(v: string): v is CategoryKey {
+  return (CATEGORY_KEYS as readonly string[]).includes(v);
+}
+
 export interface FeedActivityRow {
   feed_id: string;
   feed_name: string;
@@ -60,8 +67,8 @@ export async function getCategoryTrend30d(db: D1Database): Promise<CategoryTrend
   for (const row of rows.results ?? []) {
     const point = map.get(row.date);
     if (!point) continue;
-    const cat = row.category as keyof Omit<CategoryTrendPoint, "date">;
-    if (cat in point) point[cat] += row.n;
+    if (!isCategoryKey(row.category)) continue;
+    point[row.category] += row.n;
   }
 
   return points;

--- a/apps/web/worker/db/articles-stats.ts
+++ b/apps/web/worker/db/articles-stats.ts
@@ -61,7 +61,7 @@ export async function getCategoryTrend30d(db: D1Database): Promise<CategoryTrend
     const point = map.get(row.date);
     if (!point) continue;
     const cat = row.category as keyof Omit<CategoryTrendPoint, "date">;
-    if (cat in point) (point[cat] as number) += row.n;
+    if (cat in point) point[cat] += row.n;
   }
 
   return points;

--- a/apps/web/worker/db/feeds.ts
+++ b/apps/web/worker/db/feeds.ts
@@ -1,5 +1,5 @@
 import type { FeedCategory, FeedConfig, FeedLang } from "../types";
-import type { FeedWithStatsDbRow } from "./types";
+import type { D1BindParameter, FeedWithStatsDbRow } from "./types";
 
 export interface FeedHeaders {
   last_etag: string | null;
@@ -281,7 +281,7 @@ export async function listFeedsWithStats(
   opts?: ListFeedsWithStatsOpts,
 ): Promise<FeedWithStats[]> {
   const conds: string[] = [];
-  const binds: unknown[] = [];
+  const binds: D1BindParameter[] = [];
 
   if (opts?.category !== undefined) {
     binds.push(opts.category);

--- a/apps/web/worker/db/reports.ts
+++ b/apps/web/worker/db/reports.ts
@@ -1,6 +1,8 @@
 // reports テーブルへのアクセス層。GitHub Actions から定期投入される
 // 自動生成レポート (markdown) の upsert / list / get を提供する。
 
+import type { D1BindParameter } from "./types";
+
 export type ReportKind = "daily" | "weekly" | "monthly";
 
 export interface ReportInput {
@@ -128,7 +130,7 @@ export async function listReports(
   let query = `SELECT id, kind, period_start, period_end, category, lang,
                       source_skill, generated_at
                FROM reports`;
-  const binds: unknown[] = [];
+  const binds: D1BindParameter[] = [];
   if (filter.kind) {
     query += ` WHERE kind = ?1`;
     binds.push(filter.kind);

--- a/apps/web/worker/db/types.ts
+++ b/apps/web/worker/db/types.ts
@@ -4,6 +4,14 @@
  * DB スキーマを変更した場合はこのファイルも合わせて更新すること。
  */
 
+/**
+ * D1PreparedStatement.bind() が受け付けるパラメータ型。
+ * SQLite の型システムに対応: null / 文字列 / 整数・浮動小数点 / 真偽値 / バイナリ。
+ * workers-types の bind シグネチャは `unknown[]` だが、実際に安全に渡せる値を明示するため
+ * プロジェクト内で定義する。
+ */
+export type D1BindParameter = null | string | number | boolean | ArrayBuffer;
+
 /** articles テーブルの全カラム (JOIN なし) */
 export interface ArticleDbRow {
   id: number;

--- a/apps/web/worker/db/types.ts
+++ b/apps/web/worker/db/types.ts
@@ -9,6 +9,9 @@
  * SQLite の型システムに対応: null / 文字列 / 整数・浮動小数点 / 真偽値 / バイナリ。
  * workers-types の bind シグネチャは `unknown[]` だが、実際に安全に渡せる値を明示するため
  * プロジェクト内で定義する。
+ * - boolean: D1 ランタイムが 0/1 に SQLite で変換 (SQLite に bool 型なし)
+ * - ArrayBuffer: BLOB 列として保存 (用途あればスキーマ側で BLOB 列を定義)
+ * worker 全体で使う必要が出た場合は `worker/types.ts` への昇格を検討。
  */
 export type D1BindParameter = null | string | number | boolean | ArrayBuffer;
 


### PR DESCRIPTION
## Summary

- `apps/web/worker/db/types.ts` に `D1BindParameter` 型エイリアス (`null | string | number | boolean | ArrayBuffer`) を定義
- `articles-cursor` / `articles-query` / `articles-query-extra` / `feeds` / `reports` の `binds: unknown[]` を `D1BindParameter[]` に厳格化
- `articles-stats.ts` の `(point[cat] as number) += n` の ad-hoc cast を除去 (`keyof Omit<CategoryTrendPoint, "date">` のインデックスアクセスは `number` に推論されるため不要)
- テストファイル (`articles-cursor.test.ts`) の `binds: unknown[]` も合わせて修正
- 動作変更なし

base: refactor/articles-db-split (depends on #409)

Closes #419

## Test plan

- [x] vp check pass (errors: 0)
- [x] vp test run pass (既存の spa-shell.test.ts の失敗は worktree 環境で dist/client が未生成のため発生する既存問題で本 PR と無関係)
- [x] pnpm test:client pass (349 tests all pass)