### PR TITLE
refactor(db): extract daysAgoIso helper to eliminate 4 duplicates

### DIFF
--- a/apps/web/worker/db/_helpers.ts
+++ b/apps/web/worker/db/_helpers.ts
@@ -1,0 +1,7 @@
+/**
+ * 現在時刻から `days` 日前の ISO 8601 文字列を返す。
+ * 用途: D1 クエリで `WHERE published_at > ?` の閾値計算など。
+ */
+export function daysAgoIso(days: number): string {
+  return new Date(Date.now() - days * 86_400_000).toISOString();
+}

--- a/apps/web/worker/db/feed-stats.ts
+++ b/apps/web/worker/db/feed-stats.ts
@@ -7,6 +7,7 @@ import type {
   FeedLang,
 } from "../types";
 import type { CategorySummaryDbRow, FeedDiagnosticDbRow, FeedHealthFeedsDbRow } from "./types";
+import { daysAgoIso } from "./_helpers";
 
 export interface CategorySummary {
   id: FeedCategory;
@@ -33,7 +34,7 @@ const CATEGORY_LABELS: Record<FeedCategory, string> = {
  * client 側の CategorySummary 型に合わせて id / label を返す。
  */
 export async function getCategoriesSummary(db: D1Database): Promise<CategorySummary[]> {
-  const threshold = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+  const threshold = daysAgoIso(30);
 
   const rows = await db
     .prepare(
@@ -83,7 +84,7 @@ export async function getCategoriesSummary(db: D1Database): Promise<CategorySumm
  * enabled の有無に関わらず全フィードを返す (運用ダッシュボード用)。
  */
 export async function getFeedsDiagnostics(db: D1Database): Promise<FeedDiagnostic[]> {
-  const threshold = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+  const threshold = daysAgoIso(30);
 
   const rows = await db
     .prepare(

--- a/apps/web/worker/db/feeds.ts
+++ b/apps/web/worker/db/feeds.ts
@@ -1,5 +1,6 @@
 import type { FeedCategory, FeedConfig, FeedLang } from "../types";
 import type { D1BindParameter, FeedWithStatsDbRow } from "./types";
+import { daysAgoIso } from "./_helpers";
 
 export interface FeedHeaders {
   last_etag: string | null;
@@ -297,7 +298,7 @@ export async function listFeedsWithStats(
   }
 
   // 30d 境界を SQLite の datetime 関数で計算し bind する
-  const threshold = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+  const threshold = daysAgoIso(30);
   binds.push(threshold);
   const thresholdIdx = binds.length;
 
@@ -341,7 +342,7 @@ export async function listFeedsWithStats(
  * id が存在しない場合は null。
  */
 export async function findFeedWithStats(db: D1Database, id: string): Promise<FeedWithStats | null> {
-  const threshold = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+  const threshold = daysAgoIso(30);
 
   const row = await db
     .prepare(


### PR DESCRIPTION
## Summary

- `new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString()` の 4 重複を解消
- `apps/web/worker/db/_helpers.ts` に `daysAgoIso(days: number): string` を新規作成
- `feed-stats.ts` (L36, L86) と `feeds.ts` (L300, L344) の 4 箇所を `daysAgoIso(30)` に置き換え

## Test plan

- [x] `vp fmt --check` pass (全 300 ファイル)
- [x] `vp test run` pass (866 tests, 61 test files)
- [x] `vp check` で今回変更ファイルにエラーなし (既存の tsconfig / vitest mock 警告は変更前から存在)

Closes #453