### PR TITLE
chore(workflows): track @main on claude-code-base-action

### DIFF
--- a/.claude/skills/tech-news-digest/SKILL.md
+++ b/.claude/skills/tech-news-digest/SKILL.md
@@ -243,16 +243,16 @@ GitHub Actions (`.github/workflows/report-daily.yml`) から本 skill を起動�
 - `since=today` (固定)
 - `mode=deep` (固定)
 - `target=remote` (固定)
-- 対象カテゴリ: `bigtech,ai,jp` (zenn は除外)
+- 対象カテゴリ: `bigtech,ai` (jp / personal は除外)
 - `lang`: 指定なし
 
 ### Stage 1 の呼び方
 
 ```sh
-node tools/d1-client/recent.mjs --since=today --category=bigtech,ai,jp --target=remote --limit=600
+node tools/d1-client/recent.mjs --since=today --category=bigtech,ai --target=remote --limit=600
 ```
 
-`recent.mjs` の `--category` カンマ区切り対応版を使用する (1 回呼び出しで bigtech/ai/jp を取得)。返り値の `articles[]` は `recent.mjs` 側で URL de-dup 済み (古い `published_at` 優先)。
+`recent.mjs` の `--category` カンマ区切り対応版を使用する (1 回呼び出しで bigtech/ai を取得)。返り値の `articles[]` は `recent.mjs` 側で URL de-dup 済み (古い `published_at` 優先)。
 
 ### 出力ファイル (Stage 4 完了時に書き出す)
 
@@ -261,18 +261,18 @@ node tools/d1-client/recent.mjs --since=today --category=bigtech,ai,jp --target=
 **記事が 1 件以上ある場合**: 出力フォーマット節の構造に従う。次の節は省略禁止:
 
 - `## Pick 記事リンク一覧`: 各記事に `[<title>](url)` _(<feed_name>, <category>, <YYYY-MM-DD>)_ — 1〜2 文要約。`url` は `articles[].url` の copy-paste のみ
-- `## カテゴリ別動向`: bigtech / ai / jp の `###` サブセクションでカテゴリごとの技術動向 2〜3 点
+- `## カテゴリ別動向`: bigtech / ai の `###` サブセクションでカテゴリごとの技術動向 2〜3 点
 
 **記事が 0 件の場合 (`articles.length === 0`)**: 以下の最小レポートを書き出す。creative writing は禁止 — 「ない」事実を「ない」と書く。
 
 ```md
 # Tech News Digest — <YYYY-MM-DD> (daily)
 
-期間: <ISO start> 〜 <ISO end> / 総件数 (de-dup 後): 0 / カテゴリ: bigtech=0, ai=0, jp=0
+期間: <ISO start> 〜 <ISO end> / 総件数 (de-dup 後): 0 / カテゴリ: bigtech=0, ai=0
 
 ## 概要
 
-本日 (<YYYY-MM-DD>) は対象期間 (UTC 過去 24 時間) 内に bigtech / ai / jp カテゴリの新規収集記事はありませんでした。
+本日 (<YYYY-MM-DD>) は対象期間 (UTC 過去 24 時間) 内に bigtech / ai カテゴリの新規収集記事はありませんでした。
 
 ## カテゴリ別件数
 
@@ -280,7 +280,6 @@ node tools/d1-client/recent.mjs --since=today --category=bigtech,ai,jp --target=
 | -------- | ---- |
 | bigtech  | 0    |
 | ai       | 0    |
-| jp       | 0    |
 ```
 
 Stage 2〜4 は articles 0 件のためスキップする (`/tmp/report.md` のみ書き出して終了)。
@@ -296,11 +295,11 @@ Stage 2〜4 は articles 0 件のためスキップする (`/tmp/report.md` の�
   "period_end": "<任意の仮値。workflow が JST 暦日に上書きする>",
   "category": null,
   "lang": null,
-  "included_categories": ["bigtech", "ai", "jp"],
+  "included_categories": ["bigtech", "ai"],
   "source_skill": "tech-news-digest",
   "generated_at": "<実行時刻の ISO 8601>",
   "dedup_total": <number — 0 でもよい>,
-  "by_category": <object — 0 件のときは {"bigtech": 0, "ai": 0, "jp": 0}>,
+  "by_category": <object — 0 件のときは {"bigtech": 0, "ai": 0}>,
   "by_feed": <object — 0 件のときは {}>
 }
 ```
@@ -314,12 +313,12 @@ Slack mrkdwn 記法 (`*bold*`, `_italic_`, `<URL|label>`)。30000 文字以内 (
 **記事が 1 件以上ある場合**:
 
 - 冒頭にレポート概要 1〜2 文
-- 「カテゴリ別ハイライト (bigtech / ai / jp)」「注目記事 (各記事は 1 行、リンク付き)」を Slack で読みやすく整形
+- 「カテゴリ別ハイライト (bigtech / ai)」「注目記事 (各記事は 1 行、リンク付き)」を Slack で読みやすく整形
 
 **記事が 0 件の場合**:
 
 ```
-本日 (<YYYY-MM-DD>) は対象カテゴリ (bigtech / ai / jp) の新規収集記事はありませんでした。
+本日 (<YYYY-MM-DD>) は対象カテゴリ (bigtech / ai) の新規収集記事はありませんでした。
 ```
 
 の 1 行のみで終える。リンクや注目記事節は出さない。

--- a/.github/workflows/report-daily.yml
+++ b/.github/workflows/report-daily.yml
@@ -34,7 +34,7 @@ jobs:
       # cf-typegen は build に依存するため明示的に走らせない (skill は recent.mjs しか使わない)。
 
       - name: Run tech-news-digest skill
-        uses: anthropics/claude-code-base-action@9add77845306ce10ae847a0dc629376271d84c11 # main (pinned 2026-05-01, Claude Code 2.1.126)
+        uses: anthropics/claude-code-base-action@main # anthropics 公式 first-party action。@beta / release tag が長期間更新停止しているため main を追従
         env:
           # claude-code-base-action 内部の Setup Node.js が default 18 を入れるため、
           # wrangler d1 (Node v20+ 必須) が落ちる。skill が呼ぶ recent.mjs のために 24 を強制。

--- a/.github/workflows/report-daily.yml
+++ b/.github/workflows/report-daily.yml
@@ -67,7 +67,7 @@ jobs:
             - since=today
             - mode=deep
             - target=remote
-            - personal カテゴリは除外 (bigtech / ai / jp の 3 カテゴリを対象にする)
+            - personal / jp カテゴリは除外 (bigtech / ai の 2 カテゴリを対象にする)
             - lang 指定なし
 
             最終的に以下 3 ファイルを必ず書き出してください (記事 0 件でも書き出す):

--- a/.github/workflows/report-daily.yml
+++ b/.github/workflows/report-daily.yml
@@ -34,7 +34,7 @@ jobs:
       # cf-typegen は build に依存するため明示的に走らせない (skill は recent.mjs しか使わない)。
 
       - name: Run tech-news-digest skill
-        uses: anthropics/claude-code-base-action@e8132bc5e637a42c27763fc757faa37e1ee43b34 # beta (pinned 2026-04-30)
+        uses: anthropics/claude-code-base-action@9add77845306ce10ae847a0dc629376271d84c11 # main (pinned 2026-05-01, Claude Code 2.1.126)
         env:
           # claude-code-base-action 内部の Setup Node.js が default 18 を入れるため、
           # wrangler d1 (Node v20+ 必須) が落ちる。skill が呼ぶ recent.mjs のために 24 を強制。

--- a/.github/workflows/report-monthly.yml
+++ b/.github/workflows/report-monthly.yml
@@ -32,7 +32,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Run tech-news-weekly skill (monthly)
-        uses: anthropics/claude-code-base-action@9add77845306ce10ae847a0dc629376271d84c11 # main (pinned 2026-05-01, Claude Code 2.1.126)
+        uses: anthropics/claude-code-base-action@main # anthropics 公式 first-party action。@beta / release tag が長期間更新停止しているため main を追従
         env:
           # claude-code-base-action 内部の Setup Node.js が default 18 を入れるため、
           # wrangler d1 (Node v20+ 必須) が落ちる。skill が呼ぶ recent.mjs のために 24 を強制。

--- a/.github/workflows/report-monthly.yml
+++ b/.github/workflows/report-monthly.yml
@@ -32,7 +32,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Run tech-news-weekly skill (monthly)
-        uses: anthropics/claude-code-base-action@e8132bc5e637a42c27763fc757faa37e1ee43b34 # beta (pinned 2026-04-30)
+        uses: anthropics/claude-code-base-action@9add77845306ce10ae847a0dc629376271d84c11 # main (pinned 2026-05-01, Claude Code 2.1.126)
         env:
           # claude-code-base-action 内部の Setup Node.js が default 18 を入れるため、
           # wrangler d1 (Node v20+ 必須) が落ちる。skill が呼ぶ recent.mjs のために 24 を強制。

--- a/.github/workflows/report-monthly.yml
+++ b/.github/workflows/report-monthly.yml
@@ -57,18 +57,18 @@ jobs:
             - since=month
             - target=remote
             - limit=1000
-            - bigtech と ai の 2 カテゴリを対象にする
+            - bigtech / ai / jp の 3 カテゴリを対象にする
             - lang 指定なし
 
-            Stage 1 では bigtech / ai の 2 カテゴリを 1 回の呼び出しで取得してください:
-              node tools/d1-client/recent.mjs --since=month --category=bigtech,ai --target=remote --limit=1000
+            Stage 1 では bigtech / ai / jp の 3 カテゴリを 1 回の呼び出しで取得してください:
+              node tools/d1-client/recent.mjs --since=month --category=bigtech,ai,jp --target=remote --limit=1000
             取得した articles[] を対象に URL de-dup (古い published_at 優先) する。
             以降の Stage はマージ済み articles を対象とする。
 
             Stage 1〜4 を完走したあと、最終的な markdown レポート全文を /tmp/report.md に
             書き出してください。レポートには以下の節を必ず含めてください:
             - `## 注目記事ピックアップ` (必須・省略禁止): 各記事にタイトル/URL/feed_name/category/YYYY-MM-DD/1〜2文要約を含む
-            - `## カテゴリ別ハイライト` (必須): bigtech / ai の各サブセクション (###) でカテゴリごとの動向をサマる
+            - `## カテゴリ別ハイライト` (必須): bigtech / ai / jp の各サブセクション (###) でカテゴリごとの動向をサマる
 
             合わせて以下の JSON を /tmp/report-meta.json に書き出してください:
 
@@ -78,7 +78,7 @@ jobs:
               "period_end":   "<実行時刻の ISO 8601>",
               "category": null,
               "lang": null,
-              "included_categories": ["bigtech","ai"],
+              "included_categories": ["bigtech","ai","jp"],
               "source_skill": "tech-news-weekly",
               "generated_at": "<実行時刻の ISO 8601>",
               "dedup_total": <number>,
@@ -101,7 +101,7 @@ jobs:
             - Slack mrkdwn 記法 (*bold*, _italic_, <URL|label>)
             - 30000 文字以内 (上限。長くても構わない)
             - 冒頭にレポート概要を 1〜2 文
-            - その後に「カテゴリ別ハイライト (bigtech / ai)」「注目記事 (各記事は 1 行、リンク付き)」を Slack で読みやすく整形
+            - その後に「カテゴリ別ハイライト (bigtech / ai / jp)」「注目記事 (各記事は 1 行、リンク付き)」を Slack で読みやすく整形
             - 末尾に viewer URL は付けない (Actions 側で自動付与される)
 
       - name: Save report to D1 via admin API

--- a/.github/workflows/report-weekly.yml
+++ b/.github/workflows/report-weekly.yml
@@ -31,7 +31,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Run tech-news-weekly skill
-        uses: anthropics/claude-code-base-action@9add77845306ce10ae847a0dc629376271d84c11 # main (pinned 2026-05-01, Claude Code 2.1.126)
+        uses: anthropics/claude-code-base-action@main # anthropics 公式 first-party action。@beta / release tag が長期間更新停止しているため main を追従
         env:
           # claude-code-base-action 内部の Setup Node.js が default 18 を入れるため、
           # wrangler d1 (Node v20+ 必須) が落ちる。skill が呼ぶ recent.mjs のために 24 を強制。

--- a/.github/workflows/report-weekly.yml
+++ b/.github/workflows/report-weekly.yml
@@ -31,7 +31,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Run tech-news-weekly skill
-        uses: anthropics/claude-code-base-action@e8132bc5e637a42c27763fc757faa37e1ee43b34 # beta (pinned 2026-04-30)
+        uses: anthropics/claude-code-base-action@9add77845306ce10ae847a0dc629376271d84c11 # main (pinned 2026-05-01, Claude Code 2.1.126)
         env:
           # claude-code-base-action 内部の Setup Node.js が default 18 を入れるため、
           # wrangler d1 (Node v20+ 必須) が落ちる。skill が呼ぶ recent.mjs のために 24 を強制。


### PR DESCRIPTION
## 概要

GitHub Actions で使っている \`anthropics/claude-code-base-action\` の参照を **SHA pin → \`@main\` 追従** に切り替える。これにより新しい Claude Code リリース (今回のような retire モデル対応を含む) を手動 bump なしで取り込めるようにする。

副次効果として、現状の WebFetch 404 (haiku-3-5 retire 起因) が即時解消される (main は Claude Code 2.1.126 + Agent SDK 0.2.126 を install)。

Closes #428

## 変更内容

- \`.github/workflows/report-daily.yml\` L37: \`@e8132bc5...\` → \`@main\`
- \`.github/workflows/report-weekly.yml\` L34: 同上
- \`.github/workflows/report-monthly.yml\` L35: 同上
- pin コメントを「@beta / release tag が長期間更新停止のため main を追従」に書き換え

## 背景: なぜ tag ではなく main か

確認の結果、\`anthropics/claude-code-base-action\` の mutable tag は **すべて 2025-08-22 以降更新が停止** していた:

| 候補 | 指す commit | Claude Code 版 | 動向 |
|---|---|---|---|
| \`@beta\` | \`e8132bc5\` (2025-08-22) | v1.0.88 | 8 ヶ月以上更新停止 |
| \`@v0.0.63\` (最新 release tag) | \`2d6abe4a\` | 同上 | 同上 |
| \`@v0\` / \`@v1\` (major tag) | — | — | 存在しない |
| \`@main\` | \`9add77845\` (2026-05-01) | **v2.1.126** | 最新を追従 |

\`@main\` はファーストパーティ (anthropics 公式) repo であることを信頼する前提での選択。サードパーティ action なら絶対避けるべきだが、本件は許容範囲とする。将来 anthropics が \`@v1\` のような stable tag を出したらそちらに切り替える。

## 直前の問題 (背景)

2026-04-30 22:54 UTC 実行の daily report (run #25193358544) で 8 件全ての WebFetch が 404:

\`\`\`
API Error: 404 {"type":"error","error":{"type":"not_found_error",
"message":"model: claude-3-5-haiku-20241022"}}
\`\`\`

旧 Claude Code (v1.0.88) は WebFetch 内部要約に retire 済み haiku-3-5 を使用。結果として全 Pick が RSS \`summary\` ベースの \`(summary based)\` になり、null summary 記事は本文がハルシネーションしていた。

## テスト

- [ ] CI (lint / typecheck / test) pass
- [ ] merge 後、次回 daily 自動実行 (cron \`0 0,15 * * *\`) のログで WebFetch tool_result が成功 (200 系) で返ることを確認
- [ ] 生成 report に本文ベース要約 (\`(summary based)\` 一辺倒でない) が含まれることを確認