### PR TITLE
refactor: dedup feedsYaml cast and replace syndication inline query

### DIFF
--- a/apps/web/worker/api/articles.ts
+++ b/apps/web/worker/api/articles.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import type { Env } from "../types";
-import { loadAllFeeds } from "../feed-config";
+import { getFeedsVersion, loadAllFeeds } from "../feed-config";
 import {
   countArticlesByDay,
   countArticlesByMonth,
@@ -18,8 +18,6 @@ import {
   searchArticles,
 } from "../db/articles";
 import { computeArticlesEtag } from "../utils/etag";
-import feedsYaml from "../feeds.yaml";
-import type { FeedsFile } from "../types";
 import type {
   ArticleArchiveResponse,
   ArticleByAuthorResponse,
@@ -36,7 +34,7 @@ import type {
 import { isCategory, isLang } from "./_guards";
 import { decodeCursor, encodeCursor, isValidDateRange, parseListQuery } from "./articles-parse";
 
-const FEEDS_VERSION = (feedsYaml as FeedsFile).version;
+const FEEDS_VERSION = getFeedsVersion();
 
 const app = new Hono<{ Bindings: Env }>();
 

--- a/apps/web/worker/api/syndication.ts
+++ b/apps/web/worker/api/syndication.ts
@@ -1,10 +1,10 @@
 import { Hono } from "hono";
 import type { Context } from "hono";
-import type { Article, Env, FeedCategory, FeedLang, FeedsFile } from "../types";
+import type { Env, FeedCategory, FeedLang } from "../types";
 import { listArticles } from "../db/articles";
+import { getArticlesByAuthor } from "../db/articles-query";
 import { computeSyndicationEtag } from "../utils/etag";
-import { loadAllFeeds } from "../feed-config";
-import feedsYaml from "../feeds.yaml";
+import { getFeedsVersion, loadAllFeeds } from "../feed-config";
 import { buildUrlParts } from "./syndication/shared";
 import type { FeedMeta } from "./syndication/shared";
 import { renderJsonFeed } from "./syndication/json";
@@ -12,7 +12,7 @@ import { renderAtomFeed } from "./syndication/atom";
 import { renderRssFeed } from "./syndication/rss";
 import { isCategory, isLang } from "./_guards";
 
-const FEEDS_VERSION = (feedsYaml as FeedsFile).version;
+const FEEDS_VERSION = getFeedsVersion();
 const FEED_LIMIT = 50;
 const SITE_TITLE = "Tech News Bot";
 const SITE_DESCRIPTION = "Big tech / AI / 日本企業の technical blog を集約した RSS / JSON Feed";
@@ -75,23 +75,6 @@ function render(format: Format, meta: FeedMeta): { contentType: string; body: st
   if (format === "json") return renderJsonFeed(meta);
   if (format === "atom") return renderAtomFeed(meta);
   return renderRssFeed(meta);
-}
-
-// --- 著者別記事取得: db/articles.ts を変更せず syndication 層で直接クエリする ---
-async function fetchArticlesByAuthor(db: D1Database, author: string): Promise<Article[]> {
-  const result = await db
-    .prepare(
-      `SELECT a.id, a.guid, a.feed_id, f.name AS feed_name, a.title, a.url, a.summary,
-              a.author, a.published_at, a.fetched_at, a.category, a.lang
-       FROM articles a
-       LEFT JOIN feeds f ON f.id = a.feed_id
-       WHERE a.author = ?1
-       ORDER BY a.published_at DESC, a.id DESC
-       LIMIT ?2`,
-    )
-    .bind(author, FEED_LIMIT)
-    .all<Article>();
-  return result.results ?? [];
 }
 
 // ----------------------------- Routes --------------------------------
@@ -231,7 +214,7 @@ app.get("/feeds/author/*", async (c) => {
   const notModified = await checkEtag(c, etag, 600);
   if (notModified) return notModified;
 
-  const articles = await fetchArticlesByAuthor(c.env.DB, author);
+  const { articles } = await getArticlesByAuthor(c.env.DB, author, FEED_LIMIT, null);
   const urlParts = buildUrlParts(c.req.url);
   const meta: FeedMeta = {
     title,

--- a/apps/web/worker/feed-config.ts
+++ b/apps/web/worker/feed-config.ts
@@ -3,6 +3,10 @@ import feedsYaml from "./feeds.yaml";
 
 const file = feedsYaml as FeedsFile;
 
+export function getFeedsVersion(): number {
+  return file.version;
+}
+
 export function loadAllFeeds(): FeedConfig[] {
   return file.feeds;
 }


### PR DESCRIPTION
## 概要

`feedsYaml as FeedsFile` キャストの重複排除と syndication.ts のインライン SQL 撲滅の 2 点を 1 PR にまとめた軽量 refactor。

### A. `feedsYaml as FeedsFile` キャストの統合

`feed-config.ts` に `getFeedsVersion(): number` を追加し、`articles.ts:39` と `syndication.ts:15` の `(feedsYaml as FeedsFile).version` 重複を解消。API 層からの `as FeedsFile` キャストを根絶。

### B. `syndication.ts` インライン D1 query の撲滅

`syndication.ts` の `fetchArticlesByAuthor` (インライン SQL 15 行) を削除し、`db/articles-query.ts` の `getArticlesByAuthor(db, author, FEED_LIMIT, null)` を呼ぶ形に置換。**API 層に直接 SQL を書かない** 規約に揃える。

## 動作互換の確認

- `getArticlesByAuthor` のカラムリスト (`ARTICLES_SELECT_FIELDS`) はインライン版と完全一致
- 並び順: `ORDER BY a.published_at DESC, a.id DESC` で同一
- 件数: `FEED_LIMIT = 50` を固定で渡しており元の `LIMIT ?2` と同一

## テスト

```
Tests 82 passed (82) — syndication + by-author テスト
Tests 859 passed (859) — 全 worker テスト
```

Closes #448
