### PR TITLE
perf(api): add Cache-Control headers to /api/reports endpoints

### DIFF
--- a/apps/web/tests/worker/api/reports-public.test.ts
+++ b/apps/web/tests/worker/api/reports-public.test.ts
@@ -92,6 +92,14 @@ describe("GET /api/reports (公開一覧)", () => {
     expect.soft(res.status).toBe(200);
     expect.soft(res.headers.get("access-control-allow-origin")).toBe(allowedOrigin);
   });
+
+  it("Cache-Control ヘッダが付く", async () => {
+    const res = await SELF.fetch("https://example.com/api/reports");
+    expect.soft(res.status).toBe(200);
+    expect
+      .soft(res.headers.get("Cache-Control"))
+      .toBe("public, max-age=300, stale-while-revalidate=1500");
+  });
 });
 
 describe("GET /api/reports/:id (公開詳細)", () => {
@@ -123,5 +131,15 @@ describe("GET /api/reports/:id (公開詳細)", () => {
     });
     expect.soft(res.status).toBe(200);
     expect.soft(res.headers.get("access-control-allow-origin")).toBe(allowedOrigin);
+  });
+
+  it("Cache-Control ヘッダが付く", async () => {
+    const id = await insertReport({ content: "cache header test" });
+
+    const res = await SELF.fetch(`https://example.com/api/reports/${id}`);
+    expect.soft(res.status).toBe(200);
+    expect
+      .soft(res.headers.get("Cache-Control"))
+      .toBe("public, max-age=600, stale-while-revalidate=3000");
   });
 });

--- a/apps/web/worker/api/reports-public.ts
+++ b/apps/web/worker/api/reports-public.ts
@@ -20,7 +20,9 @@ app.get("/", async (c) => {
   const limit = Number.isFinite(limitParam) ? Math.min(Math.max(limitParam, 1), 100) : 20;
 
   const reports = await listReports(c.env.DB, { kind, limit });
-  return c.json<AdminReportListResponse>({ reports });
+  return c.json<AdminReportListResponse>({ reports }, 200, {
+    "Cache-Control": "public, max-age=300, stale-while-revalidate=1500",
+  });
 });
 
 app.get("/:id", async (c) => {
@@ -32,7 +34,9 @@ app.get("/:id", async (c) => {
   if (!detail) {
     return c.json({ error: "report not found" }, 404);
   }
-  return c.json<AdminReportDetailResponse>({ report: detail });
+  return c.json<AdminReportDetailResponse>({ report: detail }, 200, {
+    "Cache-Control": "public, max-age=600, stale-while-revalidate=3000",
+  });
 });
 
 export default app;


### PR DESCRIPTION
## Summary
- `GET /api/reports` (一覧) に `Cache-Control: public, max-age=300, stale-while-revalidate=1500` を追加 (5 分キャッシュ + 25 分 SWR)
- `GET /api/reports/:id` (詳細) に `Cache-Control: public, max-age=600, stale-while-revalidate=3000` を追加 (10 分キャッシュ + 50 分 SWR)
- 各エンドポイントに対応する Cache-Control 検証テストを追加 (`reports-public.test.ts`)

レポートは生成後ほぼ変わらないため、詳細は長めの max-age を採用。CDN/ブラウザキャッシュにより無駄な D1 query を削減。

Closes #444

## Test plan
- [x] `cd apps/web && pnpm test tests/worker/api/reports-public.test.ts` pass
- [x] `vp check` (lint/format/typecheck) pass
- [x] CI green
