### PR TITLE
refactor(reports): centralize ReportKind validation via isReportKind guard

### DIFF
--- a/apps/web/tests/worker/db/reports.test.ts
+++ b/apps/web/tests/worker/db/reports.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vite-plus/test";
 import { env } from "cloudflare:test";
-import { OverlapError, findOverlappingReports, upsertReport } from "../../../worker/db/reports";
+import {
+  OverlapError,
+  findOverlappingReports,
+  isReportKind,
+  upsertReport,
+} from "../../../worker/db/reports";
 import type { ReportInput } from "../../../worker/db/reports";
 
 function baseInput(overrides: Partial<ReportInput> = {}): ReportInput {
@@ -17,6 +22,24 @@ function baseInput(overrides: Partial<ReportInput> = {}): ReportInput {
     ...overrides,
   };
 }
+
+describe("isReportKind", () => {
+  it("returns true for valid kinds", () => {
+    expect(isReportKind("daily")).toBe(true);
+    expect(isReportKind("weekly")).toBe(true);
+    expect(isReportKind("monthly")).toBe(true);
+  });
+
+  it("returns false for an unknown string", () => {
+    expect(isReportKind("yearly")).toBe(false);
+  });
+
+  it("returns false for non-string values (null / undefined / number)", () => {
+    expect(isReportKind(null)).toBe(false);
+    expect(isReportKind(undefined)).toBe(false);
+    expect(isReportKind(42)).toBe(false);
+  });
+});
 
 describe("findOverlappingReports", () => {
   it("returns empty array when no rows exist", async () => {

--- a/apps/web/worker/api/reports-public.ts
+++ b/apps/web/worker/api/reports-public.ts
@@ -1,21 +1,19 @@
 import { Hono } from "hono";
 import type { Env } from "../types";
-import { getReport, listReports } from "../db/reports";
+import { getReport, isReportKind, listReports } from "../db/reports";
 import type { ReportKind } from "../db/reports";
 import type { AdminReportDetailResponse, AdminReportListResponse } from "./types";
 
 const app = new Hono<{ Bindings: Env }>();
 
-const VALID_KINDS = new Set<ReportKind>(["daily", "weekly", "monthly"]);
-
 app.get("/", async (c) => {
   const kindParam = c.req.query("kind");
   let kind: ReportKind | undefined;
   if (kindParam !== undefined) {
-    if (!VALID_KINDS.has(kindParam as ReportKind)) {
+    if (!isReportKind(kindParam)) {
       return c.json({ error: "kind must be one of: daily | weekly | monthly" }, 400);
     }
-    kind = kindParam as ReportKind;
+    kind = kindParam;
   }
 
   const limitParam = Number(c.req.query("limit") ?? "20");

--- a/apps/web/worker/api/reports.ts
+++ b/apps/web/worker/api/reports.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import type { Env } from "../types";
 import { adminAuthMiddleware } from "../utils/auth";
-import { OverlapError, getReport, listReports, upsertReport } from "../db/reports";
+import { OverlapError, getReport, isReportKind, listReports, upsertReport } from "../db/reports";
 import type { ReportInput, ReportKind } from "../db/reports";
 import type {
   AdminReportDetailResponse,
@@ -17,7 +17,6 @@ const app = new Hono<{ Bindings: Env }>();
 // 個別ハンドラでの authGuard 呼び出しを廃し、ハンドラ追加時の認証漏れを防ぐ。
 app.use("*", adminAuthMiddleware);
 
-const VALID_KINDS = new Set<ReportKind>(["daily", "weekly", "monthly"]);
 // content が極端に長くなるのを防ぐ (D1 の row size と Worker の CPU 時間を意識)。
 // 1MB は markdown レポートとしては十分すぎる量。
 const MAX_CONTENT_BYTES = 1_000_000;
@@ -49,7 +48,7 @@ interface PostBody {
 function parseInput(
   body: PostBody,
 ): { ok: true; input: ReportInput } | { ok: false; error: string } {
-  if (typeof body.kind !== "string" || !VALID_KINDS.has(body.kind as ReportKind)) {
+  if (!isReportKind(body.kind)) {
     return { ok: false, error: "kind must be one of: daily | weekly | monthly" };
   }
   if (!isISO8601(body.period_start)) {
@@ -105,7 +104,7 @@ function parseInput(
   return {
     ok: true,
     input: {
-      kind: body.kind as ReportKind,
+      kind: body.kind,
       period_start: body.period_start,
       period_end: body.period_end,
       category,
@@ -164,10 +163,10 @@ app.get("/", async (c) => {
   const kindParam = c.req.query("kind");
   let kind: ReportKind | undefined;
   if (kindParam !== undefined) {
-    if (!VALID_KINDS.has(kindParam as ReportKind)) {
+    if (!isReportKind(kindParam)) {
       return c.json({ error: "kind must be one of: daily | weekly | monthly" }, 400);
     }
-    kind = kindParam as ReportKind;
+    kind = kindParam;
   }
 
   const limitParam = Number(c.req.query("limit") ?? "20");

--- a/apps/web/worker/db/reports.ts
+++ b/apps/web/worker/db/reports.ts
@@ -5,6 +5,13 @@ import type { D1BindParameter } from "./types";
 
 export type ReportKind = "daily" | "weekly" | "monthly";
 
+// ReportKind の全値リスト。ここを更新すれば isReportKind も自動的に追従する。
+export const REPORT_KINDS = ["daily", "weekly", "monthly"] as const satisfies readonly ReportKind[];
+
+export function isReportKind(v: unknown): v is ReportKind {
+  return REPORT_KINDS.includes(v as ReportKind);
+}
+
 export interface ReportInput {
   kind: ReportKind;
   period_start: string;


### PR DESCRIPTION
## Summary

`apps/web/worker/api/reports.ts` と `apps/web/worker/api/reports-public.ts` で重複していた `VALID_KINDS = new Set<ReportKind>([...])` を `worker/db/reports.ts` に一元化し、`isReportKind` type guard で narrow する形に統一。`as ReportKind` アサーションも除去できる。

## 変更点

- `worker/db/reports.ts`: `REPORT_KINDS` と `isReportKind` を新規 export
- `api/reports.ts` / `api/reports-public.ts`: local `VALID_KINDS` を削除し `isReportKind` を import
- `as ReportKind` アサーションを削除（guard で narrow される）
- `tests/worker/db/reports.test.ts`: `isReportKind` のユニットテストを 3 件追加

## Test plan

- [x] `pnpm -C apps/web test run tests/worker/api/reports.test.ts tests/worker/api/reports-public.test.ts tests/worker/db/reports.test.ts` → all pass
- [x] `vp lint` / `pnpm typecheck` pass
- [ ] CI green

Closes #438
