### PR TITLE
test(db): adopt soft assertions in remaining db tests (Wave 4)

### DIFF
--- a/apps/web/tests/worker/db/articles-query-extra.test.ts
+++ b/apps/web/tests/worker/db/articles-query-extra.test.ts
@@ -103,45 +103,50 @@ describe("searchArticles (FTS5 only)", () => {
   it("returns articles matching English keyword in title (TypeScript)", async () => {
     const result = await searchArticles(env.DB, "TypeScript", 10, null);
     const guids = result.articles.map((a) => a.guid);
-    expect(guids).toContain("en-1");
-    expect(guids).toContain("ja-1");
-    expect(guids).not.toContain("en-2");
-    expect(guids).not.toContain("ja-2");
+    // ヒット / 非ヒットは独立した観点
+    expect.soft(guids).toContain("en-1");
+    expect.soft(guids).toContain("ja-1");
+    expect.soft(guids).not.toContain("en-2");
+    expect.soft(guids).not.toContain("ja-2");
   });
 
   it("returns articles matching English keyword in summary (tokio)", async () => {
     const result = await searchArticles(env.DB, "tokio", 10, null);
     const guids = result.articles.map((a) => a.guid);
-    expect(guids).toContain("en-2");
-    expect(guids).not.toContain("en-1");
+    // ヒット / 非ヒットは独立した観点
+    expect.soft(guids).toContain("en-2");
+    expect.soft(guids).not.toContain("en-1");
   });
 
   it("returns articles matching Japanese keyword in title (機械学習)", async () => {
     // trigram は 3 文字以上の部分文字列に一致する
     const result = await searchArticles(env.DB, "機械学習", 10, null);
     const guids = result.articles.map((a) => a.guid);
-    expect(guids).toContain("ja-2");
-    expect(guids).not.toContain("ja-1");
+    // ヒット / 非ヒットは独立した観点
+    expect.soft(guids).toContain("ja-2");
+    expect.soft(guids).not.toContain("ja-1");
   });
 
   it("returns articles matching Japanese keyword in summary (PyTorch)", async () => {
     const result = await searchArticles(env.DB, "PyTorch", 10, null);
     const guids = result.articles.map((a) => a.guid);
-    expect(guids).toContain("ja-2");
+    expect.soft(guids).toContain("ja-2");
   });
 
   it("returns empty when no article matches the query", async () => {
     const result = await searchArticles(env.DB, "該当なしキーワードXYZ", 10, null);
-    expect(result.articles).toHaveLength(0);
-    expect(result.nextCursor).toBeNull();
+    // articles と nextCursor は独立した属性
+    expect.soft(result.articles).toHaveLength(0);
+    expect.soft(result.nextCursor).toBeNull();
   });
 
   it("handles multi-token query (Rust async)", async () => {
     // スペース区切りで複数トークン → FTS5 が AND で解釈
     const result = await searchArticles(env.DB, "Rust async", 10, null);
     const guids = result.articles.map((a) => a.guid);
-    expect(guids).toContain("en-2");
-    expect(guids).not.toContain("en-1");
+    // ヒット / 非ヒットは独立した観点
+    expect.soft(guids).toContain("en-2");
+    expect.soft(guids).not.toContain("en-1");
   });
 
   it("handles FTS5 special characters gracefully (double-quote in query)", async () => {
@@ -211,23 +216,24 @@ describe("searchArticles (FTS5 only)", () => {
   it("respects limit and returns nextCursor for pagination", async () => {
     // TypeScript で 2 件ヒットするが limit=1 でページネーション
     const page1 = await searchArticles(env.DB, "TypeScript", 1, null);
+    // page1.articles.length が guard (page2 の前提)。nextCursor は独立
     expect(page1.articles).toHaveLength(1);
-    expect(page1.nextCursor).not.toBeNull();
+    expect.soft(page1.nextCursor).not.toBeNull();
 
     const page2 = await searchArticles(env.DB, "TypeScript", 1, page1.nextCursor);
-    expect(page2.articles).toHaveLength(1);
-    // page1 と page2 のガイドが異なること
-    expect(page2.articles[0]?.guid).not.toBe(page1.articles[0]?.guid);
+    // length と guid の非一致は独立した属性
+    expect.soft(page2.articles).toHaveLength(1);
+    expect.soft(page2.articles[0]?.guid).not.toBe(page1.articles[0]?.guid);
   });
 
   it("is case-insensitive — TypeScript and typescript both hit FTS5 index", async () => {
     // FTS5 trigram tokenizer は case-insensitive
     const lower = await searchArticles(env.DB, "typescript", 10, null);
     const upper = await searchArticles(env.DB, "TypeScript", 10, null);
-    expect(lower.articles.map((a) => a.guid)).toContain("en-1");
-    expect(upper.articles.map((a) => a.guid)).toContain("en-1");
-    // 同じ件数がヒットする
-    expect(lower.articles.length).toBe(upper.articles.length);
+    // lower/upper それぞれのヒットと件数一致は独立した観点
+    expect.soft(lower.articles.map((a) => a.guid)).toContain("en-1");
+    expect.soft(upper.articles.map((a) => a.guid)).toContain("en-1");
+    expect.soft(lower.articles.length).toBe(upper.articles.length);
   });
 
   it("does NOT fall back to LIKE — 2-char query returns no results for trigram", async () => {

--- a/apps/web/tests/worker/db/feeds.test.ts
+++ b/apps/web/tests/worker/db/feeds.test.ts
@@ -114,7 +114,8 @@ describe("loadFeedHeadersAll", () => {
 
   it("omits unknown feed ids from the returned Map", async () => {
     const map = await loadFeedHeadersAll(env.DB, ["feed-a", "non-existent"]);
-    expect(map.has("feed-a")).toBe(true);
-    expect(map.has("non-existent")).toBe(false);
+    // 存在する feed と存在しない feed の has() は独立した観点
+    expect.soft(map.has("feed-a")).toBe(true);
+    expect.soft(map.has("non-existent")).toBe(false);
   });
 });

--- a/apps/web/tests/worker/db/reports.test.ts
+++ b/apps/web/tests/worker/db/reports.test.ts
@@ -50,8 +50,9 @@ describe("findOverlappingReports", () => {
         period_end: "2026-04-29T00:00:00.000Z",
       }),
     );
+    // length は guard (overlaps[0] アクセスの前提)。id は独立した属性
     expect(overlaps).toHaveLength(1);
-    expect(overlaps[0]?.id).toBe(id);
+    expect.soft(overlaps[0]?.id).toBe(id);
   });
 
   it("returns empty array for adjacent period (new start == existing end)", async () => {
@@ -118,7 +119,8 @@ describe("upsertReport overlap guard", () => {
     } catch (err) {
       if (err instanceof OverlapError) caught = err;
     }
+    // caught が null でないことは guard (conflictingIds アクセスの前提)。id の含有は独立
     expect(caught).not.toBeNull();
-    expect(caught!.conflictingIds).toContain(id);
+    expect.soft(caught!.conflictingIds).toContain(id);
   });
 });

--- a/apps/web/tests/worker/db/retention.test.ts
+++ b/apps/web/tests/worker/db/retention.test.ts
@@ -77,9 +77,10 @@ describe("pruneOldArticles", () => {
 
     const result = await pruneOldArticles(env.DB, 0);
 
-    expect(result.deleted).toBe(0);
+    // deleted カウントと DB の残存件数は独立した観点
+    expect.soft(result.deleted).toBe(0);
     const r = await env.DB.prepare("SELECT COUNT(*) AS n FROM articles").first<{ n: number }>();
-    expect(r?.n).toBe(1);
+    expect.soft(r?.n).toBe(1);
   });
 
   it("is a no-op when days is negative", async () => {
@@ -99,8 +100,9 @@ describe("pruneOldArticles", () => {
 
     const result = await pruneOldArticles(env.DB, -1);
 
-    expect(result.deleted).toBe(0);
+    // deleted カウントと DB の残存件数は独立した観点
+    expect.soft(result.deleted).toBe(0);
     const r = await env.DB.prepare("SELECT COUNT(*) AS n FROM articles").first<{ n: number }>();
-    expect(r?.n).toBe(1);
+    expect.soft(r?.n).toBe(1);
   });
 });

--- a/apps/web/tests/worker/db/runs.test.ts
+++ b/apps/web/tests/worker/db/runs.test.ts
@@ -5,8 +5,9 @@ import { finishRun, getRun, listRuns, recordRunFeed, startRun } from "../../../w
 describe("runs db", () => {
   it("startRun returns a run_id", async () => {
     const { run_id } = await startRun(env.DB, "2024-04-01T00:00:00.000Z", 5);
-    expect(typeof run_id).toBe("number");
-    expect(run_id).toBeGreaterThan(0);
+    // 型と値の正当性は独立した観点
+    expect.soft(typeof run_id).toBe("number");
+    expect.soft(run_id).toBeGreaterThan(0);
   });
 
   it("listRuns returns empty array when no runs exist", async () => {


### PR DESCRIPTION
## Summary

Wave 4 (#388 / #334) の一環で db 系テストに `expect.soft` を追加。
1 テスト内で独立した観点を soft assert し、初回失敗で fail-fast せず全違反を集約する。

| ファイル                       | before | after |
| ------------------------------ | ------ | ----- |
| `articles-query-extra.test.ts` | 0      | 19    |
| `reports.test.ts`              | 0      | 2     |
| `runs.test.ts`                 | 18     | 20    |
| `feeds.test.ts`                | 3      | 5     |
| `retention.test.ts`            | 4      | 6     |

ルール (`.claude/rules/20-testing-overview.md`) に従い:

- 独立観点 → `expect.soft`
- guard / prerequisite (続く assert の前提) → 通常 `expect`

## Test plan

- [x] `pnpm -C apps/web test run tests/worker/db/` (52/52 pass)

Refs #388 #334
