### PR TITLE
test(client): adopt soft assertions in client tests (Wave 4)

### DIFF
--- a/apps/web/tests/client/ArticleCard.test.tsx
+++ b/apps/web/tests/client/ArticleCard.test.tsx
@@ -109,8 +109,8 @@ describe("ArticleCard", () => {
           onFilterByFeedId={noop}
         />,
       );
-      expect(document.querySelector("mark")).toBeNull();
-      expect(screen.getByText("Hello World")).toBeTruthy();
+      expect.soft(document.querySelector("mark")).toBeNull();
+      expect.soft(screen.getByText("Hello World")).toBeTruthy();
     });
 
     it("escapes regex special characters in the query (e.g. C++)", () => {

--- a/apps/web/tests/client/AuthorDetail.test.tsx
+++ b/apps/web/tests/client/AuthorDetail.test.tsx
@@ -73,13 +73,13 @@ describe("AuthorDetail", () => {
       />,
     );
     // h1 に著者名
-    expect(screen.getByRole("heading", { level: 1, name: "Author A" })).toBeTruthy();
+    expect.soft(screen.getByRole("heading", { level: 1, name: "Author A" })).toBeTruthy();
     // 記事タイトルが全て表示される
     for (let i = 1; i <= 5; i++) {
-      expect(await screen.findByText(`記事 ${i}`)).toBeTruthy();
+      expect.soft(await screen.findByText(`記事 ${i}`)).toBeTruthy();
     }
     // 件数表示
-    expect(screen.getByText(/5 件/)).toBeTruthy();
+    expect.soft(screen.getByText(/5 件/)).toBeTruthy();
   });
 
   it("0 件で「記事がありません」が表示される", async () => {

--- a/apps/web/tests/client/Stats.test.tsx
+++ b/apps/web/tests/client/Stats.test.tsx
@@ -50,8 +50,8 @@ describe("StatsPanel", () => {
   it("renders feed activity rows with feed name and count", () => {
     const stats: Stats = { ...baseStats, feed_activity: [feedActivity] };
     render(<StatsPanel stats={stats} />);
-    expect(screen.getByText("Tech Blog")).toBeTruthy();
-    expect(screen.getByText("42")).toBeTruthy();
+    expect.soft(screen.getByText("Tech Blog")).toBeTruthy();
+    expect.soft(screen.getByText("42")).toBeTruthy();
   });
 
   it("renders the category trend chart when trend data has non-zero values", () => {

--- a/apps/web/tests/client/useArticles.test.tsx
+++ b/apps/web/tests/client/useArticles.test.tsx
@@ -51,8 +51,8 @@ describe("useArticles 基本動作", () => {
       expect(result.current.loading).toBe(false);
     });
 
-    expect(result.current.articles).toHaveLength(5);
-    expect(result.current.error).toBeNull();
+    expect.soft(result.current.articles).toHaveLength(5);
+    expect.soft(result.current.error).toBeNull();
   });
 
   it("nextCursor が null のとき nextCursor が null になる", async () => {
@@ -76,8 +76,8 @@ describe("useArticles 基本動作", () => {
       expect(result.current.loading).toBe(false);
     });
 
-    expect(result.current.error).toBeTruthy();
-    expect(result.current.articles).toEqual([]);
+    expect.soft(result.current.error).toBeTruthy();
+    expect.soft(result.current.articles).toEqual([]);
   });
 
   it("loadMore で次ページが追加される", async () => {
@@ -234,9 +234,9 @@ describe("useArticles 自動 loadMore", () => {
     );
 
     // 上限到達後に autoLoadStopped が true になる
-    expect(result.current.autoLoadStopped).toBe(true);
+    expect.soft(result.current.autoLoadStopped).toBe(true);
     // これ以上 fetch が呼ばれないことを確認 (=6 回で打ち止め)
-    expect(mockFetch.mock.calls.length).toBe(6);
+    expect.soft(mockFetch.mock.calls.length).toBe(6);
   });
 
   it("autoLoadStopped は isFilterActive=false のとき false のまま", async () => {

--- a/apps/web/tests/client/useFilterHandlers.test.tsx
+++ b/apps/web/tests/client/useFilterHandlers.test.tsx
@@ -191,11 +191,11 @@ describe("useFilterHandlers", () => {
       result.current.handleClear();
     });
 
-    expect(setters.setFeedId).toHaveBeenCalledWith("");
-    expect(setters.setDateFrom).toHaveBeenCalledWith("");
-    expect(setters.setDateTo).toHaveBeenCalledWith("");
-    expect(setters.setUnreadOnly).toHaveBeenCalledWith(false);
-    expect(setters.setStarredOnly).toHaveBeenCalledWith(false);
+    expect.soft(setters.setFeedId).toHaveBeenCalledWith("");
+    expect.soft(setters.setDateFrom).toHaveBeenCalledWith("");
+    expect.soft(setters.setDateTo).toHaveBeenCalledWith("");
+    expect.soft(setters.setUnreadOnly).toHaveBeenCalledWith(false);
+    expect.soft(setters.setStarredOnly).toHaveBeenCalledWith(false);
   });
 
   it("handleBookmarkedOnlyToggle が setUrlFilters で bookmarksOnly を反転させる", () => {
@@ -237,8 +237,8 @@ describe("useFilterHandlers", () => {
       });
     });
 
-    expect(setters.setFeedId).toHaveBeenCalledWith("preset-feed");
-    expect(setters.setUnreadOnly).toHaveBeenCalledWith(true);
-    expect(setters.setStarredOnly).toHaveBeenCalledWith(false);
+    expect.soft(setters.setFeedId).toHaveBeenCalledWith("preset-feed");
+    expect.soft(setters.setUnreadOnly).toHaveBeenCalledWith(true);
+    expect.soft(setters.setStarredOnly).toHaveBeenCalledWith(false);
   });
 });

--- a/apps/web/tests/client/useKeyboardShortcuts.test.tsx
+++ b/apps/web/tests/client/useKeyboardShortcuts.test.tsx
@@ -134,11 +134,11 @@ describe("useKeyboardShortcuts", () => {
     fire("?");
     fire("G");
 
-    expect(handlers.onNext).not.toHaveBeenCalled();
-    expect(handlers.onPrev).not.toHaveBeenCalled();
-    expect(handlers.onBookmark).not.toHaveBeenCalled();
-    expect(handlers.onShowHelp).not.toHaveBeenCalled();
-    expect(handlers.onBottom).not.toHaveBeenCalled();
+    expect.soft(handlers.onNext).not.toHaveBeenCalled();
+    expect.soft(handlers.onPrev).not.toHaveBeenCalled();
+    expect.soft(handlers.onBookmark).not.toHaveBeenCalled();
+    expect.soft(handlers.onShowHelp).not.toHaveBeenCalled();
+    expect.soft(handlers.onBottom).not.toHaveBeenCalled();
 
     document.body.removeChild(input);
   });
@@ -165,7 +165,7 @@ describe("useKeyboardShortcuts", () => {
     fire("Enter");
     fire("Escape");
     for (const fn of Object.values(handlers)) {
-      expect(fn).not.toHaveBeenCalled();
+      expect.soft(fn).not.toHaveBeenCalled();
     }
   });
 


### PR DESCRIPTION
## Summary

Wave 4 (#334) として client テストに `expect.soft` を導入。1 テスト内で複数の独立観点を検証している箇所を soft 化し、最初の失敗で fail-fast せず全観点の失敗を 1 度の実行で集約できるようにする。

## 対象テスト

- `ArticleCard.test.tsx`: highlight 描画 / 平文タイトル
- `AuthorDetail.test.tsx`: heading / titles / count
- `Stats.test.tsx`: feed activity 行 (name + count)
- `useArticles.test.tsx`: fetch 成功・エラー時の複数状態 / `AUTO_LOAD_MAX` 境界値
- `useFilterHandlers.test.tsx`: `handleClear` / `handleApplyPreset` の複数 setter
- `useKeyboardShortcuts.test.tsx`: input フォーカス中の blocked keys / `enabled=false`

## 方針

- **独立した観点 → soft**。順序に意味のない state や DOM の独立した側面 (heading + titles + count, mark + plain text)
- **後続が前の assert に依存 → plain expect** (length チェックや null ガード)

## Test plan

- [x] `pnpm test:client` (該当テスト) pass
- [ ] CI green (lint / typecheck / e2e 含む)

Refs #334
