### PR TITLE
refactor(spa-shell): replace as FeedCategory cast with isCategory guard

### DIFF
--- a/apps/web/worker/api/spa-shell.ts
+++ b/apps/web/worker/api/spa-shell.ts
@@ -1,6 +1,7 @@
 import type { Env, FeedCategory } from "../types";
 import { getArticleById } from "../db/articles";
 import { findFeedWithStats } from "../db/feeds";
+import { isCategory } from "./_guards";
 
 // ---------------------------------------------------------------------------
 // 定数
@@ -53,8 +54,8 @@ function matchRoute(pathname: string): RouteMatch {
   // /by-category/:cat — issue の設計方針に合わせて /by-category/:cat を採用
   const catM = pathname.match(/^\/by-category\/(.+)$/);
   if (catM) {
-    const cat = catM[1] as FeedCategory;
-    if (cat in CATEGORY_LABELS) return { type: "category", category: cat };
+    const cat = catM[1];
+    if (isCategory(cat)) return { type: "category", category: cat };
   }
 
   return { type: "static" };


### PR DESCRIPTION
## Summary

- spa-shell.ts の matchRoute() 内で /by-category/:cat マッチ時に使用していた as FeedCategory キャストと cat in CATEGORY_LABELS チェックを、同一ディレクトリの _guards.ts にある isCategory() 型ガードで置き換えた
- CATEGORY_LABELS は resolveMeta() でも使われているため削除せず維持

## Motivation

01-typescript.md のガイドライン「型アサーションは外部入力に限定し、内部ロジックでは使わない」に準拠するため。isCategory() は Set ベースの O(1) ガードで既存の in チェックより明示的かつ型安全。

## Test plan

- vp test run tests/worker/api/spa-shell.test.ts — 14 テスト全 pass
- spa-shell.ts に lint / typecheck エラーなし

Closes #455