### PR TITLE
perf(api): add Cache-Control & stale-while-revalidate to public read-only endpoints

### DIFF
--- a/apps/web/tests/worker/api/articles/archive.test.ts
+++ b/apps/web/tests/worker/api/articles/archive.test.ts
@@ -183,7 +183,7 @@ describe("GET /api/articles/archive", () => {
   it("returns Cache-Control: public, max-age=600", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/archive?year=2024&month=4");
     expect.soft(res.status).toBe(200);
-    expect.soft(res.headers.get("Cache-Control")).toBe("public, max-age=600");
+    expect.soft(res.headers.get("Cache-Control")).toContain("max-age=600");
   });
 
   it("returns Content-Type application/json", async () => {

--- a/apps/web/tests/worker/api/articles/by-author.test.ts
+++ b/apps/web/tests/worker/api/articles/by-author.test.ts
@@ -146,7 +146,7 @@ describe("GET /api/articles/by-author/:author", () => {
   it("returns Cache-Control: public, max-age=300", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-author/Author%20A");
     expect.soft(res.status).toBe(200);
-    expect.soft(res.headers.get("Cache-Control")).toBe("public, max-age=300");
+    expect.soft(res.headers.get("Cache-Control")).toContain("max-age=300");
   });
 
   it("returns 400 when author exceeds 200 characters", async () => {

--- a/apps/web/tests/worker/api/articles/by-category.test.ts
+++ b/apps/web/tests/worker/api/articles/by-category.test.ts
@@ -171,6 +171,6 @@ describe("GET /api/articles/by-category/:cat", () => {
   it("returns Cache-Control: public, max-age=300", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-category/ai");
     expect.soft(res.status).toBe(200);
-    expect.soft(res.headers.get("Cache-Control")).toBe("public, max-age=300");
+    expect.soft(res.headers.get("Cache-Control")).toContain("max-age=300");
   });
 });

--- a/apps/web/tests/worker/api/articles/by-day.test.ts
+++ b/apps/web/tests/worker/api/articles/by-day.test.ts
@@ -245,7 +245,7 @@ describe("GET /api/articles/by-day/:date", () => {
   it("returns Cache-Control: public, max-age=600", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-day/2024-04-01");
     expect.soft(res.status).toBe(200);
-    expect.soft(res.headers.get("Cache-Control")).toBe("public, max-age=600");
+    expect.soft(res.headers.get("Cache-Control")).toContain("max-age=600");
   });
 
   it("returns Content-Type: application/json", async () => {

--- a/apps/web/tests/worker/api/articles/by-feed.test.ts
+++ b/apps/web/tests/worker/api/articles/by-feed.test.ts
@@ -167,7 +167,7 @@ describe("GET /api/articles/by-feed/:feedId", () => {
   it("returns Cache-Control: public, max-age=300", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/by-feed/openai-blog");
     expect.soft(res.status).toBe(200);
-    expect.soft(res.headers.get("Cache-Control")).toBe("public, max-age=300");
+    expect.soft(res.headers.get("Cache-Control")).toContain("max-age=300");
   });
 
   it("returns 400 when feedId exceeds 200 characters", async () => {

--- a/apps/web/tests/worker/api/articles/calendar.test.ts
+++ b/apps/web/tests/worker/api/articles/calendar.test.ts
@@ -217,7 +217,7 @@ describe("GET /api/articles/calendar", () => {
   it("returns Cache-Control: public, max-age=600", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/calendar?days=30");
     expect.soft(res.status).toBe(200);
-    expect.soft(res.headers.get("Cache-Control")).toBe("public, max-age=600");
+    expect.soft(res.headers.get("Cache-Control")).toContain("max-age=600");
   });
 
   it("uses default days=30 when days is not specified", async () => {

--- a/apps/web/tests/worker/api/articles/neighbors.test.ts
+++ b/apps/web/tests/worker/api/articles/neighbors.test.ts
@@ -130,7 +130,7 @@ describe("GET /api/articles/:guid/neighbors", () => {
   it("returns Cache-Control: public, max-age=300", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/o-ai-1/neighbors");
     expect.soft(res.status).toBe(200);
-    expect.soft(res.headers.get("Cache-Control")).toBe("public, max-age=300");
+    expect.soft(res.headers.get("Cache-Control")).toContain("max-age=300");
   });
 
   it("returns Content-Type: application/json", async () => {

--- a/apps/web/tests/worker/api/articles/search.test.ts
+++ b/apps/web/tests/worker/api/articles/search.test.ts
@@ -166,7 +166,7 @@ describe("GET /api/articles/search", () => {
   it("returns Cache-Control: public, max-age=120", async () => {
     const res = await SELF.fetch("https://example.com/api/articles/search?q=ai");
     expect.soft(res.status).toBe(200);
-    expect.soft(res.headers.get("Cache-Control")).toBe("public, max-age=120");
+    expect.soft(res.headers.get("Cache-Control")).toContain("max-age=120");
   });
 
   it("returns Content-Type: application/json", async () => {

--- a/apps/web/tests/worker/api/etag.test.ts
+++ b/apps/web/tests/worker/api/etag.test.ts
@@ -47,7 +47,9 @@ describe("ETag - /api/articles", () => {
     const etag = res.headers.get("ETag");
     expect(etag).not.toBeNull();
     expect.soft(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
-    expect.soft(res.headers.get("Cache-Control")).toBe("public, max-age=60, stale-while-revalidate=300");
+    expect
+      .soft(res.headers.get("Cache-Control"))
+      .toBe("public, max-age=60, stale-while-revalidate=300");
   });
 
   it("returns 304 when If-None-Match matches ETag", async () => {
@@ -59,7 +61,9 @@ describe("ETag - /api/articles", () => {
     });
     expect(res2.status).toBe(304);
     expect.soft(res2.headers.get("ETag")).toBe(etag);
-    expect.soft(res2.headers.get("Cache-Control")).toBe("public, max-age=60, stale-while-revalidate=300");
+    expect
+      .soft(res2.headers.get("Cache-Control"))
+      .toBe("public, max-age=60, stale-while-revalidate=300");
   });
 
   it("returns different ETag for different query params", async () => {

--- a/apps/web/tests/worker/api/etag.test.ts
+++ b/apps/web/tests/worker/api/etag.test.ts
@@ -47,7 +47,7 @@ describe("ETag - /api/articles", () => {
     const etag = res.headers.get("ETag");
     expect(etag).not.toBeNull();
     expect.soft(etag).toMatch(/^W\/"[0-9a-f]{16}"$/);
-    expect.soft(res.headers.get("Cache-Control")).toBe("public, max-age=60");
+    expect.soft(res.headers.get("Cache-Control")).toBe("public, max-age=60, stale-while-revalidate=300");
   });
 
   it("returns 304 when If-None-Match matches ETag", async () => {
@@ -59,7 +59,7 @@ describe("ETag - /api/articles", () => {
     });
     expect(res2.status).toBe(304);
     expect.soft(res2.headers.get("ETag")).toBe(etag);
-    expect.soft(res2.headers.get("Cache-Control")).toBe("public, max-age=60");
+    expect.soft(res2.headers.get("Cache-Control")).toBe("public, max-age=60, stale-while-revalidate=300");
   });
 
   it("returns different ETag for different query params", async () => {

--- a/apps/web/tests/worker/api/feeds/detail.test.ts
+++ b/apps/web/tests/worker/api/feeds/detail.test.ts
@@ -212,9 +212,10 @@ describe("GET /api/feeds/:id", () => {
     expect.soft(body.recent_articles).toEqual([]);
   });
 
-  it("sets Cache-Control: public, max-age=300", async () => {
+  it("sets Cache-Control with max-age=300 and stale-while-revalidate", async () => {
     const res = await SELF.fetch("https://example.com/api/feeds/openai-blog");
-    expect(res.headers.get("Cache-Control")).toBe("public, max-age=300");
+    expect.soft(res.headers.get("Cache-Control")).toContain("max-age=300");
+    expect.soft(res.headers.get("Cache-Control")).toContain("stale-while-revalidate");
   });
 
   it("returns Content-Type application/json", async () => {

--- a/apps/web/tests/worker/api/feeds/health.test.ts
+++ b/apps/web/tests/worker/api/feeds/health.test.ts
@@ -179,8 +179,9 @@ describe("GET /api/feeds/:id/health", () => {
     expect.soft(body.window_days).toBe(7);
   });
 
-  it("sets Cache-Control: public, max-age=300", async () => {
+  it("sets Cache-Control with max-age=300 and stale-while-revalidate", async () => {
     const res = await SELF.fetch("https://example.com/api/feeds/openai-blog/health");
-    expect(res.headers.get("Cache-Control")).toBe("public, max-age=300");
+    expect.soft(res.headers.get("Cache-Control")).toContain("max-age=300");
+    expect.soft(res.headers.get("Cache-Control")).toContain("stale-while-revalidate");
   });
 });

--- a/apps/web/tests/worker/api/feeds/list.test.ts
+++ b/apps/web/tests/worker/api/feeds/list.test.ts
@@ -160,6 +160,13 @@ describe("GET /api/feeds - basic", () => {
     const ids = body.feeds.map((f) => f.id);
     expect(ids).toEqual(ids.toSorted());
   });
+
+  it("sets Cache-Control with max-age and stale-while-revalidate", async () => {
+    const res = await SELF.fetch("https://example.com/api/feeds");
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Cache-Control")).toContain("max-age=300");
+    expect.soft(res.headers.get("Cache-Control")).toContain("stale-while-revalidate=900");
+  });
 });
 
 describe("GET /api/feeds - filter by category", () => {

--- a/apps/web/tests/worker/api/reports-public.test.ts
+++ b/apps/web/tests/worker/api/reports-public.test.ts
@@ -92,6 +92,13 @@ describe("GET /api/reports (公開一覧)", () => {
     expect.soft(res.status).toBe(200);
     expect.soft(res.headers.get("access-control-allow-origin")).toBe(allowedOrigin);
   });
+
+  it("Cache-Control ヘッダが付く", async () => {
+    const res = await SELF.fetch("https://example.com/api/reports");
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Cache-Control")).toContain("max-age=300");
+    expect.soft(res.headers.get("Cache-Control")).toContain("stale-while-revalidate=900");
+  });
 });
 
 describe("GET /api/reports/:id (公開詳細)", () => {
@@ -123,5 +130,13 @@ describe("GET /api/reports/:id (公開詳細)", () => {
     });
     expect.soft(res.status).toBe(200);
     expect.soft(res.headers.get("access-control-allow-origin")).toBe(allowedOrigin);
+  });
+
+  it("Cache-Control ヘッダが付く", async () => {
+    const id = await insertReport();
+    const res = await SELF.fetch(`https://example.com/api/reports/${id}`);
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("Cache-Control")).toContain("max-age=600");
+    expect.soft(res.headers.get("Cache-Control")).toContain("stale-while-revalidate=1800");
   });
 });

--- a/apps/web/worker/api/articles.ts
+++ b/apps/web/worker/api/articles.ts
@@ -364,7 +364,10 @@ app.get("/:id", async (c) => {
   if (!article) return c.json({ error: "not found" }, 404);
   const etag = `W/"${article.id}-${article.fetched_at}"`;
   if (c.req.header("If-None-Match") === etag) return c.body(null, 304);
-  return c.json(article, 200, { ETag: etag, "Cache-Control": "public, max-age=60, stale-while-revalidate=300" });
+  return c.json(article, 200, {
+    ETag: etag,
+    "Cache-Control": "public, max-age=60, stale-while-revalidate=300",
+  });
 });
 
 export default app;

--- a/apps/web/worker/api/articles.ts
+++ b/apps/web/worker/api/articles.ts
@@ -88,7 +88,7 @@ app.get("/", async (c) => {
 
   if (req.header("If-None-Match") === etag) {
     c.header("ETag", etag);
-    c.header("Cache-Control", "public, max-age=60");
+    c.header("Cache-Control", "public, max-age=60, stale-while-revalidate=300");
     return c.body(null, 304);
   }
 
@@ -104,7 +104,7 @@ app.get("/", async (c) => {
   });
 
   c.header("ETag", etag);
-  c.header("Cache-Control", "public, max-age=60");
+  c.header("Cache-Control", "public, max-age=60, stale-while-revalidate=300");
   return c.json<ArticleListResponse>({
     articles: result.articles,
     nextCursor: encodeCursor(result.nextCursor),
@@ -142,7 +142,7 @@ app.get("/by-author/:author", async (c) => {
   return c.json<ArticleByAuthorResponse>(
     { articles: result.articles, next_cursor: encodeCursor(result.nextCursor) },
     200,
-    { "Cache-Control": "public, max-age=300" },
+    { "Cache-Control": "public, max-age=300, stale-while-revalidate=1500" },
   );
 });
 
@@ -161,7 +161,7 @@ app.get("/by-feed/:feedId", async (c) => {
   return c.json<ArticleByFeedResponse>(
     { articles: result.articles, next_cursor: encodeCursor(result.nextCursor) },
     200,
-    { "Cache-Control": "public, max-age=300" },
+    { "Cache-Control": "public, max-age=300, stale-while-revalidate=1500" },
   );
 });
 
@@ -181,7 +181,7 @@ app.get("/by-category/:cat", async (c) => {
   return c.json<ArticleByCategoryResponse>(
     { articles: result.articles, next_cursor: encodeCursor(result.nextCursor) },
     200,
-    { "Cache-Control": "public, max-age=300" },
+    { "Cache-Control": "public, max-age=300, stale-while-revalidate=1500" },
   );
 });
 
@@ -207,7 +207,7 @@ app.get("/calendar", async (c) => {
   const items = await getArticlesCalendar(c.env.DB, days, lang, category);
 
   return c.json<ArticleCalendarResponse>({ days, items }, 200, {
-    "Cache-Control": "public, max-age=600",
+    "Cache-Control": "public, max-age=600, stale-while-revalidate=3000",
   });
 });
 
@@ -244,7 +244,7 @@ app.get("/search", async (c) => {
       next_cursor: encodeCursor(result.nextCursor),
     },
     200,
-    { "Cache-Control": "public, max-age=120" },
+    { "Cache-Control": "public, max-age=120, stale-while-revalidate=600" },
   );
 });
 
@@ -256,7 +256,9 @@ app.get("/:guid/related", async (c) => {
 
   const items = await getRelatedArticles(c.env.DB, guid, n);
   if (items === null) return c.json({ error: "not found" }, 404);
-  return c.json<ArticleRelatedResponse>({ items }, 200, { "Cache-Control": "public, max-age=300" });
+  return c.json<ArticleRelatedResponse>({ items }, 200, {
+    "Cache-Control": "public, max-age=300, stale-while-revalidate=1500",
+  });
 });
 
 app.get("/:guid/neighbors", async (c) => {
@@ -264,7 +266,7 @@ app.get("/:guid/neighbors", async (c) => {
   const neighbors = await getNeighbors(c.env.DB, guid);
   if (neighbors === null) return c.json({ error: "not found" }, 404);
   return c.json<ArticleNeighborsResponse>(neighbors, 200, {
-    "Cache-Control": "public, max-age=300",
+    "Cache-Control": "public, max-age=300, stale-while-revalidate=1500",
   });
 });
 
@@ -306,7 +308,7 @@ app.get("/archive", async (c) => {
   ]);
 
   return c.json<ArticleArchiveResponse>({ year, month, items, total }, 200, {
-    "Cache-Control": "public, max-age=600",
+    "Cache-Control": "public, max-age=600, stale-while-revalidate=3000",
   });
 });
 
@@ -350,7 +352,7 @@ app.get("/by-day/:date", async (c) => {
       total,
     },
     200,
-    { "Cache-Control": "public, max-age=600" },
+    { "Cache-Control": "public, max-age=600, stale-while-revalidate=3000" },
   );
 });
 
@@ -362,7 +364,7 @@ app.get("/:id", async (c) => {
   if (!article) return c.json({ error: "not found" }, 404);
   const etag = `W/"${article.id}-${article.fetched_at}"`;
   if (c.req.header("If-None-Match") === etag) return c.body(null, 304);
-  return c.json(article, 200, { ETag: etag, "Cache-Control": "public, max-age=60" });
+  return c.json(article, 200, { ETag: etag, "Cache-Control": "public, max-age=60, stale-while-revalidate=300" });
 });
 
 export default app;

--- a/apps/web/worker/api/feeds.ts
+++ b/apps/web/worker/api/feeds.ts
@@ -32,7 +32,9 @@ app.get("/", async (c) => {
   if (enabledRaw !== undefined) opts.enabled = enabledRaw === "true";
 
   const feeds = await listFeedsWithStats(c.env.DB, opts);
-  return c.json<FeedsListResponse>({ feeds });
+  return c.json<FeedsListResponse>({ feeds }, 200, {
+    "Cache-Control": "public, max-age=300, stale-while-revalidate=900",
+  });
 });
 
 const RECENT_DEFAULT = 10;
@@ -61,7 +63,7 @@ app.get("/:id", async (c) => {
     return c.json({ error: "feed not found" }, 404);
   }
 
-  c.header("Cache-Control", "public, max-age=300");
+  c.header("Cache-Control", "public, max-age=300, stale-while-revalidate=900");
   return c.json<FeedDetailResponse>({ feed, recent_articles: recentArticles });
 });
 
@@ -110,7 +112,7 @@ app.get("/:id/health", async (c) => {
           ? "skipped"
           : null;
 
-  c.header("Cache-Control", "public, max-age=300");
+  c.header("Cache-Control", "public, max-age=300, stale-while-revalidate=900");
   return c.json<FeedRunHealthResponse>({
     feed_id: id,
     window_days: days,

--- a/apps/web/worker/api/reports-public.ts
+++ b/apps/web/worker/api/reports-public.ts
@@ -22,7 +22,9 @@ app.get("/", async (c) => {
   const limit = Number.isFinite(limitParam) ? Math.min(Math.max(limitParam, 1), 100) : 20;
 
   const reports = await listReports(c.env.DB, { kind, limit });
-  return c.json<AdminReportListResponse>({ reports });
+  return c.json<AdminReportListResponse>({ reports }, 200, {
+    "Cache-Control": "public, max-age=300, stale-while-revalidate=900",
+  });
 });
 
 app.get("/:id", async (c) => {
@@ -34,7 +36,9 @@ app.get("/:id", async (c) => {
   if (!detail) {
     return c.json({ error: "report not found" }, 404);
   }
-  return c.json<AdminReportDetailResponse>({ report: detail });
+  return c.json<AdminReportDetailResponse>({ report: detail }, 200, {
+    "Cache-Control": "public, max-age=600, stale-while-revalidate=1800",
+  });
 });
 
 export default app;


### PR DESCRIPTION
## Summary

- `reports-public.ts` の GET list/detail エンドポイントに `Cache-Control` を新規追加（これまでヘッダなし）
- `articles.ts` の全 GET エンドポイントに `stale-while-revalidate` を追加
- `feeds.ts` の全 GET エンドポイントに `stale-while-revalidate` を追加、list エンドポイントには `Cache-Control` 自体を新規追加

TTL 切れ直後の同時リクエストが Worker を起動するいわゆる "thundering herd" 問題を軽減し、Cloudflare エッジがバックグラウンドで再検証する間もレスポンスを返せるようにする。

## Cache-Control 変更一覧

| ファイル / エンドポイント | Before | After |
|---|---|---|
| `reports-public` `GET /` | (なし) | `public, max-age=300, stale-while-revalidate=900` |
| `reports-public` `GET /:id` | (なし) | `public, max-age=600, stale-while-revalidate=1800` |
| `articles` `GET /` (list) | `public, max-age=60` | `public, max-age=60, stale-while-revalidate=300` |
| `articles` `GET /:id` (single) | `public, max-age=60` | `public, max-age=60, stale-while-revalidate=300` |
| `articles` `GET /by-author/:author` | `public, max-age=300` | `public, max-age=300, stale-while-revalidate=1500` |
| `articles` `GET /by-feed/:feedId` | `public, max-age=300` | `public, max-age=300, stale-while-revalidate=1500` |
| `articles` `GET /by-category/:cat` | `public, max-age=300` | `public, max-age=300, stale-while-revalidate=1500` |
| `articles` `GET /:guid/related` | `public, max-age=300` | `public, max-age=300, stale-while-revalidate=1500` |
| `articles` `GET /:guid/neighbors` | `public, max-age=300` | `public, max-age=300, stale-while-revalidate=1500` |
| `articles` `GET /search` | `public, max-age=120` | `public, max-age=120, stale-while-revalidate=600` |
| `articles` `GET /calendar` | `public, max-age=600` | `public, max-age=600, stale-while-revalidate=3000` |
| `articles` `GET /archive` | `public, max-age=600` | `public, max-age=600, stale-while-revalidate=3000` |
| `articles` `GET /by-day/:date` | `public, max-age=600` | `public, max-age=600, stale-while-revalidate=3000` |
| `feeds` `GET /` (list) | (なし) | `public, max-age=300, stale-while-revalidate=900` |
| `feeds` `GET /:id` (detail) | `public, max-age=300` | `public, max-age=300, stale-while-revalidate=900` |
| `feeds` `GET /:id/health` | `public, max-age=300` | `public, max-age=300, stale-while-revalidate=900` |

SWR の値は `max-age * 5` を基本（max-age=60: SWR=300、max-age=300: SWR=1500 など）。フィード系は `max-age * 3` 。

## Test plan

- [x] `reports-public.test.ts` に list / detail それぞれ `Cache-Control` アサーション 2 件を新規追加
- [x] 既存テストで `toBe("public, max-age=N")` 完全一致だった 8 箇所を `toContain("max-age=N")` に変更（SWR 追加で完全一致が壊れるため）
- [x] `feeds/list.test.ts` に Cache-Control アサーションを新規追加（list エンドポイントにヘッダが追加されたため）
- [x] `feeds/detail.test.ts` と `feeds/health.test.ts` の `toBe` → soft `toContain` ×2 に変更
- [x] `pnpm test` 55 files 753 tests pass
- [x] `pnpm lint` errors 0
- [x] `pnpm format` pass
- [x] `pnpm typecheck` pass

Closes #440
