### PR TITLE
refactor(db): dedup stats aggregation queries

### DIFF
--- a/apps/web/tests/worker/db/stats.test.ts
+++ b/apps/web/tests/worker/db/stats.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it } from "vite-plus/test";
+import { env } from "cloudflare:test";
+import { insertArticles } from "../../../worker/db/articles";
+import { getHealthArticleStats } from "../../../worker/db/articles";
+import { syncFeeds } from "../../../worker/db/feeds";
+import type { FeedConfig } from "../../../worker/types";
+
+const FEED: FeedConfig = {
+  id: "stats-test-feed",
+  name: "Stats Test Feed",
+  url: "https://x.test/stats",
+  category: "bigtech",
+  lang: "en",
+  enabled: true,
+};
+
+beforeEach(async () => {
+  await syncFeeds(env.DB, [FEED]);
+});
+
+describe("getHealthArticleStats", () => {
+  it("returns total=0 and since=0 when no articles exist", async () => {
+    const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    const result = await getHealthArticleStats(env.DB, since);
+    expect.soft(result.total).toBe(0);
+    expect.soft(result.since).toBe(0);
+  });
+
+  it("counts all articles in total regardless of date", async () => {
+    const oldAt = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
+    const recentAt = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+    await insertArticles(env.DB, [
+      {
+        guid: "s-old",
+        feed_id: FEED.id,
+        title: "Old",
+        url: "https://x.test/old",
+        summary: null,
+        author: null,
+        published_at: oldAt,
+        category: "bigtech",
+        lang: "en",
+      },
+      {
+        guid: "s-recent",
+        feed_id: FEED.id,
+        title: "Recent",
+        url: "https://x.test/recent",
+        summary: null,
+        author: null,
+        published_at: recentAt,
+        category: "bigtech",
+        lang: "en",
+      },
+    ]);
+
+    const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    const result = await getHealthArticleStats(env.DB, since);
+    expect.soft(result.total).toBe(2);
+    expect.soft(result.since).toBe(1);
+  });
+
+  it("counts only articles at or after the since boundary in the since field", async () => {
+    // 厳密に境界値を確認する: since 時刻と同一の記事は含まれる (>= )
+    const boundary = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    await insertArticles(env.DB, [
+      {
+        guid: "s-boundary",
+        feed_id: FEED.id,
+        title: "Boundary",
+        url: "https://x.test/boundary",
+        summary: null,
+        author: null,
+        published_at: boundary,
+        category: "bigtech",
+        lang: "en",
+      },
+    ]);
+
+    const result = await getHealthArticleStats(env.DB, boundary);
+    expect.soft(result.total).toBe(1);
+    expect.soft(result.since).toBe(1);
+  });
+
+  it("returns since=0 when all articles are older than the boundary", async () => {
+    const veryOld = new Date(Date.now() - 72 * 60 * 60 * 1000).toISOString();
+    await insertArticles(env.DB, [
+      {
+        guid: "s-very-old",
+        feed_id: FEED.id,
+        title: "Very Old",
+        url: "https://x.test/very-old",
+        summary: null,
+        author: null,
+        published_at: veryOld,
+        category: "bigtech",
+        lang: "en",
+      },
+    ]);
+
+    const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    const result = await getHealthArticleStats(env.DB, since);
+    expect.soft(result.total).toBe(1);
+    expect.soft(result.since).toBe(0);
+  });
+});

--- a/apps/web/worker/api/health.ts
+++ b/apps/web/worker/api/health.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { countFeeds } from "../db/feeds";
 import { getFeedHealth } from "../db/feed-stats";
-import { countAllArticles, countArticlesSince } from "../db/articles";
+import { getHealthArticleStats } from "../db/articles";
 import { getLatestCompletedRun } from "../db/runs";
 import { loadAllFeeds } from "../feed-config";
 import type { Env, FeedHealth } from "../types";
@@ -13,11 +13,12 @@ app.get("/", async (c) => {
   try {
     const since24h = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
 
-    const [feedsTotal, feedsEnabled, articlesTotal, articles24h, latestRun] = await Promise.all([
+    // countFeeds x2 + getHealthArticleStats + getLatestCompletedRun を並列で発行する。
+    // getHealthArticleStats は total と last_24h を 1 クエリで返し、従来の 2 クエリを削減する。
+    const [feedsTotal, feedsEnabled, articleStats, latestRun] = await Promise.all([
       countFeeds(c.env.DB),
       countFeeds(c.env.DB, { enabled: true }),
-      countAllArticles(c.env.DB),
-      countArticlesSince(c.env.DB, since24h),
+      getHealthArticleStats(c.env.DB, since24h),
       getLatestCompletedRun(c.env.DB),
     ]);
 
@@ -30,8 +31,8 @@ app.get("/", async (c) => {
         enabled: feedsEnabled,
       },
       articles: {
-        total: articlesTotal,
-        last_24h: articles24h,
+        total: articleStats.total,
+        last_24h: articleStats.since,
       },
       last_cron_run: latestRun
         ? {

--- a/apps/web/worker/db/articles-stats.ts
+++ b/apps/web/worker/db/articles-stats.ts
@@ -15,6 +15,30 @@ export async function countArticlesSince(db: D1Database, isoDate: string): Promi
   return row?.c ?? 0;
 }
 
+export interface ArticleHealthStats {
+  total: number;
+  since: number;
+}
+
+/**
+ * articles テーブルの total 件数と指定日時以降の件数を 1 クエリで取得する。
+ * health endpoint で 2 本の個別クエリを 1 ラウンドトリップに削減するために使う。
+ */
+export async function getHealthArticleStats(
+  db: D1Database,
+  isoDate: string,
+): Promise<ArticleHealthStats> {
+  const row = await db
+    .prepare(
+      `SELECT COUNT(*) AS total,
+              SUM(CASE WHEN published_at >= ?1 THEN 1 ELSE 0 END) AS since
+       FROM articles`,
+    )
+    .bind(isoDate)
+    .first<{ total: number; since: number | null }>();
+  return { total: row?.total ?? 0, since: row?.since ?? 0 };
+}
+
 export interface CategoryTrendPoint {
   date: string;
   ai: number;
@@ -23,74 +47,11 @@ export interface CategoryTrendPoint {
   personal: number;
 }
 
-const CATEGORY_KEYS = ["ai", "bigtech", "jp", "personal"] as const;
-type CategoryKey = (typeof CATEGORY_KEYS)[number];
-
-function isCategoryKey(v: string): v is CategoryKey {
-  return (CATEGORY_KEYS as readonly string[]).includes(v);
-}
-
 export interface FeedActivityRow {
   feed_id: string;
   feed_name: string;
   articles_30d: number;
   last_published_at: string | null;
-}
-
-/** 過去 30 日のカテゴリ別日次記事数を集計し、欠損日を 0 埋めして返す */
-export async function getCategoryTrend30d(db: D1Database): Promise<CategoryTrendPoint[]> {
-  const rows = await db
-    .prepare(
-      `SELECT date(published_at) AS date, category, COUNT(*) AS n
-       FROM articles
-       WHERE published_at >= date('now', '-30 days')
-       GROUP BY date(published_at), category
-       ORDER BY date(published_at) ASC`,
-    )
-    .all<{ date: string; category: string; n: number }>();
-
-  // 過去 30 日分の date を生成 (今日含む)
-  const today = new Date();
-  today.setUTCHours(0, 0, 0, 0);
-  const points: CategoryTrendPoint[] = [];
-  for (let i = 29; i >= 0; i--) {
-    const d = new Date(today);
-    d.setUTCDate(today.getUTCDate() - i);
-    const dateStr = d.toISOString().slice(0, 10);
-    points.push({ date: dateStr, ai: 0, bigtech: 0, jp: 0, personal: 0 });
-  }
-
-  // クエリ結果をマップにして点に埋め込む
-  const map = new Map<string, CategoryTrendPoint>();
-  for (const p of points) map.set(p.date, p);
-
-  for (const row of rows.results ?? []) {
-    const point = map.get(row.date);
-    if (!point) continue;
-    if (!isCategoryKey(row.category)) continue;
-    point[row.category] += row.n;
-  }
-
-  return points;
-}
-
-/** 過去 30 日のフィード別記事数を集計して articles_30d 降順で返す */
-export async function getFeedActivity30d(db: D1Database): Promise<FeedActivityRow[]> {
-  const rows = await db
-    .prepare(
-      `SELECT a.feed_id,
-              COALESCE(f.name, a.feed_id) AS feed_name,
-              COUNT(*) AS articles_30d,
-              MAX(a.published_at) AS last_published_at
-       FROM articles a
-       LEFT JOIN feeds f ON f.id = a.feed_id
-       WHERE a.published_at >= date('now', '-30 days')
-       GROUP BY a.feed_id
-       ORDER BY articles_30d DESC`,
-    )
-    .all<FeedActivityRow>();
-
-  return rows.results ?? [];
 }
 
 export interface TopAuthorRow {
@@ -107,45 +68,4 @@ export interface TopPublisherRow {
 export interface ByLang30d {
   ja: number;
   en: number;
-}
-
-/**
- * 過去 30 日の author 別記事数 TOP 10 (null / 空文字除外)。
- * personal カテゴリ (個人ブログ) は企業 tech blog の人気著者ランキングからは除外する。
- */
-export async function getTopAuthors30d(db: D1Database): Promise<TopAuthorRow[]> {
-  const rows = await db
-    .prepare(
-      `SELECT author, COUNT(*) AS count
-       FROM articles
-       WHERE author IS NOT NULL
-         AND author != ''
-         AND category != 'personal'
-         AND published_at >= datetime('now', '-30 days')
-       GROUP BY author
-       ORDER BY count DESC
-       LIMIT 10`,
-    )
-    .all<TopAuthorRow>();
-
-  return rows.results ?? [];
-}
-
-/** 過去 30 日の言語別記事数 (ja / en 両方を常に返す) */
-export async function getByLang30d(db: D1Database): Promise<ByLang30d> {
-  const rows = await db
-    .prepare(
-      `SELECT lang, COUNT(*) AS count
-       FROM articles
-       WHERE published_at >= datetime('now', '-30 days')
-       GROUP BY lang`,
-    )
-    .all<{ lang: string; count: number }>();
-
-  const result: ByLang30d = { ja: 0, en: 0 };
-  for (const row of rows.results ?? []) {
-    if (row.lang === "ja") result.ja = row.count;
-    else if (row.lang === "en") result.en = row.count;
-  }
-  return result;
 }

--- a/apps/web/worker/db/articles.ts
+++ b/apps/web/worker/db/articles.ts
@@ -61,20 +61,14 @@ export {
 } from "./articles-query-extra";
 
 export type {
+  ArticleHealthStats,
   CategoryTrendPoint,
   FeedActivityRow,
   TopAuthorRow,
   TopPublisherRow,
   ByLang30d,
 } from "./articles-stats";
-export {
-  countAllArticles,
-  countArticlesSince,
-  getCategoryTrend30d,
-  getFeedActivity30d,
-  getTopAuthors30d,
-  getByLang30d,
-} from "./articles-stats";
+export { countAllArticles, countArticlesSince, getHealthArticleStats } from "./articles-stats";
 
 export type { InsertableArticle } from "./articles-write";
 export {


### PR DESCRIPTION
## Summary

- `articles-stats.ts` の未使用関数 (`getCategoryTrend30d` / `getFeedActivity30d` / `getTopAuthors30d` / `getByLang30d`) を削除し、型定義のみ残す。stats.ts が `db.batch` で同等 SQL を直接実行しており、これらの関数はデッドコードだった
- `health.ts` で `countAllArticles` + `countArticlesSince` の 2 クエリを `getHealthArticleStats` (1 クエリ + `SUM(CASE WHEN ...)`) に統合し、D1 の subrequest を 1 本削減
- `tests/worker/db/stats.test.ts` を新規追加して `getHealthArticleStats` の動作を検証

## Test plan

- [x] `tests/worker/api/stats.test.ts` — 既存 44 tests pass
- [x] `tests/worker/api/health.test.ts` — 既存 tests pass
- [x] `tests/worker/db/stats.test.ts` — 新規 4 tests pass
- [x] 全 worker tests (863 tests) pass

Closes #443
