### PR TITLE
test(worker): adopt soft assertions in collector tests (Wave 4)

### DIFF
--- a/apps/web/tests/worker/collector/d1Disabled.test.ts
+++ b/apps/web/tests/worker/collector/d1Disabled.test.ts
@@ -46,16 +46,16 @@ describe("getEnabledFeedIds + setFeedEnabled (D1 runtime toggle)", () => {
     await setFeedEnabled(env.DB, "feed-b", true);
 
     const ids = await getEnabledFeedIds(env.DB);
-    expect(ids.has("feed-b")).toBe(true);
+    expect.soft(ids.has("feed-b")).toBe(true);
   });
 
   it("setFeedEnabled returns found=false for unknown id", async () => {
     const result = await setFeedEnabled(env.DB, "no-such-feed", false);
-    expect(result.found).toBe(false);
+    expect.soft(result.found).toBe(false);
   });
 
   it("setFeedEnabled returns found=true for existing feed", async () => {
     const result = await setFeedEnabled(env.DB, "feed-a", false);
-    expect(result.found).toBe(true);
+    expect.soft(result.found).toBe(true);
   });
 });

--- a/apps/web/tests/worker/collector/feedWriter.test.ts
+++ b/apps/web/tests/worker/collector/feedWriter.test.ts
@@ -124,7 +124,7 @@ describe("handleNotModified", () => {
     const count = await env.DB.prepare("SELECT COUNT(*) AS n FROM collector_run_feeds").first<{
       n: number;
     }>();
-    expect(count?.n).toBe(0);
+    expect.soft(count?.n).toBe(0);
   });
 });
 
@@ -173,7 +173,7 @@ describe("handleSuccess", () => {
     const count = await env.DB.prepare("SELECT COUNT(*) AS n FROM articles WHERE feed_id = ?1")
       .bind(FEED.id)
       .first<{ n: number }>();
-    expect(count?.n).toBe(2);
+    expect.soft(count?.n).toBe(2);
   });
 
   it("saves etag and last_modified in feeds table", async () => {
@@ -339,7 +339,7 @@ describe("handleError", () => {
       .bind(run_id, FEED.id)
       .first<{ status: string }>();
 
-    expect(row?.status).toBe("failed");
+    expect.soft(row?.status).toBe("failed");
   });
 
   it("skips run feed recording when runId is null", async () => {
@@ -350,6 +350,6 @@ describe("handleError", () => {
     const count = await env.DB.prepare("SELECT COUNT(*) AS n FROM collector_run_feeds").first<{
       n: number;
     }>();
-    expect(count?.n).toBe(0);
+    expect.soft(count?.n).toBe(0);
   });
 });

--- a/apps/web/tests/worker/collector/metrics.test.ts
+++ b/apps/web/tests/worker/collector/metrics.test.ts
@@ -28,8 +28,8 @@ describe("writeCollectorEvent", () => {
 
     writeCollectorEvent(env, { feedId: "feed-a", status: "ok", ms: 123, statusCode: 200 });
 
-    expect(writeDataPoint).toHaveBeenCalledTimes(1);
-    expect(writeDataPoint).toHaveBeenCalledWith({
+    expect.soft(writeDataPoint).toHaveBeenCalledTimes(1);
+    expect.soft(writeDataPoint).toHaveBeenCalledWith({
       blobs: ["feed-a", "ok"],
       doubles: [123, 200],
       indexes: ["feed-a"],
@@ -42,8 +42,8 @@ describe("writeCollectorEvent", () => {
 
     writeCollectorEvent(env, { feedId: "feed-b", status: "error", ms: 456, statusCode: 503 });
 
-    expect(writeDataPoint).toHaveBeenCalledTimes(1);
-    expect(writeDataPoint).toHaveBeenCalledWith({
+    expect.soft(writeDataPoint).toHaveBeenCalledTimes(1);
+    expect.soft(writeDataPoint).toHaveBeenCalledWith({
       blobs: ["feed-b", "error"],
       doubles: [456, 503],
       indexes: ["feed-b"],
@@ -61,8 +61,8 @@ describe("writeCollectorEvent", () => {
       statusCode: 304,
     });
 
-    expect(writeDataPoint).toHaveBeenCalledTimes(1);
-    expect(writeDataPoint).toHaveBeenCalledWith({
+    expect.soft(writeDataPoint).toHaveBeenCalledTimes(1);
+    expect.soft(writeDataPoint).toHaveBeenCalledWith({
       blobs: ["feed-c", "not_modified"],
       doubles: [50, 304],
       indexes: ["feed-c"],
@@ -138,8 +138,8 @@ describe("writeD1CostEvent", () => {
       articlesInserted: 15,
     });
 
-    expect(writeDataPoint).toHaveBeenCalledTimes(1);
-    expect(writeDataPoint).toHaveBeenCalledWith({
+    expect.soft(writeDataPoint).toHaveBeenCalledTimes(1);
+    expect.soft(writeDataPoint).toHaveBeenCalledWith({
       blobs: ["collect_run_d1"],
       doubles: [100, 20, 500, 15],
       indexes: ["d1_cost"],

--- a/apps/web/tests/worker/collector/retention.test.ts
+++ b/apps/web/tests/worker/collector/retention.test.ts
@@ -55,12 +55,12 @@ describe("collectFeeds: retention は実行しない", () => {
     const result = await collectFeeds(env, ["ret-feed"]);
 
     // collectFeeds は retention を実行しないため pruned は 0
-    expect(result.pruned).toBe(0);
+    expect.soft(result.pruned).toBe(0);
 
     // 古い記事はまだ残っている (retention は scheduled() で実行されるため)
     const row = await env.DB.prepare(
       "SELECT COUNT(*) AS n FROM articles WHERE guid = 'ret-old'",
     ).first<{ n: number }>();
-    expect(row?.n).toBe(1);
+    expect.soft(row?.n).toBe(1);
   });
 });

--- a/apps/web/tests/worker/collector/retry.test.ts
+++ b/apps/web/tests/worker/collector/retry.test.ts
@@ -129,8 +129,8 @@ describe("fetchFeed retry behavior", () => {
     await vi.runAllTimersAsync();
     const result = await promise;
 
-    expect(result.xml).toBe(VALID_XML);
-    expect(spy).toHaveBeenCalledTimes(2);
+    expect.soft(result.xml).toBe(VALID_XML);
+    expect.soft(spy).toHaveBeenCalledTimes(2);
   });
 
   it("retries on AbortError and succeeds on 2nd attempt", async () => {
@@ -144,8 +144,8 @@ describe("fetchFeed retry behavior", () => {
     await vi.runAllTimersAsync();
     const result = await promise;
 
-    expect(result.xml).toBe(VALID_XML);
-    expect(spy).toHaveBeenCalledTimes(2);
+    expect.soft(result.xml).toBe(VALID_XML);
+    expect.soft(spy).toHaveBeenCalledTimes(2);
   });
 
   it("exhausts all retries on consecutive 503 and throws final error", async () => {
@@ -159,7 +159,7 @@ describe("fetchFeed retry behavior", () => {
     await rejectPromise;
 
     // 初回 + 2 回リトライ = 計 3 回
-    expect(spy).toHaveBeenCalledTimes(3);
+    expect.soft(spy).toHaveBeenCalledTimes(3);
   });
 
   it("does not retry on 404 (permanent error)", async () => {
@@ -169,7 +169,7 @@ describe("fetchFeed retry behavior", () => {
 
     await expect(fetchFeed(DUMMY_URL, 10000, 2)).rejects.toThrow("HTTP 404");
     // 4xx はリトライしないので 1 回のみ
-    expect(spy).toHaveBeenCalledTimes(1);
+    expect.soft(spy).toHaveBeenCalledTimes(1);
   });
 
   it("does not retry on 400 (permanent error)", async () => {
@@ -178,7 +178,7 @@ describe("fetchFeed retry behavior", () => {
       .mockResolvedValue(new Response("Bad Request", { status: 400, statusText: "Bad Request" }));
 
     await expect(fetchFeed(DUMMY_URL, 10000, 2)).rejects.toThrow("HTTP 400");
-    expect(spy).toHaveBeenCalledTimes(1);
+    expect.soft(spy).toHaveBeenCalledTimes(1);
   });
 
   it("retries on TypeError (network failure)", async () => {
@@ -191,8 +191,8 @@ describe("fetchFeed retry behavior", () => {
     await vi.runAllTimersAsync();
     const result = await promise;
 
-    expect(result.xml).toBe(VALID_XML);
-    expect(spy).toHaveBeenCalledTimes(2);
+    expect.soft(result.xml).toBe(VALID_XML);
+    expect.soft(spy).toHaveBeenCalledTimes(2);
   });
 
   it("respects maxRetries=0 and does not retry", async () => {
@@ -201,6 +201,6 @@ describe("fetchFeed retry behavior", () => {
       .mockResolvedValue(new Response("Service Unavailable", { status: 503 }));
 
     await expect(fetchFeed(DUMMY_URL, 10000, 0)).rejects.toThrow("HTTP 503");
-    expect(spy).toHaveBeenCalledTimes(1);
+    expect.soft(spy).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/tests/worker/feed-config.test.ts
+++ b/apps/web/tests/worker/feed-config.test.ts
@@ -15,15 +15,15 @@ describe("loadAllFeeds", () => {
   it("each feed has required fields: id, name, url, category, lang, enabled", () => {
     const feeds = loadAllFeeds();
     for (const feed of feeds) {
-      expect(typeof feed.id).toBe("string");
-      expect(feed.id.length).toBeGreaterThan(0);
-      expect(typeof feed.name).toBe("string");
-      expect(feed.name.length).toBeGreaterThan(0);
-      expect(typeof feed.url).toBe("string");
-      expect(feed.url).toMatch(/^https?:\/\//);
-      expect(["bigtech", "ai", "jp", "personal"]).toContain(feed.category);
-      expect(["ja", "en"]).toContain(feed.lang);
-      expect(typeof feed.enabled).toBe("boolean");
+      expect.soft(typeof feed.id).toBe("string");
+      expect.soft(feed.id.length).toBeGreaterThan(0);
+      expect.soft(typeof feed.name).toBe("string");
+      expect.soft(feed.name.length).toBeGreaterThan(0);
+      expect.soft(typeof feed.url).toBe("string");
+      expect.soft(feed.url).toMatch(/^https?:\/\//);
+      expect.soft(["bigtech", "ai", "jp", "personal"]).toContain(feed.category);
+      expect.soft(["ja", "en"]).toContain(feed.lang);
+      expect.soft(typeof feed.enabled).toBe("boolean");
     }
   });
 
@@ -46,9 +46,9 @@ describe("loadAllFeeds", () => {
   it("includes well-known feeds (google-developers, openai-blog, zenn-mizchi)", () => {
     const feeds = loadAllFeeds();
     const ids = feeds.map((f) => f.id);
-    expect(ids).toContain("google-developers");
-    expect(ids).toContain("openai-blog");
-    expect(ids).toContain("zenn-mizchi");
+    expect.soft(ids).toContain("google-developers");
+    expect.soft(ids).toContain("openai-blog");
+    expect.soft(ids).toContain("zenn-mizchi");
   });
 });
 
@@ -96,16 +96,16 @@ describe("loadEnabledFeeds", () => {
   it("covers all 4 categories (bigtech, ai, jp, personal)", () => {
     const feeds = loadEnabledFeeds();
     const categories = new Set(feeds.map((f) => f.category));
-    expect(categories.has("bigtech")).toBe(true);
-    expect(categories.has("ai")).toBe(true);
-    expect(categories.has("jp")).toBe(true);
-    expect(categories.has("personal")).toBe(true);
+    expect.soft(categories.has("bigtech")).toBe(true);
+    expect.soft(categories.has("ai")).toBe(true);
+    expect.soft(categories.has("jp")).toBe(true);
+    expect.soft(categories.has("personal")).toBe(true);
   });
 
   it("covers both langs (ja and en)", () => {
     const feeds = loadEnabledFeeds();
     const langs = new Set(feeds.map((f) => f.lang));
-    expect(langs.has("ja")).toBe(true);
-    expect(langs.has("en")).toBe(true);
+    expect.soft(langs.has("ja")).toBe(true);
+    expect.soft(langs.has("en")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Wave 4 (#388) として collector / feed-config 系のテストに `expect.soft` を導入。

## 対象 / 変更点

| ファイル | 変更 (plain → soft) | 備考 |
|---|---|---|
| `collector/retention.test.ts` | 2 → 2 | pruned / DB row count の各観点 |
| `collector/d1Disabled.test.ts` | 3 → 3 | re-enable / found=false / found=true |
| `collector/feedWriter.test.ts` | 5 → 5 | DB count / run_feed status 各観点 |
| `collector/metrics.test.ts` | 8 → 8 | writeDataPoint args 各観点 |
| `collector/retry.test.ts` | 11 → 11 | xml / notModified / spy.calledTimes 各観点 |
| `feed-config.test.ts` | 17 → 17 | required fields / well-known ids / categories / langs 各観点 |

## 変更しない判断

- `alert.test.ts` / `conditionalGet.test.ts` / `rssParser.test.ts` / `url-safety.test.ts`: すでに適切に soft 化済み
- `deduplicator.test.ts`: 各 `it` が単一 assert のため soft 化不要
- `feedWriter.test.ts` の `expect(result.status).toBe("error")`: discriminated union narrowing のガード。次行で `result.errorKind` を読むため fail-fast が必要

## Test plan

- [x] `pnpm test` 該当ファイル pass: 12 files / 171 tests
- [ ] CI green

Refs #388
