### PR TITLE
refactor(reports): upsertReport の OverlapError throw を Result 型に置換

### DIFF
--- a/apps/web/tests/worker/db/reports.test.ts
+++ b/apps/web/tests/worker/db/reports.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 import { env } from "cloudflare:test";
-import {
-  OverlapError,
-  findOverlappingReports,
-  isReportKind,
-  upsertReport,
-} from "../../../worker/db/reports";
+import { findOverlappingReports, isReportKind, upsertReport } from "../../../worker/db/reports";
 import type { ReportInput } from "../../../worker/db/reports";
 
 function baseInput(overrides: Partial<ReportInput> = {}): ReportInput {
@@ -61,10 +56,12 @@ describe("findOverlappingReports", () => {
   });
 
   it("detects partial overlap (start shifted)", async () => {
-    const { id } = await upsertReport(
+    const inserted = await upsertReport(
       env.DB,
       baseInput({ generated_at: "2026-04-28T00:00:00.000Z" }),
     );
+    // inserted が ok: true であることは guard (id アクセスの前提)
+    expect(inserted.ok).toBe(true);
     // 既存: 04-21〜04-28 / 新規: 04-22〜04-29 → overlap
     const overlaps = await findOverlappingReports(
       env.DB,
@@ -75,7 +72,7 @@ describe("findOverlappingReports", () => {
     );
     // length は guard (overlaps[0] アクセスの前提)。id は独立した属性
     expect(overlaps).toHaveLength(1);
-    expect.soft(overlaps[0]?.id).toBe(id);
+    expect.soft(overlaps[0]?.id).toBe(inserted.ok ? inserted.id : undefined);
   });
 
   it("returns empty array for adjacent period (new start == existing end)", async () => {
@@ -110,40 +107,39 @@ describe("findOverlappingReports", () => {
 });
 
 describe("upsertReport overlap guard", () => {
-  it("throws OverlapError when overlapping row exists", async () => {
+  it("returns ok: false when overlapping row exists", async () => {
     await upsertReport(env.DB, baseInput({ generated_at: "2026-04-28T00:00:00.000Z" }));
-    await expect(
-      upsertReport(
-        env.DB,
-        baseInput({
-          period_start: "2026-04-22T00:00:00.000Z",
-          period_end: "2026-04-29T00:00:00.000Z",
-          generated_at: "2026-04-29T00:00:00.000Z",
-        }),
-      ),
-    ).rejects.toBeInstanceOf(OverlapError);
+    const result = await upsertReport(
+      env.DB,
+      baseInput({
+        period_start: "2026-04-22T00:00:00.000Z",
+        period_end: "2026-04-29T00:00:00.000Z",
+        generated_at: "2026-04-29T00:00:00.000Z",
+      }),
+    );
+    expect(result.ok).toBe(false);
   });
 
-  it("OverlapError contains conflicting ids", async () => {
-    const { id } = await upsertReport(
+  it("ok: false result contains conflicting ids", async () => {
+    const first = await upsertReport(
       env.DB,
       baseInput({ generated_at: "2026-04-28T00:00:00.000Z" }),
     );
-    let caught: OverlapError | null = null;
-    try {
-      await upsertReport(
-        env.DB,
-        baseInput({
-          period_start: "2026-04-22T00:00:00.000Z",
-          period_end: "2026-04-29T00:00:00.000Z",
-          generated_at: "2026-04-29T00:00:00.000Z",
-        }),
-      );
-    } catch (err) {
-      if (err instanceof OverlapError) caught = err;
+    // first が ok: true であることは guard (id アクセスの前提)
+    expect(first.ok).toBe(true);
+    if (!first.ok) return;
+    const result = await upsertReport(
+      env.DB,
+      baseInput({
+        period_start: "2026-04-22T00:00:00.000Z",
+        period_end: "2026-04-29T00:00:00.000Z",
+        generated_at: "2026-04-29T00:00:00.000Z",
+      }),
+    );
+    // result が ok: false であることは guard (conflictingIds アクセスの前提)
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect.soft(result.conflictingIds).toContain(first.id);
     }
-    // caught が null でないことは guard (conflictingIds アクセスの前提)。id の含有は独立
-    expect(caught).not.toBeNull();
-    expect.soft(caught!.conflictingIds).toContain(id);
   });
 });

--- a/apps/web/worker/api/reports.ts
+++ b/apps/web/worker/api/reports.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import type { Env } from "../types";
 import { adminAuthMiddleware } from "../utils/auth";
-import { OverlapError, getReport, isReportKind, listReports, upsertReport } from "../db/reports";
+import { getReport, isReportKind, listReports, upsertReport } from "../db/reports";
 import type { ReportInput, ReportKind } from "../db/reports";
 import type {
   AdminReportDetailResponse,
@@ -141,23 +141,18 @@ app.post("/", async (c) => {
     return c.json({ error: validated.error }, 400);
   }
 
-  let id: number;
-  try {
-    ({ id } = await upsertReport(c.env.DB, validated.input));
-  } catch (err) {
-    if (err instanceof OverlapError) {
-      return c.json<AdminReportOverlapResponse>(
-        {
-          error: "report period overlaps with existing report(s)",
-          conflicting_ids: err.conflictingIds,
-        },
-        409,
-      );
-    }
-    throw err;
+  const result = await upsertReport(c.env.DB, validated.input);
+  if (!result.ok) {
+    return c.json<AdminReportOverlapResponse>(
+      {
+        error: "report period overlaps with existing report(s)",
+        conflicting_ids: result.conflictingIds,
+      },
+      409,
+    );
   }
 
-  return c.json<AdminReportSaveResponse>({ ok: true, id });
+  return c.json<AdminReportSaveResponse>({ ok: true, id: result.id });
 });
 
 app.get("/", async (c) => {

--- a/apps/web/worker/db/reports.ts
+++ b/apps/web/worker/db/reports.ts
@@ -42,6 +42,12 @@ export interface ReportDetailRow extends ReportRow {
 
 const ALL_SENTINEL = "__all__";
 
+// upsertReport の戻り値。overlap 検出時は throw せず ok: false を返すことで
+// 呼び出し側が網羅的に分岐でき、try/catch を境界 (HTTP handler) のみに限定できる。
+export type UpsertReportResult =
+  | { ok: true; id: number }
+  | { ok: false; reason: "overlap"; conflictingIds: number[] };
+
 // 半開区間 [period_start, period_end) が既存 row と overlap する row を返す。
 // 完全一致 (period_start == new.period_start AND period_end == new.period_end) は
 // 既存の UNIQUE 制約 + ON CONFLICT UPDATE で処理されるため overlap 扱いしない。
@@ -70,24 +76,17 @@ export async function findOverlappingReports(
   return result.results ?? [];
 }
 
-// overlap した既存レポートが存在するときに upsertReport が throw するエラー。
-export class OverlapError extends Error {
-  public readonly conflictingIds: number[];
-  constructor(conflictingIds: number[]) {
-    super(`report period overlaps with existing report(s): ids=[${conflictingIds.join(",")}]`);
-    this.name = "OverlapError";
-    this.conflictingIds = conflictingIds;
-  }
-}
-
 // (kind, period_start, period_end, category, lang) で upsert する。
 // UNIQUE index が COALESCE(category, '__all__') で張られているため、
 // ON CONFLICT の target にも同じ式を指定する必要がある (SQLite 3.24+ の挙動)。
-// 半開区間 overlap が検出された場合は OverlapError を throw する。
-export async function upsertReport(db: D1Database, input: ReportInput): Promise<{ id: number }> {
+// 半開区間 overlap が検出された場合は { ok: false, reason: "overlap" } を返す。
+export async function upsertReport(
+  db: D1Database,
+  input: ReportInput,
+): Promise<UpsertReportResult> {
   const overlapping = await findOverlappingReports(db, input);
   if (overlapping.length > 0) {
-    throw new OverlapError(overlapping.map((r) => r.id));
+    return { ok: false, reason: "overlap", conflictingIds: overlapping.map((r) => r.id) };
   }
 
   const result = await db
@@ -123,7 +122,7 @@ export async function upsertReport(db: D1Database, input: ReportInput): Promise<
   if (!result) {
     throw new Error("upsertReport returned no row");
   }
-  return { id: result.id };
+  return { ok: true, id: result.id };
 }
 
 export async function listReports(


### PR DESCRIPTION
Closes #475

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for overlapping report submissions with clearer conflict responses.

* **Refactor**
  * Refactored internal report overlap detection to use result-based responses instead of exception-based handling, providing better stability and consistency in conflict reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->