### PR TITLE
refactor(api): extract parseLimit/parsePositiveInt to _helpers.ts

### DIFF
--- a/apps/web/tests/worker/api/_helpers.test.ts
+++ b/apps/web/tests/worker/api/_helpers.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vite-plus/test";
+import { parseLimit, parsePositiveInt } from "../../../worker/api/_helpers";
+
+describe("parseLimit", () => {
+  const opts = { default: 20, max: 100 };
+
+  it("正常な数値文字列を clamp せずに返す", () => {
+    expect(parseLimit("10", opts)).toBe(10);
+  });
+
+  it("undefined はデフォルト値を返す", () => {
+    expect(parseLimit(undefined, opts)).toBe(20);
+  });
+
+  it("空文字列はデフォルト値を返す (NaN フォールバック)", () => {
+    expect(parseLimit("", opts)).toBe(20);
+  });
+
+  it("数値でない文字列はデフォルト値を返す", () => {
+    expect(parseLimit("abc", opts)).toBe(20);
+  });
+
+  it("0 は min (1) に clamp される", () => {
+    expect(parseLimit("0", opts)).toBe(1);
+  });
+
+  it("負数は min (1) に clamp される", () => {
+    expect(parseLimit("-5", opts)).toBe(1);
+  });
+
+  it("max を超える値は max に clamp される", () => {
+    expect(parseLimit("9999", opts)).toBe(100);
+  });
+
+  it("min オプションを指定すると下限が変わる", () => {
+    expect(parseLimit("0", { default: 20, max: 100, min: 5 })).toBe(5);
+  });
+});
+
+describe("parsePositiveInt", () => {
+  it("正の整数文字列をそのまま返す", () => {
+    expect(parsePositiveInt("10")).toBe(10);
+  });
+
+  it("0 は null を返す", () => {
+    expect(parsePositiveInt("0")).toBeNull();
+  });
+
+  it("負数は null を返す", () => {
+    expect(parsePositiveInt("-5")).toBeNull();
+  });
+
+  it("数値でない文字列は null を返す", () => {
+    expect(parsePositiveInt("abc")).toBeNull();
+  });
+
+  it("小数は null を返す (整数でない)", () => {
+    expect(parsePositiveInt("1.5")).toBeNull();
+  });
+
+  it("空文字列は null を返す", () => {
+    expect(parsePositiveInt("")).toBeNull();
+  });
+});

--- a/apps/web/worker/api/_helpers.ts
+++ b/apps/web/worker/api/_helpers.ts
@@ -6,8 +6,10 @@ export function parseLimit(
   raw: string | undefined,
   opts: { default: number; max: number; min?: number },
 ): number {
+  // 空文字列も "未指定" として扱う (Number("") は 0 になり意図せず min に丸まるため)
+  if (raw === undefined || raw === "") return opts.default;
   const min = opts.min ?? 1;
-  const n = Number(raw ?? String(opts.default));
+  const n = Number(raw);
   if (!Number.isFinite(n)) return opts.default;
   return Math.min(Math.max(n, min), opts.max);
 }

--- a/apps/web/worker/api/_helpers.ts
+++ b/apps/web/worker/api/_helpers.ts
@@ -1,0 +1,23 @@
+/**
+ * limit クエリパラメータを解析して clamp した整数を返す。
+ * 数値として無効な値 (NaN, Infinity) はデフォルト値にフォールバックする。
+ */
+export function parseLimit(
+  raw: string | undefined,
+  opts: { default: number; max: number; min?: number },
+): number {
+  const min = opts.min ?? 1;
+  const n = Number(raw ?? String(opts.default));
+  if (!Number.isFinite(n)) return opts.default;
+  return Math.min(Math.max(n, min), opts.max);
+}
+
+/**
+ * 正の整数文字列を解析する。0・負・NaN・Infinity など無効な場合は null を返す。
+ * URL パラメータ (:id) の解析に使う。
+ */
+export function parsePositiveInt(raw: string): number | null {
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0 || !Number.isInteger(n)) return null;
+  return n;
+}

--- a/apps/web/worker/api/admin.ts
+++ b/apps/web/worker/api/admin.ts
@@ -3,6 +3,7 @@ import type { MiddlewareHandler } from "hono";
 import type { Env } from "../types";
 import { adminAuthMiddleware } from "../utils/auth";
 import { withTimeout } from "../utils/with-timeout";
+import { parseLimit, parsePositiveInt } from "./_helpers";
 import { collectAll, collectFeeds, validateFeedUrl } from "../collector";
 import { loadAllFeeds } from "../feed-config";
 import { setFeedEnabled } from "../db/feeds";
@@ -207,15 +208,14 @@ app.post("/feeds/:id/enabled", async (c) => {
 });
 
 app.get("/runs", async (c) => {
-  const limitParam = Number(c.req.query("limit") ?? "20");
-  const limit = Number.isFinite(limitParam) ? Math.min(Math.max(limitParam, 1), 100) : 20;
+  const limit = parseLimit(c.req.query("limit"), { default: 20, max: 100 });
   const runs = await listRuns(c.env.DB, limit);
   return c.json<AdminRunListResponse>({ runs });
 });
 
 app.get("/runs/:id", async (c) => {
-  const idParam = Number(c.req.param("id"));
-  if (!Number.isFinite(idParam) || idParam <= 0) {
+  const idParam = parsePositiveInt(c.req.param("id"));
+  if (idParam === null) {
     return c.json({ error: "invalid id" }, 400);
   }
   const detail = await getRun(c.env.DB, idParam);

--- a/apps/web/worker/api/reports-public.ts
+++ b/apps/web/worker/api/reports-public.ts
@@ -3,6 +3,7 @@ import type { Env } from "../types";
 import { getReport, isReportKind, listReports } from "../db/reports";
 import type { ReportKind } from "../db/reports";
 import type { AdminReportDetailResponse, AdminReportListResponse } from "./types";
+import { parseLimit, parsePositiveInt } from "./_helpers";
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -16,8 +17,7 @@ app.get("/", async (c) => {
     kind = kindParam;
   }
 
-  const limitParam = Number(c.req.query("limit") ?? "20");
-  const limit = Number.isFinite(limitParam) ? Math.min(Math.max(limitParam, 1), 100) : 20;
+  const limit = parseLimit(c.req.query("limit"), { default: 20, max: 100 });
 
   const reports = await listReports(c.env.DB, { kind, limit });
   return c.json<AdminReportListResponse>({ reports }, 200, {
@@ -26,8 +26,8 @@ app.get("/", async (c) => {
 });
 
 app.get("/:id", async (c) => {
-  const idParam = Number(c.req.param("id"));
-  if (!Number.isFinite(idParam) || idParam <= 0) {
+  const idParam = parsePositiveInt(c.req.param("id"));
+  if (idParam === null) {
     return c.json({ error: "invalid id" }, 400);
   }
   const detail = await getReport(c.env.DB, idParam);

--- a/apps/web/worker/api/reports.ts
+++ b/apps/web/worker/api/reports.ts
@@ -10,6 +10,7 @@ import type {
   AdminReportSaveResponse,
 } from "./types";
 import { isCategory, isLang } from "./_guards";
+import { parseLimit, parsePositiveInt } from "./_helpers";
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -169,16 +170,15 @@ app.get("/", async (c) => {
     kind = kindParam;
   }
 
-  const limitParam = Number(c.req.query("limit") ?? "20");
-  const limit = Number.isFinite(limitParam) ? Math.min(Math.max(limitParam, 1), 100) : 20;
+  const limit = parseLimit(c.req.query("limit"), { default: 20, max: 100 });
 
   const reports = await listReports(c.env.DB, { kind, limit });
   return c.json<AdminReportListResponse>({ reports });
 });
 
 app.get("/:id", async (c) => {
-  const idParam = Number(c.req.param("id"));
-  if (!Number.isFinite(idParam) || idParam <= 0) {
+  const idParam = parsePositiveInt(c.req.param("id"));
+  if (idParam === null) {
     return c.json({ error: "invalid id" }, 400);
   }
   const detail = await getReport(c.env.DB, idParam);


### PR DESCRIPTION
## 概要

`admin.ts` / `reports.ts` / `reports-public.ts` の 6 箇所で重複していた limit クランプパターンと正の整数パースパターンを `worker/api/_helpers.ts` に共通ヘルパーとして抽出する。

Closes #470

## 変更内容

- `apps/web/worker/api/_helpers.ts` (新規): `parseLimit` / `parsePositiveInt` を export
- `apps/web/worker/api/admin.ts`: `/runs` の limit 解析、`/runs/:id` の id 解析を置換
- `apps/web/worker/api/reports.ts`: `GET /` の limit 解析、`GET /:id` の id 解析を置換
- `apps/web/worker/api/reports-public.ts`: 同上
- `apps/web/tests/worker/api/_helpers.test.ts` (新規): 境界値 unit テスト 14 件

## テスト

- [x] `pnpm test` — 62 ファイル / 914 テスト pass (既存 integration テストの regression なし)
- [x] `pnpm check` — 変更ファイルに lint / typecheck エラーなし
- [x] 新規 unit テスト: `parseLimit` 8 件 + `parsePositiveInt` 6 件

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced utility functions for consistent parameter validation across API endpoints
  * Standardized limit and ID parameter handling with proper validation, clamping, and error responses across multiple endpoints

* **Tests**
  * Added comprehensive test suites for parameter parsing utilities covering edge cases, validation rules, and default/fallback behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->