### PR TITLE
feat(worker): AI Crawler / AI bot ブロック対応

### DIFF
--- a/apps/web/tests/worker/api/robots.test.ts
+++ b/apps/web/tests/worker/api/robots.test.ts
@@ -1,0 +1,77 @@
+import { beforeAll, describe, expect, it } from "vite-plus/test";
+import { SELF } from "cloudflare:test";
+import { AI_TRAINING_BOT_TOKENS } from "../../../worker/middleware/ai-crawler-block";
+
+// 必ず通過すべき代理エージェント (明示 Disallow されてはいけない)
+const PROXY_AGENTS = [
+  "ChatGPT-User",
+  "Claude-User",
+  "OAI-SearchBot",
+  "Claude-SearchBot",
+  "PerplexityBot",
+] as const;
+
+describe("/robots.txt", () => {
+  let response: Response;
+  let robotsTxt: string;
+
+  beforeAll(async () => {
+    response = await SELF.fetch("https://x.test/robots.txt");
+    robotsTxt = await response.text();
+  });
+
+  it("ステータス 200 を返す", () => {
+    expect(response.status).toBe(200);
+  });
+
+  it("Content-Type が text/plain; charset=utf-8 を含む", () => {
+    expect.soft(response.headers.get("Content-Type")).toContain("text/plain");
+    expect.soft(response.headers.get("Content-Type")).toContain("charset=utf-8");
+  });
+
+  it("Cache-Control が public, max-age=3600, stale-while-revalidate=86400 である (変わっていないこと)", () => {
+    expect(response.headers.get("Cache-Control")).toBe(
+      "public, max-age=3600, stale-while-revalidate=86400",
+    );
+  });
+
+  it("body に User-agent: * が含まれる", () => {
+    expect(robotsTxt).toContain("User-agent: *");
+  });
+
+  it("body に Allow: / が含まれる", () => {
+    expect(robotsTxt).toContain("Allow: /");
+  });
+
+  it("body に Disallow: /api/admin/ が含まれる", () => {
+    expect(robotsTxt).toContain("Disallow: /api/admin/");
+  });
+
+  it("body に Sitemap: https://x.test/sitemap.xml が含まれる", () => {
+    expect(robotsTxt).toContain("Sitemap: https://x.test/sitemap.xml");
+  });
+
+  describe("AI 学習 bot の User-agent と Disallow: / が含まれる", () => {
+    it.each(AI_TRAINING_BOT_TOKENS)("bot=%s の User-agent 行と Disallow: / が含まれる", (bot) => {
+      expect.soft(robotsTxt).toContain(`User-agent: ${bot}`);
+      // 各 AI 学習 bot のセクションに Disallow: / がある
+      // セクション単位でパースして確認する
+      const sections = robotsTxt.split(/\n\n+/);
+      const botSection = sections.find((s) => s.includes(`User-agent: ${bot}`));
+      expect(botSection).toBeDefined();
+      expect(botSection).toContain("Disallow: /");
+    });
+  });
+
+  describe("代理エージェントは明示 Disallow されていない", () => {
+    it.each(PROXY_AGENTS)(
+      "代理エージェント %s は User-agent として明示 Disallow されていない",
+      (agent) => {
+        const lines = robotsTxt.split("\n");
+        // "User-agent: <agent>" という行が存在しないことを negative assert
+        const hasExplicitEntry = lines.some((line) => line.trim() === `User-agent: ${agent}`);
+        expect(hasExplicitEntry).toBe(false);
+      },
+    );
+  });
+});

--- a/apps/web/tests/worker/api/spa-shell.test.ts
+++ b/apps/web/tests/worker/api/spa-shell.test.ts
@@ -229,3 +229,32 @@ describe("SPA shell rewrite: duplicate meta tag regression", () => {
     expect(matches).toHaveLength(1);
   });
 });
+
+describe("SPA shell rewrite: robots meta tag", () => {
+  it('記事ページの HTML に <meta name="robots" content="noai, noimageai"> が含まれる', async () => {
+    const row = await env.DB.prepare("SELECT id FROM articles WHERE guid = ?1")
+      .bind("g-bt-1")
+      .first<{ id: number }>();
+    const id = row?.id;
+
+    const res = await SELF.fetch(`https://example.com/articles/${id}`);
+    // fail-fast: status が 200 でなければ html の検証が無意味
+    expect(res.status).toBe(200);
+
+    const html = await res.text();
+    expect(extractMeta(html, '[name="robots"]')).toBe("noai, noimageai");
+  });
+
+  it("記事ページの HTML に noindex が含まれない", async () => {
+    const row = await env.DB.prepare("SELECT id FROM articles WHERE guid = ?1")
+      .bind("g-bt-1")
+      .first<{ id: number }>();
+    const id = row?.id;
+
+    const res = await SELF.fetch(`https://example.com/articles/${id}`);
+    expect(res.status).toBe(200);
+
+    const html = await res.text();
+    expect(/noindex/i.test(html)).toBe(false);
+  });
+});

--- a/apps/web/tests/worker/middleware/ai-crawler-block.test.ts
+++ b/apps/web/tests/worker/middleware/ai-crawler-block.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "vite-plus/test";
+import { Hono } from "hono";
+import { aiCrawlerBlock, isAiTrainingBot } from "../../../worker/middleware/ai-crawler-block";
+import type { Env } from "../../../worker/types";
+
+function makeApp() {
+  const app = new Hono<{ Bindings: Env }>();
+  app.use("*", aiCrawlerBlock);
+  app.get("/x", (c) => c.text("ok"));
+  return app;
+}
+
+const MIN_ENV = {} as Partial<Env>;
+
+// ---------------------------------------------------------------------------
+// isAiTrainingBot — 純粋関数のテスト
+// ---------------------------------------------------------------------------
+describe("isAiTrainingBot", () => {
+  describe("null / undefined / 空文字 → false", () => {
+    it("null を渡すと false を返す", () => {
+      expect(isAiTrainingBot(null)).toBe(false);
+    });
+
+    it("undefined を渡すと false を返す", () => {
+      expect(isAiTrainingBot(undefined)).toBe(false);
+    });
+
+    it("空文字を渡すと false を返す", () => {
+      expect(isAiTrainingBot("")).toBe(false);
+    });
+  });
+
+  describe("denylist 12 token → true", () => {
+    it.each([
+      ["GPTBot", "GPTBot/1.0"],
+      ["ClaudeBot", "ClaudeBot/1.0"],
+      ["anthropic-ai", "anthropic-ai/0.1"],
+      ["Claude-Web", "Claude-Web/1.0"],
+      ["Google-Extended", "Google-Extended/1.0"],
+      ["CCBot", "CCBot/2.0"],
+      ["Bytespider", "Bytespider/1.0"],
+      ["Amazonbot", "Amazonbot/0.1"],
+      ["Applebot-Extended", "Applebot-Extended/1.0"],
+      ["Meta-ExternalAgent", "Meta-ExternalAgent/1.0"],
+      ["FacebookBot", "FacebookBot/1.0"],
+      ["cohere-training-data-crawler", "cohere-training-data-crawler/1.0"],
+    ])("token=%s の UA は true を返す", (_token, ua) => {
+      expect(isAiTrainingBot(ua)).toBe(true);
+    });
+  });
+
+  describe("case-insensitive マッチ → true", () => {
+    it("小文字 gptbot/1.0 は true を返す", () => {
+      expect(isAiTrainingBot("gptbot/1.0")).toBe(true);
+    });
+
+    it("大文字 CLAUDEBOT/1.0 は true を返す", () => {
+      expect(isAiTrainingBot("CLAUDEBOT/1.0")).toBe(true);
+    });
+
+    it("混在ケース AnThRoPiC-Ai は true を返す", () => {
+      expect(isAiTrainingBot("AnThRoPiC-Ai/1.0")).toBe(true);
+    });
+  });
+
+  describe("部分マッチ → true", () => {
+    it("something-GPTBot-something は true を返す", () => {
+      expect(isAiTrainingBot("something-GPTBot-something/1.0")).toBe(true);
+    });
+  });
+
+  describe("通常ブラウザ UA → false", () => {
+    it("Chrome UA は false を返す", () => {
+      expect(
+        isAiTrainingBot(
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+        ),
+      ).toBe(false);
+    });
+
+    it("Firefox UA は false を返す", () => {
+      expect(
+        isAiTrainingBot(
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:125.0) Gecko/20100101 Firefox/125.0",
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("代理エージェント → false (必ず通過)", () => {
+    it.each([
+      ["ChatGPT-User", "ChatGPT-User/1.0"],
+      ["Claude-User", "Claude-User/1.0"],
+      ["OAI-SearchBot", "OAI-SearchBot/1.0"],
+      ["Claude-SearchBot", "Claude-SearchBot/1.0"],
+      ["PerplexityBot", "PerplexityBot/1.0"],
+    ])("代理エージェント %s は false を返す", (_name, ua) => {
+      expect(isAiTrainingBot(ua)).toBe(false);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// aiCrawlerBlock middleware のテスト
+// ---------------------------------------------------------------------------
+describe("aiCrawlerBlock middleware", () => {
+  it("AI_BOT_BLOCK_ENABLED=1 + 学習 bot UA → 403 + JSON error body + X-Robots-Tag", async () => {
+    const app = makeApp();
+    const res = await app.fetch(
+      new Request("https://x.test/x", {
+        headers: { "user-agent": "GPTBot/1.0" },
+      }),
+      { ...MIN_ENV, AI_BOT_BLOCK_ENABLED: "1" } as Env,
+    );
+
+    // fail-fast: status が 403 でなければ body の検証が無意味
+    expect(res.status).toBe(403);
+    const body = await res.json<{ error: string; code: string }>();
+    expect.soft(body.error).toBe("AI crawlers are not allowed");
+    expect.soft(body.code).toBe("ai_bot_blocked");
+    expect.soft(res.headers.get("X-Robots-Tag")).toBe("noai, noimageai");
+  });
+
+  it("AI_BOT_BLOCK_ENABLED=1 + 代理エージェント UA (ChatGPT-User) → 200 + X-Robots-Tag", async () => {
+    const app = makeApp();
+    const res = await app.fetch(
+      new Request("https://x.test/x", {
+        headers: { "user-agent": "ChatGPT-User/1.0" },
+      }),
+      { ...MIN_ENV, AI_BOT_BLOCK_ENABLED: "1" } as Env,
+    );
+
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("X-Robots-Tag")).toBe("noai, noimageai");
+  });
+
+  it("AI_BOT_BLOCK_ENABLED=1 + 代理エージェント UA (Claude-User) → 200 + X-Robots-Tag", async () => {
+    const app = makeApp();
+    const res = await app.fetch(
+      new Request("https://x.test/x", {
+        headers: { "user-agent": "Claude-User/1.0" },
+      }),
+      { ...MIN_ENV, AI_BOT_BLOCK_ENABLED: "1" } as Env,
+    );
+
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("X-Robots-Tag")).toBe("noai, noimageai");
+  });
+
+  it("AI_BOT_BLOCK_ENABLED=1 + 代理エージェント UA (OAI-SearchBot) → 200 + X-Robots-Tag", async () => {
+    const app = makeApp();
+    const res = await app.fetch(
+      new Request("https://x.test/x", {
+        headers: { "user-agent": "OAI-SearchBot/1.0" },
+      }),
+      { ...MIN_ENV, AI_BOT_BLOCK_ENABLED: "1" } as Env,
+    );
+
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("X-Robots-Tag")).toBe("noai, noimageai");
+  });
+
+  it("AI_BOT_BLOCK_ENABLED=1 + 通常ブラウザ UA → 200 + X-Robots-Tag", async () => {
+    const app = makeApp();
+    const res = await app.fetch(
+      new Request("https://x.test/x", {
+        headers: {
+          "user-agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+        },
+      }),
+      { ...MIN_ENV, AI_BOT_BLOCK_ENABLED: "1" } as Env,
+    );
+
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("X-Robots-Tag")).toBe("noai, noimageai");
+  });
+
+  it("AI_BOT_BLOCK_ENABLED 未設定 + 学習 bot UA → 200 + X-Robots-Tag (フラグ off は完全 no-op)", async () => {
+    const app = makeApp();
+    const res = await app.fetch(
+      new Request("https://x.test/x", {
+        headers: { "user-agent": "GPTBot/1.0" },
+      }),
+      { ...MIN_ENV } as Env,
+    );
+
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("X-Robots-Tag")).toBe("noai, noimageai");
+  });
+
+  it("AI_BOT_BLOCK_ENABLED=0 + 学習 bot UA → 200 + X-Robots-Tag", async () => {
+    const app = makeApp();
+    const res = await app.fetch(
+      new Request("https://x.test/x", {
+        headers: { "user-agent": "ClaudeBot/1.0" },
+      }),
+      { ...MIN_ENV, AI_BOT_BLOCK_ENABLED: "0" } as Env,
+    );
+
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("X-Robots-Tag")).toBe("noai, noimageai");
+  });
+
+  it("AI_BOT_BLOCK_ENABLED=1 + UA ヘッダー無し → 200 + X-Robots-Tag", async () => {
+    const app = makeApp();
+    const res = await app.fetch(new Request("https://x.test/x"), {
+      ...MIN_ENV,
+      AI_BOT_BLOCK_ENABLED: "1",
+    } as Env);
+
+    expect.soft(res.status).toBe(200);
+    expect.soft(res.headers.get("X-Robots-Tag")).toBe("noai, noimageai");
+  });
+});

--- a/apps/web/worker/api/robots.ts
+++ b/apps/web/worker/api/robots.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { AI_TRAINING_BOT_TOKENS } from "../middleware/ai-crawler-block";
 import type { Env } from "../types";
 
 const app = new Hono<{ Bindings: Env }>();
@@ -6,13 +7,21 @@ const app = new Hono<{ Bindings: Env }>();
 app.get("/robots.txt", (c) => {
   const url = new URL(c.req.url);
   const origin = `${url.protocol}//${url.host}`;
+
+  const aiBlocks = AI_TRAINING_BOT_TOKENS.map((token) => `User-agent: ${token}\nDisallow: /`).join(
+    "\n\n",
+  );
+
   const body = [
     "User-agent: *",
     "Allow: /",
     "Disallow: /api/admin/",
     "",
+    aiBlocks,
+    "",
     `Sitemap: ${origin}/sitemap.xml`,
   ].join("\n");
+
   c.header("Content-Type", "text/plain; charset=utf-8");
   // robots.txt の内容は静的なためエッジキャッシュを積極活用する。
   // stale-while-revalidate でキャッシュ切れ後も裏でリフレッシュしつつ即返せる。

--- a/apps/web/worker/api/router.ts
+++ b/apps/web/worker/api/router.ts
@@ -3,6 +3,7 @@ import { cors } from "hono/cors";
 import type { Context, Next } from "hono";
 import type { Env } from "../types";
 import { type AccessUser, accessJwtMiddleware } from "../middleware/access-jwt";
+import { aiCrawlerBlock } from "../middleware/ai-crawler-block";
 import articles from "./articles";
 import categories from "./categories";
 import feeds from "./feeds";
@@ -20,6 +21,8 @@ api.use("*", async (c, next) => {
   c.header("Cache-Control", "no-store");
   await next();
 });
+
+api.use("*", aiCrawlerBlock);
 
 // /api/admin/* は server-to-server 専用のため CORS を付けない。
 // それ以外の公開エンドポイントは wrangler.toml の CORS_ALLOWED_ORIGINS で制御する。

--- a/apps/web/worker/api/spa-shell.ts
+++ b/apps/web/worker/api/spa-shell.ts
@@ -100,6 +100,7 @@ function applyMetaRewriter(response: Response, meta: PageMeta): Response {
   let twitterCardDone = false;
   let twitterTitleDone = false;
   let twitterDescDone = false;
+  let robotsNoaiDone = false;
 
   return new HTMLRewriter()
     .on("title", {
@@ -114,6 +115,8 @@ function applyMetaRewriter(response: Response, meta: PageMeta): Response {
 
         if (name === "description") {
           el.setAttribute("content", escapeHtml(meta.description));
+        } else if (name === "robots" && el.getAttribute("content")?.includes("noai")) {
+          robotsNoaiDone = true;
         } else if (name === "twitter:card") {
           el.setAttribute("content", "summary");
           twitterCardDone = true;
@@ -188,6 +191,9 @@ function applyMetaRewriter(response: Response, meta: PageMeta): Response {
             missing.push(
               `<meta name="twitter:description" content="${escapeHtml(meta.description)}" />`,
             );
+          }
+          if (!robotsNoaiDone) {
+            missing.push(`<meta name="robots" content="noai, noimageai" />`);
           }
 
           if (missing.length > 0) {

--- a/apps/web/worker/middleware/ai-crawler-block.ts
+++ b/apps/web/worker/middleware/ai-crawler-block.ts
@@ -1,0 +1,43 @@
+import type { MiddlewareHandler } from "hono";
+import type { Env } from "../types";
+
+// AI 学習 bot の robots.txt token / User-Agent 部分文字列。
+// 代理エージェント (ChatGPT-User / Claude-User / OAI-SearchBot / Claude-SearchBot / PerplexityBot)
+// は意図的に除外している (ユーザー自発の "この URL を読んで" を 403 にしたくないため)。
+export const AI_TRAINING_BOT_TOKENS = [
+  "GPTBot",
+  "ClaudeBot",
+  "anthropic-ai",
+  "Claude-Web",
+  "Google-Extended",
+  "CCBot",
+  "Bytespider",
+  "Amazonbot",
+  "Applebot-Extended",
+  "Meta-ExternalAgent",
+  "FacebookBot",
+  "cohere-training-data-crawler",
+] as const;
+
+export function isAiTrainingBot(userAgent: string | null | undefined): boolean {
+  if (!userAgent) return false;
+  const ua = userAgent.toLowerCase();
+  return AI_TRAINING_BOT_TOKENS.some((t) => ua.includes(t.toLowerCase()));
+}
+
+export const aiCrawlerBlock: MiddlewareHandler<{ Bindings: Env }> = async (c, next) => {
+  // 常に X-Robots-Tag を付与 (HTML を parse しない bot 向けの補助シグナル)。
+  // AI_BOT_BLOCK_ENABLED の on/off に関わらずヘッダーは常時付与する。
+  // フラグ off で 403 を返さない場合でも noai シグナルだけは常に出す意図。
+  c.header("X-Robots-Tag", "noai, noimageai");
+
+  // フラグが "1" のときだけブロック動作。デフォルトは no-op (段階的ロールアウト用)。
+  if (c.env.AI_BOT_BLOCK_ENABLED === "1") {
+    const ua = c.req.header("user-agent");
+    if (isAiTrainingBot(ua)) {
+      return c.json({ error: "AI crawlers are not allowed", code: "ai_bot_blocked" }, 403);
+    }
+  }
+
+  return await next();
+};

--- a/apps/web/worker/types.ts
+++ b/apps/web/worker/types.ts
@@ -27,6 +27,8 @@ export interface Env {
   CF_ACCESS_TEAM_DOMAIN?: string;
   // ローカル開発でアクセス JWT 検証をスキップする ("1" でスキップ)
   SKIP_ACCESS_JWT?: string;
+  // "1" のとき /api/* で AI 学習 bot を 403 ブロックする
+  AI_BOT_BLOCK_ENABLED?: string;
 }
 
 export type FeedCategory = "bigtech" | "ai" | "jp" | "personal";

--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -50,6 +50,8 @@ COLLECTOR_ALERT_THRESHOLD = "5"
 # TODO(#375): CF_ACCESS_AUD / CF_ACCESS_TEAM_DOMAIN を secret 登録した時点でこの行を削除する。
 # 削除を忘れると本番で /api/admin/* が adminAuthMiddleware (Bearer) のみで守られる状態が継続する。
 SKIP_ACCESS_JWT = "1"
+# AI_BOT_BLOCK_ENABLED は `wrangler secret put AI_BOT_BLOCK_ENABLED` で本番に投入する。
+# 未設定 = フラグ off (X-Robots-Tag のみ付与、403 ブロックなし)。段階的ロールアウト用。
 
 [[analytics_engine_datasets]]
 binding = "COLLECTOR_AE"


### PR DESCRIPTION
## 概要

公開サイトに対する AI 学習 bot のオプトアウトと、`/api/*` の UA ベースブロック機構を導入。自分自身が他サイトの RSS を巡回している立場として相手の robots.txt を尊重するなら、自サイトでも AI 学習 bot 向けの意思表示と最低限の強制力を持たせる、という意図。

Closes #465

## 変更内容

### robots.txt (`apps/web/worker/api/robots.ts`)

- AI 学習 bot 12 token ごとに `User-agent: <token>` / `Disallow: /` ブロックを追加
  - `GPTBot`, `ClaudeBot`, `anthropic-ai`, `Claude-Web`, `Google-Extended`, `CCBot`, `Bytespider`, `Amazonbot`, `Applebot-Extended`, `Meta-ExternalAgent`, `FacebookBot`, `cohere-training-data-crawler`
- 代理エージェント (`ChatGPT-User`, `Claude-User`, `OAI-SearchBot`, `Claude-SearchBot`, `PerplexityBot`) は **明示 Disallow しない** (`User-agent: *` の Allow に包含)。ユーザーが自発的に「この URL 読んで」と AI に渡した時の UX を壊さないため。
- token list は `middleware/ai-crawler-block.ts` から import して 1 箇所定義。

### UA ベース block middleware (`apps/web/worker/middleware/ai-crawler-block.ts` 新規)

- `/api/*` のみに適用 (RSS / OPML / sitemap / robots.txt は対象外)
- `c.env.AI_BOT_BLOCK_ENABLED === "1"` のときのみブロック動作。デフォルトは no-op (段階的ロールアウト用)
- マッチ時: `403 { error: "AI crawlers are not allowed", code: "ai_bot_blocked" }`
- フラグ on/off に関わらず `X-Robots-Tag: noai, noimageai` を常時付与 (HTML を parse しない bot 向けの補助シグナル)
- case-insensitive substring match

### SPA shell (`apps/web/worker/api/spa-shell.ts`)

- `applyMetaRewriter` に `<meta name="robots" content="noai, noimageai">` の追加処理を加える
- `noindex` は **絶対に付けない** (検索インデックスから外れるため)。`noai, noimageai` のみ。

### Env / wrangler.toml

- `Env` interface に `AI_BOT_BLOCK_ENABLED?: string` を追加
- `wrangler.toml` には値を入れない (デフォルト無効)。本番有効化は `wrangler secret put AI_BOT_BLOCK_ENABLED` または Cloudflare dashboard での投入を運用フローとし、コメントで明記

### テスト (新規 2 / 修正 1)

- `apps/web/tests/worker/middleware/ai-crawler-block.test.ts`
  - `isAiTrainingBot` 純粋関数: null/undefined/空文字、12 token (it.each)、case-insensitive、部分マッチ、ブラウザ UA、代理エージェント 5 種
  - middleware: フラグ on + 学習 bot → 403、代理エージェント → 200、ブラウザ → 200、フラグ未設定 / "0" / UA 無し → 200。すべて `X-Robots-Tag` 付与を検証
- `apps/web/tests/worker/api/robots.test.ts`
  - status / Content-Type / Cache-Control 維持 / 12 token の Disallow 検証 / 代理エージェント 5 種が明示 Disallow されていないこと
  - `beforeAll` で 1 回 fetch して使い回し (重複 fetch 回避)
- `apps/web/tests/worker/api/spa-shell.test.ts` 修正
  - `<meta name="robots" content="noai, noimageai">` が含まれること
  - `noindex` が含まれないこと

## 採用しなかった案

- **Cloudflare Dashboard の "Block AI bots" toggle**: Free plan では path 単位の制御ができず `/feed.xml` や `/robots.txt` まで一律 403 になるリスクがあるため不採用。
- **代理エージェント (Claude-User / ChatGPT-User 等) も block する案**: ユーザーが自発的に AI 経由で記事を読みに来た時の UX を壊すため不採用。
- **`<meta name="robots" content="noindex">`**: 検索インデックスから外れる副作用があるため不採用。

## テスト

- [x] `pnpm check` pass (lint / format / typecheck)
- [x] `pnpm test` pass (worker: 64 files / 974 tests)
- [x] `pnpm test:client` pass (49 files / 406 tests)
- [x] `AI_BOT_BLOCK_ENABLED` 未設定 / "0" で middleware が完全に no-op になることをテストで確認
- [x] 代理エージェント 5 種が通過することをテストで確認
- [x] 12 token すべてが robots.txt に出力されることをテストで確認