### PR TITLE
test: adopt soft assertions in reports & spa-shell tests (Wave 4)

### DIFF
--- a/apps/web/tests/worker/api/reports.test.ts
+++ b/apps/web/tests/worker/api/reports.test.ts
@@ -198,9 +198,9 @@ describe("POST /api/admin/reports", () => {
         }),
       ),
     });
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
-    expect(body.error).toBe("period_end must be after period_start");
+    expect.soft(body.error).toBe("period_end must be after period_start");
   });
 
   it("400: rejects period_start > period_end", async () => {
@@ -214,9 +214,9 @@ describe("POST /api/admin/reports", () => {
         }),
       ),
     });
-    expect(res.status).toBe(400);
+    expect.soft(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
-    expect(body.error).toBe("period_end must be after period_start");
+    expect.soft(body.error).toBe("period_end must be after period_start");
   });
 
   // ---- overlap validation ----
@@ -253,7 +253,7 @@ describe("POST /api/admin/reports", () => {
     });
     expect(res.status).toBe(200);
     const body = (await res.json()) as AdminReportSaveResponse;
-    expect(body.ok).toBe(true);
+    expect.soft(body.ok).toBe(true);
   });
 
   it("409: partial overlap (start shifted by 1 day)", async () => {
@@ -561,7 +561,7 @@ describe("GET /api/admin/reports", () => {
     });
     expect(res.status).toBe(200);
     const body = (await res.json()) as AdminReportListResponse;
-    expect(body.reports.length).toBeGreaterThanOrEqual(2);
+    expect.soft(body.reports.length).toBeGreaterThanOrEqual(2);
     expect.soft(body.reports[0].generated_at >= body.reports[1].generated_at).toBe(true);
   });
 
@@ -583,7 +583,7 @@ describe("GET /api/admin/reports", () => {
     });
     expect(res.status).toBe(200);
     const body = (await res.json()) as AdminReportListResponse;
-    expect(body.reports.every((r) => r.kind === "weekly")).toBe(true);
+    expect.soft(body.reports.every((r) => r.kind === "weekly")).toBe(true);
   });
 
   it("400: rejects invalid kind", async () => {

--- a/apps/web/tests/worker/api/reports.test.ts
+++ b/apps/web/tests/worker/api/reports.test.ts
@@ -198,7 +198,7 @@ describe("POST /api/admin/reports", () => {
         }),
       ),
     });
-    expect.soft(res.status).toBe(400);
+    expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
     expect.soft(body.error).toBe("period_end must be after period_start");
   });
@@ -214,7 +214,7 @@ describe("POST /api/admin/reports", () => {
         }),
       ),
     });
-    expect.soft(res.status).toBe(400);
+    expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
     expect.soft(body.error).toBe("period_end must be after period_start");
   });
@@ -561,7 +561,8 @@ describe("GET /api/admin/reports", () => {
     });
     expect(res.status).toBe(200);
     const body = (await res.json()) as AdminReportListResponse;
-    expect.soft(body.reports.length).toBeGreaterThanOrEqual(2);
+    // length は後続の reports[1] アクセスの guard なので fail-fast
+    expect(body.reports.length).toBeGreaterThanOrEqual(2);
     expect.soft(body.reports[0].generated_at >= body.reports[1].generated_at).toBe(true);
   });
 

--- a/apps/web/tests/worker/api/spa-shell.test.ts
+++ b/apps/web/tests/worker/api/spa-shell.test.ts
@@ -73,13 +73,14 @@ describe("SPA shell rewrite: GET /articles/:id", () => {
     const id = row?.id;
 
     const res = await SELF.fetch(`https://example.com/articles/${id}`);
-    expect.soft(res.status).toBe(200);
+    // status は Cache-Control 検証の前提なので fail-fast
+    expect(res.status).toBe(200);
     expect.soft(res.headers.get("Cache-Control")).toContain("max-age=300");
   });
 
   it("falls back to static index.html for unknown article id", async () => {
     const res = await SELF.fetch("https://example.com/articles/99999999");
-    expect.soft(res.status).toBe(200);
+    expect(res.status).toBe(200);
     // fallback の場合は no-cache
     expect.soft(res.headers.get("Cache-Control")).toContain("no-cache");
   });
@@ -99,7 +100,7 @@ describe("SPA shell rewrite: GET /feed/:feedId", () => {
 
   it("falls back to static index.html for unknown feedId", async () => {
     const res = await SELF.fetch("https://example.com/feed/nonexistent-feed-xyz");
-    expect.soft(res.status).toBe(200);
+    expect(res.status).toBe(200);
     expect.soft(res.headers.get("Cache-Control")).toContain("no-cache");
   });
 });
@@ -144,7 +145,7 @@ describe("SPA shell rewrite: GET /by-category/:cat", () => {
 describe("SPA shell rewrite: static routes (no rewriting)", () => {
   it("returns default title for top page /", async () => {
     const res = await SELF.fetch("https://example.com/");
-    expect.soft(res.status).toBe(200);
+    expect(res.status).toBe(200);
 
     // トップページは書き換えなし → Cache-Control は no-cache
     expect.soft(res.headers.get("Cache-Control")).toContain("no-cache");
@@ -152,14 +153,14 @@ describe("SPA shell rewrite: static routes (no rewriting)", () => {
 
   it("returns no-cache for /stats", async () => {
     const res = await SELF.fetch("https://example.com/stats");
-    expect.soft(res.status).toBe(200);
+    expect(res.status).toBe(200);
     expect.soft(res.headers.get("Cache-Control")).toContain("no-cache");
   });
 
   it("does not rewrite /api/* routes", async () => {
     // /api/* は JSON を返すため HTML ではない
     const res = await SELF.fetch("https://example.com/api/articles?limit=1");
-    expect.soft(res.status).toBe(200);
+    expect(res.status).toBe(200);
     const ct = res.headers.get("Content-Type") ?? "";
     expect.soft(ct).toContain("application/json");
   });

--- a/apps/web/tests/worker/api/spa-shell.test.ts
+++ b/apps/web/tests/worker/api/spa-shell.test.ts
@@ -73,7 +73,7 @@ describe("SPA shell rewrite: GET /articles/:id", () => {
     const id = row?.id;
 
     const res = await SELF.fetch(`https://example.com/articles/${id}`);
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
     expect.soft(res.headers.get("Cache-Control")).toContain("max-age=300");
   });
 
@@ -144,16 +144,16 @@ describe("SPA shell rewrite: GET /by-category/:cat", () => {
 describe("SPA shell rewrite: static routes (no rewriting)", () => {
   it("returns default title for top page /", async () => {
     const res = await SELF.fetch("https://example.com/");
-    expect(res.status).toBe(200);
+    expect.soft(res.status).toBe(200);
 
     // トップページは書き換えなし → Cache-Control は no-cache
-    expect(res.headers.get("Cache-Control")).toContain("no-cache");
+    expect.soft(res.headers.get("Cache-Control")).toContain("no-cache");
   });
 
   it("returns no-cache for /stats", async () => {
     const res = await SELF.fetch("https://example.com/stats");
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Cache-Control")).toContain("no-cache");
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Cache-Control")).toContain("no-cache");
   });
 
   it("does not rewrite /api/* routes", async () => {
@@ -194,7 +194,7 @@ describe("SPA shell rewrite: article with null summary", () => {
     const html = await res.text();
     // description は DEFAULT_DESCRIPTION にフォールバック
     const desc = extractMeta(html, '[name="description"]');
-    expect(desc).toBe("海外 big tech / AI / 国内企業の tech blog 記事を集約");
+    expect.soft(desc).toBe("海外 big tech / AI / 国内企業の tech blog 記事を集約");
   });
 });
 


### PR DESCRIPTION
## Summary

Wave 4 (#388 / #334) の一環で reports / spa-shell 系 spec に `expect.soft` を導入。
1 テスト内で独立した観点を soft assert し、初回失敗で fail-fast せず全違反を集約する。

対象:

- `apps/web/tests/worker/api/reports.test.ts`
- `apps/web/tests/worker/api/spa-shell.test.ts`

ルール (`.claude/rules/20-testing-overview.md`) に従い:

- 独立観点 → `expect.soft`
- guard / prerequisite (続く assert の前提) → 通常 `expect`

## Test plan

- [x] `pnpm -C apps/web test run tests/worker/api/reports.test.ts tests/worker/api/spa-shell.test.ts` (53/53 pass)
- [x] origin/main rebase 後の整合性確認

Refs #388 #334


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined assertion patterns in report API and SPA shell rewrite tests for improved test reliability and diagnostic clarity
  * Enhanced test validation strategy with differentiated assertion strictness—critical checks remain strict while metadata assertions become more flexible
  * Improved test code documentation with clarifying comments for complex assertion logic and guard conditions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->