### PR TITLE
refactor(stats): replace internal as-assertions with isCategory guard

### DIFF
--- a/apps/web/worker/api/stats.ts
+++ b/apps/web/worker/api/stats.ts
@@ -7,6 +7,7 @@ import type {
   ByLang30d,
 } from "../db/articles";
 import { rowsAs } from "../db/_helpers";
+import { isCategory } from "../db/_guards";
 import type { Env } from "../types";
 import type { StatsResponse } from "./types";
 
@@ -129,8 +130,9 @@ app.get("/", async (c) => {
     for (const row of rowsAs<{ date: string; category: string; n: number }>(categoryTrendRaw)) {
       const point = trendMap.get(row.date);
       if (!point) continue;
-      const cat = row.category as keyof Omit<CategoryTrendPoint, "date">;
-      if (cat in point) (point[cat] as number) += row.n;
+      if (isCategory(row.category)) {
+        point[row.category] += row.n;
+      }
     }
 
     // getByLang30d と同等の集計


### PR DESCRIPTION
## Summary

- apps/web/worker/api/stats.ts:132-133 で内部ロジックに残っていた as アサーション 2 か所を isCategory 型ガードに置換
- 動作は完全等価（旧コードも cat in point で実行時チェックしていたため）
- .claude/rules/01-typescript.md 規約「型アサーションは外部入力に限定し、内部ロジックでは使わない」に適合

## Test plan

- All 1006 tests pass with vp test run
- apps/web typecheck: no errors
- vp lint: 0 new errors

Closes #476