### PR TITLE
refactor(client): dedup formatDate into client/lib/format-date

### DIFF
--- a/apps/web/client/components/ArticleCard.tsx
+++ b/apps/web/client/components/ArticleCard.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { useEffect, useRef, useState } from "react";
 import { useReadState } from "../hooks/useReadState";
 import { useStarredState } from "../hooks/useStarredState";
+import { formatDatetime } from "../lib/format-date";
 import type { Article, FeedCategory } from "../types/api";
 import { safeHref } from "../utils/safe-href";
 import { BookmarkButton } from "./BookmarkButton";
@@ -52,18 +53,6 @@ const CATEGORY_BADGE_CLASS: Record<string, string> = {
   jp: "bg-[var(--cat-jp-bg)] text-[var(--cat-jp)]",
   personal: "bg-[var(--cat-personal-bg)] text-[var(--cat-personal)]",
 };
-
-function formatDate(iso: string): string {
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return iso;
-  return d.toLocaleString("ja-JP", {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-}
 
 export function ArticleCard({
   article,
@@ -157,7 +146,7 @@ export function ArticleCard({
           {article.feed_name ?? article.feed_id}
         </button>
         <span>·</span>
-        <time dateTime={article.published_at}>{formatDate(article.published_at)}</time>
+        <time dateTime={article.published_at}>{formatDatetime(article.published_at)}</time>
         {article.author && (
           <>
             <span>·</span>

--- a/apps/web/client/components/ReportDetail.tsx
+++ b/apps/web/client/components/ReportDetail.tsx
@@ -2,6 +2,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { Components } from "react-markdown";
 import { useReport } from "../hooks/useReports";
+import { formatDatetime } from "../lib/format-date";
 import { safeHref } from "../utils/safe-href";
 
 const KIND_LABELS: Record<string, string> = {
@@ -23,18 +24,6 @@ function parseMeta(metaJson: string | null): MetaJson | null {
   } catch {
     return null;
   }
-}
-
-function formatDate(iso: string): string {
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return iso;
-  return d.toLocaleString("ja-JP", {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
 }
 
 // markdown 内のリンクを新タブで開くカスタムレンダラ。
@@ -113,7 +102,7 @@ export function ReportDetail({ id, onBack }: Props) {
           {new Date(report.period_end).toLocaleDateString("ja-JP")}
         </p>
         <p className="text-[var(--fg-muted)] text-[var(--font-size-xs)] m-0">
-          生成: {formatDate(report.generated_at)} · {report.source_skill}
+          生成: {formatDatetime(report.generated_at)} · {report.source_skill}
         </p>
       </div>
 

--- a/apps/web/client/components/ReportsList.tsx
+++ b/apps/web/client/components/ReportsList.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { formatDatetime } from "../lib/format-date";
 import type { ReportKind } from "../types/api";
 import { useReportsList } from "../hooks/useReports";
 
@@ -12,18 +13,6 @@ type KindFilter = ReportKind | undefined;
 
 interface Props {
   onSelectReport: (id: number) => void;
-}
-
-function formatDate(iso: string): string {
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return iso;
-  return d.toLocaleString("ja-JP", {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
 }
 
 export function ReportsList({ onSelectReport }: Props) {
@@ -112,7 +101,7 @@ export function ReportsList({ onSelectReport }: Props) {
                   {new Date(report.period_end).toLocaleDateString("ja-JP")}
                 </p>
                 <p className="text-[var(--fg-muted)] text-[var(--font-size-xs)] m-0">
-                  生成: {formatDate(report.generated_at)} · {report.source_skill}
+                  生成: {formatDatetime(report.generated_at)} · {report.source_skill}
                 </p>
               </button>
             </li>

--- a/apps/web/client/components/Stats.tsx
+++ b/apps/web/client/components/Stats.tsx
@@ -1,20 +1,10 @@
 import { FEED_CATEGORIES } from "../lib/feed-categories";
+import { formatDateShort } from "../lib/format-date";
 import type { FeedActivity, Stats } from "../hooks/useStats";
 import { StatsChart } from "./StatsChart";
 
 interface StatsProps {
   stats: Stats;
-}
-
-function formatDate(iso: string): string {
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return iso;
-  return d.toLocaleDateString("ja-JP", {
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
 }
 
 function FeedActivityTable({ rows }: { rows: FeedActivity[] }) {
@@ -47,7 +37,7 @@ function FeedActivityTable({ rows }: { rows: FeedActivity[] }) {
               {row.articles_30d}
             </td>
             <td className="py-[var(--space-2)] px-[var(--space-2)] text-left border-b border-[var(--border-subtle)] text-[var(--fg-muted)] whitespace-nowrap w-[160px]">
-              {row.last_published_at ? formatDate(row.last_published_at) : "—"}
+              {row.last_published_at ? formatDateShort(row.last_published_at) : "—"}
             </td>
           </tr>
         ))}

--- a/apps/web/client/lib/format-date.ts
+++ b/apps/web/client/lib/format-date.ts
@@ -1,0 +1,33 @@
+// 複数コンポーネントで重複していた日付フォーマット関数を集約
+
+/**
+ * ISO 文字列を「YYYY/MM/DD HH:mm」形式にフォーマットする。
+ * ArticleCard / ReportDetail / ReportsList の generated_at / published_at 表示用。
+ */
+export function formatDatetime(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString("ja-JP", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+/**
+ * ISO 文字列を「M月D日 HH:mm」形式にフォーマットする。
+ * Stats コンポーネントのフィード別アクティビティ表 (最終記事日時) 用。
+ * year を省略し month:"short" で短縮表示する。
+ */
+export function formatDateShort(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString("ja-JP", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}

--- a/apps/web/tests/client/format-date.test.ts
+++ b/apps/web/tests/client/format-date.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vite-plus/test";
+import { formatDateShort, formatDatetime } from "../../client/lib/format-date";
+
+// toLocaleString の出力は ICU データに依存するため、実行時に期待値を生成して等値比較する
+
+const ISO = "2024-03-15T10:30:00Z";
+const INVALID = "not-a-date";
+
+describe("formatDatetime", () => {
+  it("有効な ISO 文字列を ja-JP の年月日 HH:mm 形式にフォーマットする", () => {
+    const d = new Date(ISO);
+    const expected = d.toLocaleString("ja-JP", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+    expect(formatDatetime(ISO)).toBe(expected);
+  });
+
+  it("不正な ISO 文字列はそのまま返す", () => {
+    expect(formatDatetime(INVALID)).toBe(INVALID);
+  });
+
+  it("空文字はそのまま返す", () => {
+    expect(formatDatetime("")).toBe("");
+  });
+});
+
+describe("formatDateShort", () => {
+  it("有効な ISO 文字列を ja-JP の month:short day HH:mm 形式にフォーマットする", () => {
+    const d = new Date(ISO);
+    const expected = d.toLocaleDateString("ja-JP", {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+    expect(formatDateShort(ISO)).toBe(expected);
+  });
+
+  it("不正な ISO 文字列はそのまま返す", () => {
+    expect(formatDateShort(INVALID)).toBe(INVALID);
+  });
+
+  it("空文字はそのまま返す", () => {
+    expect(formatDateShort("")).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

- 4 コンポーネント (ArticleCard / ReportDetail / ReportsList / Stats) に散在していたほぼ同一の formatDate ローカル関数を client/lib/format-date.ts に集約
- formatDatetime (年月日 HH:mm) と formatDateShort (month:short day HH:mm) の 2 関数に整理
- UI の表示文字列はゼロ変更 (各コンポーネントの振る舞いを維持)
- ユニットテスト追加 (tests/client/format-date.test.ts)

## Test plan

- [x] vp test run --config vitest.client.config.ts — 406 tests passed
- [x] vp fmt --write — フォーマット確認済み
- [x] vp check — 既存エラーのみ (tsconfig-error は main でも発生していた既知の問題)

Closes #461