### PR TITLE
perf(db): reduce getRelatedArticles subrequests from 3 to 2 via CTE

### DIFF
--- a/apps/web/tests/worker/db/articles.test.ts
+++ b/apps/web/tests/worker/db/articles.test.ts
@@ -413,5 +413,17 @@ describe("articles db", () => {
       const feedBItems = (result ?? []).filter((a) => a.feed_id === "feed-b");
       expect(feedBItems.length).toBe(0);
     });
+
+    it("returns only same-feed articles when n equals same-feed count", async () => {
+      // 同 feed (feed-a) に target 除く bigtech 記事は a-bt-1, a-bt-2 の 2 件。
+      // n=2 で要求した場合、同 feed だけで埋まり同 category 補完は走らない。
+      // CTE の source_priority と LIMIT が機能していることを確認。
+      const result = await getRelatedArticles(env.DB, "a-bt-target", 2);
+      expect(result).not.toBeNull();
+      const items = result ?? [];
+      expect.soft(items.length).toBe(2);
+      expect.soft(items.every((a) => a.feed_id === "feed-a")).toBe(true);
+      expect.soft(items.some((a) => a.feed_id === "feed-c")).toBe(false);
+    });
   });
 });

--- a/apps/web/tests/worker/db/articles.test.ts
+++ b/apps/web/tests/worker/db/articles.test.ts
@@ -421,7 +421,9 @@ describe("articles db", () => {
       const result = await getRelatedArticles(env.DB, "a-bt-target", 2);
       expect(result).not.toBeNull();
       const items = result ?? [];
-      expect.soft(items.length).toBe(2);
+      // 後続の every/some は items が空でも true/false を返してしまうため
+      // length は guard として plain expect で fail-fast させる。
+      expect(items.length).toBe(2);
       expect.soft(items.every((a) => a.feed_id === "feed-a")).toBe(true);
       expect.soft(items.some((a) => a.feed_id === "feed-c")).toBe(false);
     });

--- a/apps/web/tests/worker/db/articles.test.ts
+++ b/apps/web/tests/worker/db/articles.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vite-plus/test";
 import { env } from "cloudflare:test";
-import { insertArticles, listArticles } from "../../../worker/db/articles";
+import { getRelatedArticles, insertArticles, listArticles } from "../../../worker/db/articles";
 import { syncFeeds } from "../../../worker/db/feeds";
 import type { FeedConfig } from "../../../worker/types";
 
@@ -255,6 +255,163 @@ describe("articles db", () => {
     it("returns empty when no article matches the query", async () => {
       const result = await listArticles(env.DB, { limit: 10, q: "該当なしのキーワード" });
       expect(result.articles).toHaveLength(0);
+    });
+  });
+
+  describe("getRelatedArticles", () => {
+    beforeEach(async () => {
+      // feed-a (bigtech), feed-b (ai) は FEEDS で登録済み
+      // feed-c (bigtech) を追加して category 補完のテストに使う
+      await syncFeeds(env.DB, [
+        ...FEEDS,
+        {
+          id: "feed-c",
+          name: "Feed C",
+          url: "https://c.test/rss",
+          category: "bigtech",
+          lang: "en",
+          enabled: true,
+        },
+      ]);
+      await insertArticles(env.DB, [
+        // feed-a: bigtech 3 件
+        {
+          guid: "a-bt-1",
+          feed_id: "feed-a",
+          title: "A BigTech 1",
+          url: "https://a.test/1",
+          summary: null,
+          author: null,
+          published_at: "2024-05-01T00:00:00.000Z",
+          category: "bigtech",
+          lang: "en",
+        },
+        {
+          guid: "a-bt-2",
+          feed_id: "feed-a",
+          title: "A BigTech 2",
+          url: "https://a.test/2",
+          summary: null,
+          author: null,
+          published_at: "2024-05-02T00:00:00.000Z",
+          category: "bigtech",
+          lang: "en",
+        },
+        {
+          guid: "a-bt-target",
+          feed_id: "feed-a",
+          title: "A BigTech Target",
+          url: "https://a.test/target",
+          summary: null,
+          author: null,
+          published_at: "2024-05-03T00:00:00.000Z",
+          category: "bigtech",
+          lang: "en",
+        },
+        // feed-c: bigtech 3 件 (別 feed、同 category)
+        {
+          guid: "c-bt-1",
+          feed_id: "feed-c",
+          title: "C BigTech 1",
+          url: "https://c.test/1",
+          summary: null,
+          author: null,
+          published_at: "2024-05-01T12:00:00.000Z",
+          category: "bigtech",
+          lang: "en",
+        },
+        {
+          guid: "c-bt-2",
+          feed_id: "feed-c",
+          title: "C BigTech 2",
+          url: "https://c.test/2",
+          summary: null,
+          author: null,
+          published_at: "2024-05-02T12:00:00.000Z",
+          category: "bigtech",
+          lang: "en",
+        },
+        {
+          guid: "c-bt-3",
+          feed_id: "feed-c",
+          title: "C BigTech 3",
+          url: "https://c.test/3",
+          summary: null,
+          author: null,
+          published_at: "2024-05-03T12:00:00.000Z",
+          category: "bigtech",
+          lang: "en",
+        },
+        // feed-b: ai 2 件 (category が違うので補完されない)
+        {
+          guid: "b-ai-1",
+          feed_id: "feed-b",
+          title: "B AI 1",
+          url: "https://b.test/1",
+          summary: null,
+          author: null,
+          published_at: "2024-05-01T00:00:00.000Z",
+          category: "ai",
+          lang: "en",
+        },
+      ]);
+    });
+
+    it("returns null for unknown guid", async () => {
+      const result = await getRelatedArticles(env.DB, "does-not-exist", 5);
+      expect(result).toBeNull();
+    });
+
+    it("does not include the target article itself", async () => {
+      const result = await getRelatedArticles(env.DB, "a-bt-target", 5);
+      expect(result).not.toBeNull();
+      const guids = (result ?? []).map((a) => a.guid);
+      expect(guids).not.toContain("a-bt-target");
+    });
+
+    it("fills remaining slots with same category articles from other feeds", async () => {
+      // feed-a の bigtech は a-bt-1, a-bt-2 の 2 件のみ (target 除く)
+      // n=5 なので残り 3 件を feed-c (bigtech) で補完する
+      const result = await getRelatedArticles(env.DB, "a-bt-target", 5);
+      expect(result).not.toBeNull();
+      const items = result ?? [];
+      expect(items.length).toBe(5);
+      // 同 feed の記事が先頭に来る
+      const feedAItems = items.filter((a) => a.feed_id === "feed-a");
+      const feedCItems = items.filter((a) => a.feed_id === "feed-c");
+      expect(feedAItems.length).toBe(2);
+      expect(feedCItems.length).toBe(3);
+      // 先頭 2 件が feed-a
+      expect.soft(items[0].feed_id).toBe("feed-a");
+      expect.soft(items[1].feed_id).toBe("feed-a");
+    });
+
+    it("does not include duplicate guids (same feed articles not repeated in category section)", async () => {
+      // CTE 内の guid NOT IN (SELECT guid FROM same_feed) で重複除去していることを確認
+      const result = await getRelatedArticles(env.DB, "a-bt-target", 10);
+      expect(result).not.toBeNull();
+      const items = result ?? [];
+      const guids = items.map((a) => a.guid);
+      const uniqueGuids = new Set(guids);
+      expect(guids.length).toBe(uniqueGuids.size);
+    });
+
+    it("returns same feed articles sorted by published_at desc", async () => {
+      // feed-a: a-bt-2 (2024-05-02) > a-bt-1 (2024-05-01) の順
+      const result = await getRelatedArticles(env.DB, "a-bt-target", 5);
+      expect(result).not.toBeNull();
+      const feedAItems = (result ?? []).filter((a) => a.feed_id === "feed-a");
+      expect(feedAItems.length).toBeGreaterThanOrEqual(2);
+      expect.soft(feedAItems[0].guid).toBe("a-bt-2");
+      expect.soft(feedAItems[1].guid).toBe("a-bt-1");
+    });
+
+    it("does not leak articles from different category into results", async () => {
+      // feed-b の ai 記事は bigtech の target には含まれない
+      const result = await getRelatedArticles(env.DB, "a-bt-target", 10);
+      expect(result).not.toBeNull();
+      const feedBItems = (result ?? []).filter((a) => a.feed_id === "feed-b");
+      expect(feedBItems.length).toBe(0);
     });
   });
 });

--- a/apps/web/worker/db/articles-cursor.ts
+++ b/apps/web/worker/db/articles-cursor.ts
@@ -8,6 +8,13 @@ import type { Article } from "../types";
 export const ARTICLES_SELECT_FIELDS = `a.id, a.guid, a.feed_id, f.name AS feed_name, a.title, a.url, a.summary,
            a.author, a.published_at, a.fetched_at, a.category, a.lang`;
 
+/**
+ * ARTICLES_SELECT_FIELDS から `a.` プレフィックスと `f.name AS` を剥いた素のカラム列。
+ * CTE / サブクエリの外側 SELECT で使う (alias 後は a./f. 修飾できないため)。
+ */
+export const ARTICLES_BARE_FIELDS = `id, guid, feed_id, feed_name, title, url, summary,
+           author, published_at, fetched_at, category, lang`;
+
 /** articles + feeds の FROM / JOIN 句 */
 export const ARTICLES_FROM_JOIN = "FROM articles a LEFT JOIN feeds f ON f.id = a.feed_id";
 

--- a/apps/web/worker/db/articles-query.ts
+++ b/apps/web/worker/db/articles-query.ts
@@ -1,5 +1,6 @@
 import type { Article, FeedCategory, FeedLang } from "../types";
 import {
+  ARTICLES_BARE_FIELDS,
   ARTICLES_FROM_JOIN,
   ARTICLES_SELECT_FIELDS,
   type CursorPage,
@@ -184,27 +185,24 @@ export async function getRelatedArticles(
   const rows = await db
     .prepare(
       `WITH same_feed AS (
-         SELECT a.id, a.guid, a.feed_id, f.name AS feed_name, a.title, a.url, a.summary,
-                a.author, a.published_at, a.fetched_at, a.category, a.lang,
+         SELECT ${ARTICLES_SELECT_FIELDS},
                 0 AS source_priority
-         FROM articles a LEFT JOIN feeds f ON f.id = a.feed_id
+         ${ARTICLES_FROM_JOIN}
          WHERE a.feed_id = ?1 AND a.guid != ?2
          ORDER BY a.published_at DESC
          LIMIT ?3
        ),
        same_category AS (
-         SELECT a.id, a.guid, a.feed_id, f.name AS feed_name, a.title, a.url, a.summary,
-                a.author, a.published_at, a.fetched_at, a.category, a.lang,
+         SELECT ${ARTICLES_SELECT_FIELDS},
                 1 AS source_priority
-         FROM articles a LEFT JOIN feeds f ON f.id = a.feed_id
+         ${ARTICLES_FROM_JOIN}
          WHERE a.category = ?4 AND a.feed_id != ?1
            AND a.guid NOT IN (SELECT guid FROM same_feed)
            AND a.guid != ?2
          ORDER BY a.published_at DESC
          LIMIT ?3
        )
-       SELECT id, guid, feed_id, feed_name, title, url, summary,
-              author, published_at, fetched_at, category, lang
+       SELECT ${ARTICLES_BARE_FIELDS}
        FROM (SELECT * FROM same_feed UNION ALL SELECT * FROM same_category)
        ORDER BY source_priority ASC, published_at DESC
        LIMIT ?3`,

--- a/apps/web/worker/db/articles-query.ts
+++ b/apps/web/worker/db/articles-query.ts
@@ -182,6 +182,9 @@ export async function getRelatedArticles(
   // CTE で「同 feed の最大 n 件」と「同 category かつ別 feed の最大 n 件」を
   // UNION ALL で 1 クエリにまとめる。source_priority で同 feed 優先を保証し、
   // 各グループ内は published_at DESC で整列する。
+  // same_category 側も LIMIT ?3 で最大 n 件読むが、同 feed が少ないと余分に読む可能性がある。
+  // 別 bind を増やすと statement キャッシュのヒット率が落ちるため n で固定し、
+  // 外側 SELECT の LIMIT ?3 で最終的に n 件に絞る。
   const rows = await db
     .prepare(
       `WITH same_feed AS (
@@ -198,6 +201,7 @@ export async function getRelatedArticles(
          ${ARTICLES_FROM_JOIN}
          WHERE a.category = ?4 AND a.feed_id != ?1
            AND a.guid NOT IN (SELECT guid FROM same_feed)
+           -- same_feed が空 (同 feed に他記事ゼロ) の場合に target 自身を弾くガード
            AND a.guid != ?2
          ORDER BY a.published_at DESC
          LIMIT ?3

--- a/apps/web/worker/db/articles-query.ts
+++ b/apps/web/worker/db/articles-query.ts
@@ -165,13 +165,10 @@ export async function getRandomArticles(
  * 同 feed_id を優先し、不足分を同 category の記事で補う。
  * guid が存在しない場合は null を返す (呼び出し側で 404 ハンドル)。
  *
- * パフォーマンス (#398):
- * 旧実装: sequential 3 クエリ (target → sameFeed → sameCategory)
- * 新実装: target 取得後に sameFeed / sameCategory を Promise.all で並列発行し
- *         ラウンドトリップを 3 → 2 に削減。
- * sameCategory クエリは a.feed_id != target.feed_id かつ a.guid != target.guid で
- * 粗く除外し、アプリ側で sameFeed と重複する guid を Set で除去する。
- * これにより sameFeed の結果を待たずに sameCategory を発行できる。
+ * subrequest 削減のための CTE: target 取得後に同 feed / 同 category を
+ * UNION ALL で 1 クエリにまとめ 3 subrequest → 2 subrequest に削減 (#398)。
+ * same_feed CTE を参照して sameCategory 側で重複 guid を SQL で除外するため
+ * アプリ層でのフィルタリングも不要。
  */
 export async function getRelatedArticles(
   db: D1Database,
@@ -181,44 +178,41 @@ export async function getRelatedArticles(
   const target = await findArticleByGuid(db, guid);
   if (!target) return null;
 
-  // sameFeed と sameCategory を並列発行 (ラウンドトリップ削減)
-  // sameCategory は sameFeed の結果を待たずに発行するため LIMIT n を使う。
-  // 実際の採用上限は最終的な slice(0, n) で制御する。
-  const [sameFeedRows, sameCategoryRows] = await Promise.all([
-    db
-      .prepare(
-        `SELECT ${ARTICLES_SELECT_FIELDS}
-         ${ARTICLES_FROM_JOIN}
+  // CTE で「同 feed の最大 n 件」と「同 category かつ別 feed の最大 n 件」を
+  // UNION ALL で 1 クエリにまとめる。source_priority で同 feed 優先を保証し、
+  // 各グループ内は published_at DESC で整列する。
+  const rows = await db
+    .prepare(
+      `WITH same_feed AS (
+         SELECT a.id, a.guid, a.feed_id, f.name AS feed_name, a.title, a.url, a.summary,
+                a.author, a.published_at, a.fetched_at, a.category, a.lang,
+                0 AS source_priority
+         FROM articles a LEFT JOIN feeds f ON f.id = a.feed_id
          WHERE a.feed_id = ?1 AND a.guid != ?2
          ORDER BY a.published_at DESC
-         LIMIT ?3`,
-      )
-      .bind(target.feed_id, guid, n)
-      .all<Article>(),
-    db
-      .prepare(
-        `SELECT ${ARTICLES_SELECT_FIELDS}
-         ${ARTICLES_FROM_JOIN}
-         WHERE a.category = ?1 AND a.feed_id != ?2 AND a.guid != ?3
+         LIMIT ?3
+       ),
+       same_category AS (
+         SELECT a.id, a.guid, a.feed_id, f.name AS feed_name, a.title, a.url, a.summary,
+                a.author, a.published_at, a.fetched_at, a.category, a.lang,
+                1 AS source_priority
+         FROM articles a LEFT JOIN feeds f ON f.id = a.feed_id
+         WHERE a.category = ?4 AND a.feed_id != ?1
+           AND a.guid NOT IN (SELECT guid FROM same_feed)
+           AND a.guid != ?2
          ORDER BY a.published_at DESC
-         LIMIT ?4`,
-      )
-      .bind(target.category, target.feed_id, guid, n)
-      .all<Article>(),
-  ]);
+         LIMIT ?3
+       )
+       SELECT id, guid, feed_id, feed_name, title, url, summary,
+              author, published_at, fetched_at, category, lang
+       FROM (SELECT * FROM same_feed UNION ALL SELECT * FROM same_category)
+       ORDER BY source_priority ASC, published_at DESC
+       LIMIT ?3`,
+    )
+    .bind(target.feed_id, guid, n, target.category)
+    .all<Article>();
 
-  const sameFeedArticles = sameFeedRows.results ?? [];
-  const remaining = n - sameFeedArticles.length;
-
-  if (remaining <= 0) return sameFeedArticles.slice(0, n);
-
-  // sameFeed の guid を Set にしてアプリ側で重複除去し、結合後に n 件で打ち切る
-  const sameFeedGuids = new Set(sameFeedArticles.map((a) => a.guid));
-  const sameCategoryFiltered = (sameCategoryRows.results ?? []).filter(
-    (a) => !sameFeedGuids.has(a.guid),
-  );
-
-  return [...sameFeedArticles, ...sameCategoryFiltered].slice(0, n);
+  return rows.results ?? [];
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `getRelatedArticles` の同 feed / 同 category 取得を CTE + `UNION ALL` で 1 クエリにまとめ、D1 subrequest を 3 → 2 に削減
- アプリ層での重複除去を SQL 内 (`guid NOT IN (SELECT guid FROM same_feed)`) に押し下げ
- CTE 内の SELECT カラム列重複を `ARTICLES_BARE_FIELDS` 定数に集約 (DRY)

## Test plan
- [x] `pnpm -C apps/web test run tests/worker/db/articles.test.ts` (26/26 pass)
  - 既存の関連記事テスト 5 件
  - 新規: `n=同 feed 件数` で同 category 補完が走らず CTE LIMIT が効くことを確認
- [x] `pnpm check` (0 errors)

Closes #398