### PR TITLE
refactor: extract withTimeout util to dedup AbortController boilerplate

### DIFF
--- a/apps/web/tests/worker/utils/with-timeout.test.ts
+++ b/apps/web/tests/worker/utils/with-timeout.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { withTimeout } from "../../../worker/utils/with-timeout";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("withTimeout", () => {
+  it("resolve fn の値をそのまま返す", async () => {
+    const result = await withTimeout(async () => "ok", 1000);
+    expect(result).toBe("ok");
+  });
+
+  it("fn に AbortSignal を渡す", async () => {
+    let received: AbortSignal | null = null;
+    await withTimeout(async (signal) => {
+      received = signal;
+      return 1;
+    }, 1000);
+
+    // guard: signal が渡っていないと後続の assert が無意味になる
+    expect(received).not.toBeNull();
+    expect.soft(received).toBeInstanceOf(AbortSignal);
+    expect.soft((received as AbortSignal | null)?.aborted).toBe(false);
+  });
+
+  it("timeout 経過で AbortError を throw する", async () => {
+    vi.useFakeTimers();
+
+    const promise = withTimeout(
+      // 永久に解決しない fn (signal を無視するケース)
+      () => new Promise<string>(() => {}),
+      100,
+    );
+    // unhandled rejection を避けるため即時に catch を attach
+    const caught = promise.catch((e: unknown) => e);
+
+    await vi.advanceTimersByTimeAsync(150);
+    const err = await caught;
+
+    expect(err).toBeInstanceOf(DOMException);
+    expect.soft((err as DOMException).name).toBe("AbortError");
+  });
+
+  it("timeout 時に fn の signal も abort される (signal を観測する fn の場合)", async () => {
+    vi.useFakeTimers();
+
+    let observed: AbortSignal | null = null;
+    const promise = withTimeout((signal) => {
+      observed = signal;
+      return new Promise<string>((_resolve, reject) => {
+        signal.addEventListener("abort", () => reject(new Error("fn-aborted")));
+      });
+    }, 100);
+    const caught = promise.catch((e: unknown) => e);
+
+    await vi.advanceTimersByTimeAsync(150);
+    await caught;
+
+    // 注: race の勝者は abortPromise (DOMException) または fn の reject (Error) のどちらでも良い。
+    // 重要なのは fn 側が abort を受け取れていること。
+    expect(observed).not.toBeNull();
+    expect((observed as AbortSignal | null)?.aborted).toBe(true);
+  });
+
+  it("fn が reject したらその error を伝播する (timeout 前)", async () => {
+    const err = await withTimeout(async () => {
+      throw new Error("inner");
+    }, 1000).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toBe("inner");
+  });
+
+  it("fn が成功してもタイマーがリークしない (即座に解決後、setTimeout が走らない)", async () => {
+    vi.useFakeTimers();
+
+    let timeoutFired = false;
+    // setTimeout を spy して、withTimeout 内のタイマーが clear されたか観測
+    const realSetTimeout = globalThis.setTimeout;
+    const spy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+      fn: () => void,
+      ms: number,
+    ) => {
+      const id = realSetTimeout(() => {
+        timeoutFired = true;
+        fn();
+      }, ms) as unknown as number;
+      return id;
+    }) as typeof globalThis.setTimeout);
+
+    await withTimeout(async () => "done", 1000);
+
+    // fn が即時 resolve して、timer が clearTimeout されているはずなので advance しても fire しない
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(timeoutFired).toBe(false);
+
+    spy.mockRestore();
+  });
+});

--- a/apps/web/worker/api/admin.ts
+++ b/apps/web/worker/api/admin.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import type { MiddlewareHandler } from "hono";
 import type { Env } from "../types";
 import { adminAuthMiddleware } from "../utils/auth";
+import { withTimeout } from "../utils/with-timeout";
 import { collectAll, collectFeeds, validateFeedUrl } from "../collector";
 import { loadAllFeeds } from "../feed-config";
 import { setFeedEnabled } from "../db/feeds";
@@ -60,11 +61,12 @@ app.post("/feeds/validate", async (c) => {
   if (typeof body.url !== "string" || !body.url) {
     return c.json({ error: "url is required" }, 400);
   }
+  const url = body.url;
 
   // URL 形式チェック (http/https のみ許可)
   let parsedUrl: URL;
   try {
-    parsedUrl = new URL(body.url);
+    parsedUrl = new URL(url);
   } catch {
     return c.json({ error: "invalid url" }, 400);
   }
@@ -73,25 +75,18 @@ app.post("/feeds/validate", async (c) => {
   }
 
   // 12s でタイムアウト。fetch 自体は I/O なので CPU には乗らないが安全マージン。
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 12_000);
-
   let validateResult: Awaited<ReturnType<typeof validateFeedUrl>>;
   try {
-    validateResult = await Promise.race([
-      validateFeedUrl(body.url),
-      new Promise<never>((_, reject) => {
-        controller.signal.addEventListener("abort", () =>
-          reject(new Error("validate timed out after 12s")),
-        );
-      }),
-    ]);
+    validateResult = await withTimeout((_signal) => validateFeedUrl(url), 12_000);
   } catch (err) {
-    clearTimeout(timer);
-    const msg = err instanceof Error ? err.message : String(err);
+    const msg =
+      err instanceof Error && err.name === "AbortError"
+        ? "validate timed out after 12s"
+        : err instanceof Error
+          ? err.message
+          : String(err);
     validateResult = { ok: false, error: msg };
   }
-  clearTimeout(timer);
 
   c.header("Cache-Control", "no-store");
   return c.json(validateResult);
@@ -170,28 +165,16 @@ app.post("/collector/run", async (c) => {
   const startedAt = new Date().toISOString();
 
   // 25s タイムアウト (Workers の cron 制限 30s に対して余裕を持たせる)
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 25_000);
-
   let collectResult: Awaited<ReturnType<typeof collectFeeds>>;
   try {
-    const collectPromise = collectFeeds(c.env, feedIds);
-    // AbortSignal が発火したら reject に落とす
-    const abortPromise = new Promise<never>((_, reject) => {
-      controller.signal.addEventListener("abort", () =>
-        reject(new Error("collector timed out after 25s")),
-      );
-    });
-    collectResult = await Promise.race([collectPromise, abortPromise]);
+    collectResult = await withTimeout((_signal) => collectFeeds(c.env, feedIds), 25_000);
   } catch (err) {
-    clearTimeout(timer);
-    const msg = err instanceof Error ? err.message : String(err);
-    if (msg.includes("timed out")) {
+    if (err instanceof Error && err.name === "AbortError") {
       return c.json({ error: "collector timed out (25s)" }, 504);
     }
+    const msg = err instanceof Error ? err.message : String(err);
     return c.json({ error: msg }, 500);
   }
-  clearTimeout(timer);
 
   const finishedAt = new Date().toISOString();
   const results = collectResult.results.map((r) => ({

--- a/apps/web/worker/collector/alert.ts
+++ b/apps/web/worker/collector/alert.ts
@@ -1,4 +1,5 @@
 import type { Env } from "../types";
+import { withTimeout } from "../utils/with-timeout";
 import type { CollectResult } from "./index";
 
 export interface AlertSummary {
@@ -40,16 +41,18 @@ export async function notifyCollectorFailure(
   }
 
   const text = lines.join("\n");
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 5000);
 
   try {
-    const res = await fetch(webhookUrl, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ text }),
-      signal: controller.signal,
-    });
+    const res = await withTimeout(
+      (signal) =>
+        fetch(webhookUrl, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ text }),
+          signal,
+        }),
+      5000,
+    );
     if (!res.ok) {
       console.error(`[alert] webhook returned non-2xx: ${res.status} ${res.statusText}`);
     }
@@ -57,8 +60,6 @@ export async function notifyCollectorFailure(
     console.error(
       `[alert] failed to send webhook: ${err instanceof Error ? err.message : String(err)}`,
     );
-  } finally {
-    clearTimeout(timer);
   }
 }
 
@@ -98,23 +99,22 @@ export async function sendAlert(env: Env, result: AlertRunResult): Promise<void>
     ],
   };
 
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 5000);
-
   try {
-    const res = await fetch(webhookUrl, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
-      signal: controller.signal,
-    });
+    const res = await withTimeout(
+      (signal) =>
+        fetch(webhookUrl, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+          signal,
+        }),
+      5000,
+    );
     if (!res.ok) {
       console.error(`[alert] sendAlert webhook returned non-2xx: ${res.status} ${res.statusText}`);
     }
   } catch (err) {
     console.error(`[alert] sendAlert failed: ${err instanceof Error ? err.message : String(err)}`);
-  } finally {
-    clearTimeout(timer);
   }
 }
 

--- a/apps/web/worker/utils/with-timeout.ts
+++ b/apps/web/worker/utils/with-timeout.ts
@@ -1,0 +1,25 @@
+/**
+ * Promise を timeout 付きで実行する。timeout 時は AbortController.signal を fn に渡し、
+ * 自前で abort してリソース解放させる。fn が signal を使わない場合でも timeout で reject する。
+ */
+export async function withTimeout<T>(
+  fn: (signal: AbortSignal) => Promise<T>,
+  ms: number,
+): Promise<T> {
+  const ctrl = new AbortController();
+
+  // fn が signal を使う (fetch 等) 場合は signal 経由でキャンセルされる。
+  // fn が signal を無視する場合でも abortPromise が reject して timeout を強制する。
+  const abortPromise = new Promise<never>((_, reject) => {
+    ctrl.signal.addEventListener("abort", () =>
+      reject(new DOMException("The operation was aborted", "AbortError")),
+    );
+  });
+
+  const timer = setTimeout(() => ctrl.abort(), ms);
+  try {
+    return await Promise.race([fn(ctrl.signal), abortPromise]);
+  } finally {
+    clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
## Summary

- AbortController + setTimeout + Promise.race + clearTimeout の timeout パターンが 4 箇所 (admin.ts の validate / collector/run、alert.ts の Slack/Discord webhook) で重複していた
- 共通ヘルパー \`withTimeout(fn, ms)\` を \`worker/utils/with-timeout.ts\` に切り出し、4 箇所を置換
- ヘルパーは \`AbortSignal\` を fn に forward し、timeout 経過時は AbortError (DOMException) を throw、必ず \`finally\` で \`clearTimeout\`

## Test plan

- [x] 新規 unit test 6 ケース追加 (success / signal forwarding / timeout AbortError / fn signal abort 観測 / fn rejection 伝播 / no timer leak on success)
- [x] 既存 admin / collector テスト 207 件で regression なし
- [x] vp check pass (typecheck / lint / format)

Closes #467

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for timeout handling, error propagation, and resource cleanup.

* **Refactor**
  * Unified timeout enforcement across feed validation, collector operations, and alert notifications for consistent behavior.
  * Improved error messaging to clearly indicate timeout conditions and durations.
  * Enhanced resource cleanup to prevent timer leaks in timeout operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->