### PR TITLE
test(worker): adopt soft assertions in admin family specs (Wave 4)

### DIFF
--- a/apps/web/tests/worker/api/admin-cron-health.test.ts
+++ b/apps/web/tests/worker/api/admin-cron-health.test.ts
@@ -52,9 +52,9 @@ describe("GET /api/admin/cron-health", () => {
     const res = await SELF.fetch("https://example.com/api/admin/cron-health?days=99", {
       headers: AUTH_HEADER,
     });
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
-    expect(body.error).toMatch(/days must be 7 or 30/);
+    expect.soft(body.error).toMatch(/days must be 7 or 30/);
   });
 
   it("400: days=0 → 400", async () => {
@@ -68,7 +68,7 @@ describe("GET /api/admin/cron-health", () => {
     const res = await SELF.fetch("https://example.com/api/admin/cron-health", {
       headers: AUTH_HEADER,
     });
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = (await res.json()) as {
       window_days: number;
       runs_total: number;
@@ -96,7 +96,7 @@ describe("GET /api/admin/cron-health", () => {
     const res = await SELF.fetch("https://example.com/api/admin/cron-health?days=7", {
       headers: AUTH_HEADER,
     });
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = (await res.json()) as {
       runs_total: number;
       runs_succeeded: number;
@@ -120,11 +120,12 @@ describe("GET /api/admin/cron-health", () => {
     const res = await SELF.fetch("https://example.com/api/admin/cron-health?days=7", {
       headers: AUTH_HEADER,
     });
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = (await res.json()) as {
       top_failing_feeds: { feed_id: string; failures: number }[];
     };
     // feed-a (failures=2) が feed-b (failures=1) より先
+    // length は [0]/[1] アクセスのガードなので plain expect を使う
     expect(body.top_failing_feeds.length).toBeGreaterThanOrEqual(2);
     expect.soft(body.top_failing_feeds[0].feed_id).toBe("feed-a");
     expect.soft(body.top_failing_feeds[0].failures).toBe(2);
@@ -139,9 +140,9 @@ describe("GET /api/admin/cron-health", () => {
     const res = await SELF.fetch("https://example.com/api/admin/cron-health?days=7", {
       headers: AUTH_HEADER,
     });
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = (await res.json()) as { runs_total: number };
-    expect(body.runs_total).toBe(0);
+    expect.soft(body.runs_total).toBe(0);
   });
 
   it("200: days=30 で 8 日前のデータが含まれる", async () => {
@@ -151,7 +152,7 @@ describe("GET /api/admin/cron-health", () => {
     const res = await SELF.fetch("https://example.com/api/admin/cron-health?days=30", {
       headers: AUTH_HEADER,
     });
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = (await res.json()) as { runs_total: number; window_days: number };
     expect.soft(body.window_days).toBe(30);
     expect.soft(body.runs_total).toBe(1);
@@ -161,7 +162,7 @@ describe("GET /api/admin/cron-health", () => {
     const res = await SELF.fetch("https://example.com/api/admin/cron-health", {
       headers: AUTH_HEADER,
     });
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const cacheControl = res.headers.get("cache-control") ?? "";
     expect.soft(cacheControl).toContain("private");
     expect.soft(cacheControl).toContain("max-age=60");

--- a/apps/web/tests/worker/api/admin-cron-health.test.ts
+++ b/apps/web/tests/worker/api/admin-cron-health.test.ts
@@ -52,7 +52,7 @@ describe("GET /api/admin/cron-health", () => {
     const res = await SELF.fetch("https://example.com/api/admin/cron-health?days=99", {
       headers: AUTH_HEADER,
     });
-    expect.soft(res.status).toBe(400);
+    expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
     expect.soft(body.error).toMatch(/days must be 7 or 30/);
   });

--- a/apps/web/tests/worker/api/admin-feeds-diagnostics.test.ts
+++ b/apps/web/tests/worker/api/admin-feeds-diagnostics.test.ts
@@ -51,7 +51,8 @@ describe("GET /api/admin/feeds/diagnostics", () => {
     });
     expect.soft(res.status).toBe(200);
     const body = (await res.json()) as { feeds: unknown[]; count: number };
-    expect.soft(Array.isArray(body.feeds)).toBe(true);
+    // Array.isArray は後続 toHaveLength の guard として fail-fast させる
+    expect(Array.isArray(body.feeds)).toBe(true);
     expect.soft(body.feeds).toHaveLength(0);
     expect.soft(body.count).toBe(0);
   });

--- a/apps/web/tests/worker/api/admin-feeds-diagnostics.test.ts
+++ b/apps/web/tests/worker/api/admin-feeds-diagnostics.test.ts
@@ -49,18 +49,18 @@ describe("GET /api/admin/feeds/diagnostics", () => {
     const res = await SELF.fetch("https://example.com/api/admin/feeds/diagnostics", {
       headers: AUTH_HEADER,
     });
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = (await res.json()) as { feeds: unknown[]; count: number };
-    expect(Array.isArray(body.feeds)).toBe(true);
-    expect(body.feeds).toHaveLength(0);
-    expect(body.count).toBe(0);
+    expect.soft(Array.isArray(body.feeds)).toBe(true);
+    expect.soft(body.feeds).toHaveLength(0);
+    expect.soft(body.count).toBe(0);
   });
 
   it("200: Cache-Control が private, max-age=30", async () => {
     const res = await SELF.fetch("https://example.com/api/admin/feeds/diagnostics", {
       headers: AUTH_HEADER,
     });
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const cc = res.headers.get("cache-control") ?? "";
     expect.soft(cc).toContain("private");
     expect.soft(cc).toContain("max-age=30");
@@ -72,12 +72,12 @@ describe("GET /api/admin/feeds/diagnostics", () => {
     const res = await SELF.fetch("https://example.com/api/admin/feeds/diagnostics", {
       headers: AUTH_HEADER,
     });
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = (await res.json()) as {
       feeds: { id: string; enabled: boolean }[];
       count: number;
     };
-    expect(body.count).toBe(2);
+    expect.soft(body.count).toBe(2);
     const ids = body.feeds.map((f) => f.id);
     expect.soft(ids).toContain("feed-alpha");
     expect.soft(ids).toContain("feed-beta");
@@ -98,7 +98,7 @@ describe("GET /api/admin/feeds/diagnostics", () => {
     const res = await SELF.fetch("https://example.com/api/admin/feeds/diagnostics", {
       headers: AUTH_HEADER,
     });
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = (await res.json()) as {
       feeds: {
         id: string;
@@ -119,6 +119,7 @@ describe("GET /api/admin/feeds/diagnostics", () => {
       }[];
       count: number;
     };
+    // count は feeds[0] アクセスのガードなので plain expect を使う
     expect(body.count).toBe(1);
     const f = body.feeds[0];
     expect.soft(f.id).toBe("feed-alpha");
@@ -147,7 +148,7 @@ describe("GET /api/admin/feeds/diagnostics", () => {
     const res = await SELF.fetch("https://example.com/api/admin/feeds/diagnostics", {
       headers: AUTH_HEADER,
     });
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = (await res.json()) as {
       feeds: {
         id: string;
@@ -201,7 +202,7 @@ describe("GET /api/admin/feeds/diagnostics", () => {
     const res = await SELF.fetch("https://example.com/api/admin/feeds/diagnostics", {
       headers: AUTH_HEADER,
     });
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const body = (await res.json()) as {
       feeds: {
         id: string;

--- a/apps/web/tests/worker/api/admin-validate.test.ts
+++ b/apps/web/tests/worker/api/admin-validate.test.ts
@@ -74,7 +74,7 @@ describe("POST /api/admin/feeds/validate (integration)", () => {
       headers: { ...AUTH_HEADER, "content-type": "application/json" },
       body: JSON.stringify({ url: "not-a-url" }),
     });
-    expect.soft(res.status).toBe(400);
+    expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
     expect.soft(body.error).toMatch(/invalid url/i);
   });
@@ -85,7 +85,7 @@ describe("POST /api/admin/feeds/validate (integration)", () => {
       headers: { ...AUTH_HEADER, "content-type": "application/json" },
       body: JSON.stringify({ url: "ftp://example.com/feed.xml" }),
     });
-    expect.soft(res.status).toBe(400);
+    expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
     expect.soft(body.error).toMatch(/invalid url/i);
   });

--- a/apps/web/tests/worker/api/admin-validate.test.ts
+++ b/apps/web/tests/worker/api/admin-validate.test.ts
@@ -74,9 +74,9 @@ describe("POST /api/admin/feeds/validate (integration)", () => {
       headers: { ...AUTH_HEADER, "content-type": "application/json" },
       body: JSON.stringify({ url: "not-a-url" }),
     });
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
-    expect(body.error).toMatch(/invalid url/i);
+    expect.soft(body.error).toMatch(/invalid url/i);
   });
 
   it("400: http/https 以外のスキーマ → 400", async () => {
@@ -85,9 +85,9 @@ describe("POST /api/admin/feeds/validate (integration)", () => {
       headers: { ...AUTH_HEADER, "content-type": "application/json" },
       body: JSON.stringify({ url: "ftp://example.com/feed.xml" }),
     });
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
-    expect(body.error).toMatch(/invalid url/i);
+    expect.soft(body.error).toMatch(/invalid url/i);
   });
 
   it("200 + ok:false: 外部 fetch は CI 環境では失敗 → ok:false と Cache-Control: no-store", async () => {
@@ -98,12 +98,12 @@ describe("POST /api/admin/feeds/validate (integration)", () => {
       headers: { ...AUTH_HEADER, "content-type": "application/json" },
       body: JSON.stringify({ url: "https://example.com/feed.xml" }),
     });
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     const cacheControl = res.headers.get("cache-control") ?? "";
     expect.soft(cacheControl).toContain("no-store");
     const body = (await res.json()) as { ok: boolean };
     // CI では外部 fetch が失敗するため ok:false。テスト環境の制約上、ok:true は下記ユニットテストで検証する。
-    expect(typeof body.ok).toBe("boolean");
+    expect.soft(typeof body.ok).toBe("boolean");
   });
 });
 
@@ -119,6 +119,7 @@ describe("validateFeedUrl (unit)", () => {
     );
 
     const result = await validateFeedUrl("https://example.com/feed.xml");
+    // result.ok は後続の narrowing guard なので plain expect を使う
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error("expected ok:true");
     expect.soft(result.title).toBe("Example Tech Blog");
@@ -135,6 +136,7 @@ describe("validateFeedUrl (unit)", () => {
     );
 
     const result = await validateFeedUrl("https://example.com/feed.atom");
+    // result.ok は後続の narrowing guard なので plain expect を使う
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error("expected ok:true");
     expect.soft(result.title).toBe("日本語テックブログ");
@@ -146,10 +148,11 @@ describe("validateFeedUrl (unit)", () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response("Not Found", { status: 404 }));
 
     const result = await validateFeedUrl("https://example.com/feed.xml");
+    // result.ok は後続の narrowing guard なので plain expect を使う
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error("expected ok:false");
-    expect(typeof result.error).toBe("string");
-    expect(result.error.length).toBeGreaterThan(0);
+    expect.soft(typeof result.error).toBe("string");
+    expect.soft(result.error.length).toBeGreaterThan(0);
   });
 
   it("ok:false: XML でないレスポンス (HTML) → ok:false", async () => {
@@ -180,8 +183,9 @@ describe("validateFeedUrl (unit)", () => {
     vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(new TypeError("Failed to fetch"));
 
     const result = await validateFeedUrl("https://unreachable.example.com/feed.xml");
+    // result.ok は後続の narrowing guard なので plain expect を使う
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error("expected ok:false");
-    expect(typeof result.error).toBe("string");
+    expect.soft(typeof result.error).toBe("string");
   });
 });


### PR DESCRIPTION
## Summary

Wave 4 (#388 / #334) の一環で admin 系 spec に `expect.soft` を導入。
1 テスト内で独立した観点 (status / header / 各 body フィールド) を soft assert し、初回失敗で fail-fast せず全違反を集約する。

対象:

- `apps/web/tests/worker/api/admin-cron-health.test.ts`
- `apps/web/tests/worker/api/admin-feeds-diagnostics.test.ts`
- `apps/web/tests/worker/api/admin-validate.test.ts`

ルール (`.claude/rules/20-testing-overview.md`) に従い:

- 独立観点 → `expect.soft`
- guard / prerequisite (続く assert の前提) → 通常 `expect`

## Test plan

- [x] `pnpm -C apps/web test run tests/worker/api/admin-{cron-health,feeds-diagnostics,validate}.test.ts` (40/40 pass)
- [x] origin/main rebase 後の整合性確認

Refs #388 #334


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test resilience by converting assertion checks to continue on non-critical failures, allowing multiple validation checks to run even if earlier assertions fail.
  * Added clarifying comments within test cases for better test maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->