### PR TITLE
refactor(db): dedup escapeFtsQuery — import from articles-query-extra

### DIFF
--- a/apps/web/worker/db/articles-query.ts
+++ b/apps/web/worker/db/articles-query.ts
@@ -8,6 +8,7 @@ import {
   buildPaginatedQuery,
   extractWithCursor,
 } from "./articles-cursor";
+import { escapeFtsQuery } from "./articles-query-extra";
 import type { D1BindParameter } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -364,17 +365,3 @@ export async function getArticlesByDay(
   return extractWithCursor(result.results ?? [], limit);
 }
 
-// ---------------------------------------------------------------------------
-// FTS5 クエリエスケープ (listArticles の q パラメータで使用)
-// ---------------------------------------------------------------------------
-
-function escapeFtsQuery(input: string): string {
-  // FTS5 で安全に扱うため、特殊記号を除去して各単語をフレーズ扱いにする
-  const tokens = input
-    .replace(/["()*:^]/g, " ")
-    .split(/\s+/)
-    .filter(Boolean)
-    .slice(0, 8)
-    .map((t) => `"${t.replace(/"/g, "")}"`);
-  return tokens.length > 0 ? tokens.join(" ") : '""';
-}

--- a/apps/web/worker/db/articles-query.ts
+++ b/apps/web/worker/db/articles-query.ts
@@ -364,4 +364,3 @@ export async function getArticlesByDay(
     .all<Article>();
   return extractWithCursor(result.results ?? [], limit);
 }
-


### PR DESCRIPTION
## Summary

`articles-query.ts` 内の private `escapeFtsQuery` 関数 (FTS5 特殊文字除去 → フレーズクォート) を削除し、`articles-query-extra.ts` の export 版を import に切り替え。同一ロジックの 2 ファイル並立を解消し、片方を直して片方を取りこぼすバグ温床を除去。

## Test plan

- [x] `tests/worker/db/articles.test.ts` / `tests/worker/api/api.test.ts` pass (69 tests)
- [x] `vp check` pass

Closes #447
