### PR TITLE
refactor(db): D1 category/lang の as アサーションを型ガードに置換

### DIFF
--- a/apps/web/tests/worker/db/db-guards.test.ts
+++ b/apps/web/tests/worker/db/db-guards.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { isCategory, isLang, parseCategory, parseLang } from "../../../worker/db/_guards";
+
+// ---------------------------------------------------------------------------
+// isCategory
+// ---------------------------------------------------------------------------
+
+describe("isCategory", () => {
+  it("returns true for all valid categories", () => {
+    expect.soft(isCategory("bigtech")).toBe(true);
+    expect.soft(isCategory("ai")).toBe(true);
+    expect.soft(isCategory("jp")).toBe(true);
+    expect.soft(isCategory("personal")).toBe(true);
+  });
+
+  it("returns false for unknown string", () => {
+    expect(isCategory("general")).toBe(false);
+  });
+
+  it("returns false for non-string values", () => {
+    expect.soft(isCategory(null)).toBe(false);
+    expect.soft(isCategory(undefined)).toBe(false);
+    expect.soft(isCategory(42)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isLang
+// ---------------------------------------------------------------------------
+
+describe("isLang", () => {
+  it("returns true for all valid langs", () => {
+    expect.soft(isLang("ja")).toBe(true);
+    expect.soft(isLang("en")).toBe(true);
+  });
+
+  it("returns false for unknown string", () => {
+    expect(isLang("zh")).toBe(false);
+  });
+
+  it("returns false for non-string values", () => {
+    expect.soft(isLang(null)).toBe(false);
+    expect.soft(isLang(undefined)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseCategory: warn + fallback
+// ---------------------------------------------------------------------------
+
+describe("parseCategory", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("returns the value as-is for valid categories", () => {
+    expect(parseCategory("ai")).toBe("ai");
+  });
+
+  it("returns 'bigtech' and emits console.warn for invalid category", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const result = parseCategory("garbage");
+    expect.soft(result).toBe("bigtech");
+    expect.soft(warnSpy).toHaveBeenCalledWith(expect.stringContaining("unexpected category value"));
+  });
+
+  it("includes context string in the warning message when provided", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    parseCategory("unknown", "feed=test-feed");
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("feed=test-feed"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseLang: warn + fallback
+// ---------------------------------------------------------------------------
+
+describe("parseLang", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("returns the value as-is for valid langs", () => {
+    expect(parseLang("ja")).toBe("ja");
+  });
+
+  it("returns 'en' and emits console.warn for invalid lang", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const result = parseLang("xx");
+    expect.soft(result).toBe("en");
+    expect.soft(warnSpy).toHaveBeenCalledWith(expect.stringContaining("unexpected lang value"));
+  });
+
+  it("includes context string in the warning message when provided", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    parseLang("bad", "feed=test-feed");
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("feed=test-feed"));
+  });
+});

--- a/apps/web/worker/db/_guards.ts
+++ b/apps/web/worker/db/_guards.ts
@@ -1,0 +1,46 @@
+/**
+ * D1 結果の category / lang 列を検証する型ガード。
+ * DB に想定外の値が入っていた場合に console.warn して安全な fallback 値に倒す。
+ *
+ * api/_guards.ts と同様のロジックだが、db 層 (feeds.ts / feed-stats.ts) の
+ * 2 ファイルから使うため、01-typescript.md の「1 ディレクトリ内の 2-3 ファイル →
+ * そのディレクトリ内に <domain>.ts を作る」ルールに従いここに配置する。
+ */
+
+import type { FeedCategory, FeedLang } from "../types";
+
+const VALID_CATEGORIES = new Set<string>(["bigtech", "ai", "jp", "personal"]);
+const VALID_LANGS = new Set<string>(["ja", "en"]);
+
+export function isCategory(value: unknown): value is FeedCategory {
+  return typeof value === "string" && VALID_CATEGORIES.has(value);
+}
+
+export function isLang(value: unknown): value is FeedLang {
+  return typeof value === "string" && VALID_LANGS.has(value);
+}
+
+/**
+ * D1 結果の category 列を検証して FeedCategory を返す。
+ * 不正値の場合は console.warn して "bigtech" を fallback として返す。
+ * "bigtech" は FeedCategory の最初の定義値で、既知の安全な値。
+ */
+export function parseCategory(raw: unknown, context?: string): FeedCategory {
+  if (isCategory(raw)) return raw;
+  console.warn(
+    `[db/_guards] unexpected category value: ${JSON.stringify(raw)}${context ? ` (${context})` : ""}. Falling back to "bigtech".`,
+  );
+  return "bigtech";
+}
+
+/**
+ * D1 結果の lang 列を検証して FeedLang を返す。
+ * 不正値の場合は console.warn して "en" を fallback として返す。
+ */
+export function parseLang(raw: unknown, context?: string): FeedLang {
+  if (isLang(raw)) return raw;
+  console.warn(
+    `[db/_guards] unexpected lang value: ${JSON.stringify(raw)}${context ? ` (${context})` : ""}. Falling back to "en".`,
+  );
+  return "en";
+}

--- a/apps/web/worker/db/feed-stats.ts
+++ b/apps/web/worker/db/feed-stats.ts
@@ -1,12 +1,6 @@
-import type {
-  Article,
-  FeedCategory,
-  FeedConfig,
-  FeedDiagnostic,
-  FeedHealth,
-  FeedLang,
-} from "../types";
+import type { Article, FeedCategory, FeedConfig, FeedDiagnostic, FeedHealth } from "../types";
 import type { CategorySummaryDbRow, FeedDiagnosticDbRow, FeedHealthFeedsDbRow } from "./types";
+import { parseCategory, parseLang } from "./_guards";
 import { daysAgoIso } from "./_helpers";
 
 export interface CategorySummary {
@@ -51,7 +45,7 @@ export async function getCategoriesSummary(db: D1Database): Promise<CategorySumm
 
   const dbMap = new Map(
     (rows.results ?? []).map((r) => {
-      const id = r.category as CategorySummary["id"];
+      const id = parseCategory(r.category);
       return [
         id,
         {
@@ -117,8 +111,8 @@ export async function getFeedsDiagnostics(db: D1Database): Promise<FeedDiagnosti
     id: r.id,
     name: r.name,
     url: r.url,
-    category: r.category as FeedCategory,
-    lang: r.lang as FeedLang,
+    category: parseCategory(r.category, `feed=${r.id}`),
+    lang: parseLang(r.lang, `feed=${r.id}`),
     enabled: r.enabled === 1,
     last_fetched_at: r.last_fetched_at,
     last_status: r.last_status,

--- a/apps/web/worker/db/feeds.ts
+++ b/apps/web/worker/db/feeds.ts
@@ -1,5 +1,6 @@
 import type { FeedCategory, FeedConfig, FeedLang } from "../types";
 import type { D1BindParameter, FeedWithStatsDbRow } from "./types";
+import { parseCategory, parseLang } from "./_guards";
 import { daysAgoIso } from "./_helpers";
 
 export interface FeedHeaders {
@@ -329,8 +330,8 @@ export async function listFeedsWithStats(
     id: r.id,
     name: r.name,
     url: r.url,
-    category: r.category as FeedCategory,
-    lang: r.lang as FeedLang,
+    category: parseCategory(r.category, `feed=${r.id}`),
+    lang: parseLang(r.lang, `feed=${r.id}`),
     enabled: r.enabled === 1,
     articles_30d: r.articles_30d,
     last_published_at: r.last_published_at,
@@ -363,8 +364,8 @@ export async function findFeedWithStats(db: D1Database, id: string): Promise<Fee
     id: row.id,
     name: row.name,
     url: row.url,
-    category: row.category as FeedCategory,
-    lang: row.lang as FeedLang,
+    category: parseCategory(row.category, `feed=${row.id}`),
+    lang: parseLang(row.lang, `feed=${row.id}`),
     enabled: row.enabled === 1,
     articles_30d: row.articles_30d,
     last_published_at: row.last_published_at,


### PR DESCRIPTION
## 背景 / 目的

D1 から取得した raw 文字列を `as FeedCategory` / `as FeedLang` で型アサーションしていた箇所が 6 箇所あり、不正値が混入した場合に実行時エラーや型不整合が発生するリスクがあった。

## 変更内容

- `apps/web/worker/db/_guards.ts` を新設
  - `isCategory` / `isLang` (型ガード)
  - `parseCategory` / `parseLang` (不正値を `console.warn` して fallback 値を返す)
- `feeds.ts`: `listFeedsWithStats` / `findFeedWithStats` の 4 箇所を置換
- `feed-stats.ts`: `getCategoriesSummary` / `getFeedsDiagnostics` の 2 箇所を置換
- `tests/worker/db/db-guards.test.ts` を新設 (12 ケース: 型ガード + warn/fallback)

## テスト

- `vp test run`: 926 件 pass 確認済み
- `vp check`: format/lint pass 確認済み

Closes #469