### PR TITLE
test(worker): adopt soft assertions in utils & middleware tests (Wave 4)

### DIFF
--- a/apps/web/tests/worker/middleware/access-jwt.test.ts
+++ b/apps/web/tests/worker/middleware/access-jwt.test.ts
@@ -18,8 +18,8 @@ describe("accessJwtMiddleware", () => {
   it("SKIP_ACCESS_JWT=1 のときは next() を呼ぶ", async () => {
     const fetch = makeApp({ SKIP_ACCESS_JWT: "1" });
     const res = await fetch(new Request("https://x.test/"));
-    expect(res.status).toBe(200);
-    expect(await res.text()).toBe("ok");
+    expect.soft(res.status).toBe(200);
+    expect.soft(await res.text()).toBe("ok");
   });
 
   it("SKIP_ACCESS_JWT=1 でも accessUser が context に set される (Variables 契約維持)", async () => {
@@ -32,17 +32,19 @@ describe("accessJwtMiddleware", () => {
     app.use("*", accessJwtMiddleware as any);
     app.get("/", (c) => c.json({ user: c.get("accessUser") }));
     const res = await app.fetch(new Request("https://x.test/"), { SKIP_ACCESS_JWT: "1" });
+    // ガードなので fail-fast: status 200 でなければ body.user を取得できない
     expect(res.status).toBe(200);
     const body = await res.json<{ user: { email: string | undefined; sub: string | undefined } }>();
-    expect(body.user).toEqual({ email: undefined, sub: undefined });
+    expect.soft(body.user).toEqual({ email: undefined, sub: undefined });
   });
 
   it("CF_ACCESS_AUD / TEAM_DOMAIN 未設定で 503", async () => {
     const fetch = makeApp({});
     const res = await fetch(new Request("https://x.test/"));
+    // ガードなので fail-fast: status 503 でなければ body.error を取得できない
     expect(res.status).toBe(503);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toBe("service unavailable");
+    expect.soft(body.error).toBe("service unavailable");
   });
 
   it("CF_ACCESS_AUD のみ設定で TEAM_DOMAIN 未設定のとき 503", async () => {
@@ -57,9 +59,10 @@ describe("accessJwtMiddleware", () => {
       CF_ACCESS_TEAM_DOMAIN: "test.cloudflareaccess.com",
     });
     const res = await fetch(new Request("https://x.test/"));
+    // ガードなので fail-fast: status 401 でなければ body.error を取得できない
     expect(res.status).toBe(401);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toBe("unauthorized");
+    expect.soft(body.error).toBe("unauthorized");
   });
 
   it("不正な JWT で 401", async () => {
@@ -82,8 +85,9 @@ describe("accessJwtMiddleware", () => {
         headers: { "cf-access-jwt-assertion": "invalid.jwt.token" },
       }),
     );
+    // ガードなので fail-fast: status 401 でなければ body.error を取得できない
     expect(res.status).toBe(401);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toBe("unauthorized");
+    expect.soft(body.error).toBe("unauthorized");
   });
 });

--- a/apps/web/tests/worker/utils/auth.test.ts
+++ b/apps/web/tests/worker/utils/auth.test.ts
@@ -27,8 +27,8 @@ describe("timingSafeEqual", () => {
   });
 
   it("長さが異なる場合は false を返す", () => {
-    expect(timingSafeEqual("abc", "abcd")).toBe(false);
-    expect(timingSafeEqual("abcd", "abc")).toBe(false);
+    expect.soft(timingSafeEqual("abc", "abcd")).toBe(false);
+    expect.soft(timingSafeEqual("abcd", "abc")).toBe(false);
   });
 
   it("空文字同士は true を返す", () => {
@@ -36,8 +36,8 @@ describe("timingSafeEqual", () => {
   });
 
   it("片方が空文字の場合は false を返す", () => {
-    expect(timingSafeEqual("abc", "")).toBe(false);
-    expect(timingSafeEqual("", "abc")).toBe(false);
+    expect.soft(timingSafeEqual("abc", "")).toBe(false);
+    expect.soft(timingSafeEqual("", "abc")).toBe(false);
   });
 });
 

--- a/apps/web/tests/worker/utils/types.test.ts
+++ b/apps/web/tests/worker/utils/types.test.ts
@@ -37,8 +37,8 @@ describe("makeOneOf", () => {
     });
 
     it("returns false for case-mismatched value", () => {
-      expect(isCategory("BigTech")).toBe(false);
-      expect(isCategory("AI")).toBe(false);
+      expect.soft(isCategory("BigTech")).toBe(false);
+      expect.soft(isCategory("AI")).toBe(false);
     });
   });
 

--- a/apps/web/tests/worker/utils/xml.test.ts
+++ b/apps/web/tests/worker/utils/xml.test.ts
@@ -142,8 +142,8 @@ describe("pickText", () => {
   });
 
   it("converts boolean to string", () => {
-    expect(pickText(true)).toBe("true");
-    expect(pickText(false)).toBe("false");
+    expect.soft(pickText(true)).toBe("true");
+    expect.soft(pickText(false)).toBe("false");
   });
 
   it("picks #text from object with #text property", () => {
@@ -216,8 +216,8 @@ describe("asArray", () => {
   });
 
   it("wraps number in an array", () => {
-    expect(asArray(0)).toEqual([0]);
-    expect(asArray(99)).toEqual([99]);
+    expect.soft(asArray(0)).toEqual([0]);
+    expect.soft(asArray(99)).toEqual([99]);
   });
 });
 


### PR DESCRIPTION
## Summary

Wave 4 (#388) として utils / middleware 系の worker テストに `expect.soft` を導入。

## 対象 / 変更点

| ファイル | soft before | soft after | 変更 it 数 |
|---|---|---|---|
| `auth.test.ts` | 0 | 4 | 2 it (長さ違い / 空文字片側) |
| `types.test.ts` | 0 | 2 | 1 it (大文字小文字違い) |
| `xml.test.ts` | 5 | 9 | 2 it (boolean変換ペア / 数値ラップペア) |
| `middleware/access-jwt.test.ts` | 0 | 4 | 4 it (body フィールドの独立観点) |

## 変更しない判断

- `auth.test.ts` の各 `isValidAdminToken` テストは 1 expect のみ → soft 化の利点なし
- `access-jwt.test.ts` の `res.status` は後続 `res.json()` のガード → plain `expect` のまま (コメントで意図を明記)
- `xml.test.ts` の既存 soft 箇所 (RSS item, Atom entry) は変更なし

## Test plan

- [x] `pnpm test` (該当ファイル) pass: 78 件 全 pass
- [ ] CI green

Refs #388
