### PR TITLE
fix(ci): migrate report-*.yml to claude-code-base-action's claude_args input

### DIFF
--- a/.github/workflows/report-daily.yml
+++ b/.github/workflows/report-daily.yml
@@ -46,11 +46,12 @@ jobs:
           ANTHROPIC_DEFAULT_HAIKU_MODEL: "claude-haiku-4-5-20251001"
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # action は v?.? で input が破壊的変更され `model` / `allowed_tools` /
+          # `timeout_minutes` が廃止され `claude_args` (CLI 引数直渡し) に統一された。
           # 廃止モデル (claude-3-5-haiku-20241022) への自動 fallback で 404 が出るため
-          # 現行 sonnet を明示する。
-          model: "claude-sonnet-4-5-20250929"
-          allowed_tools: "Bash,Read,Write,WebFetch,Skill"
-          timeout_minutes: 30
+          # 現行 sonnet を `--model` で明示する。`timeout_minutes` 相当は job-level
+          # `timeout-minutes: 60` でカバーされるため省略。
+          claude_args: "--model claude-sonnet-4-5-20250929 --allowedTools Bash,Read,Write,WebFetch,Skill"
           # daily digest 生成プロンプト。詳細な手順 (出力ファイル / フォーマット / no-articles 挙動 /
           # URL grounding) は .claude/skills/tech-news-digest/SKILL.md の「自動 daily report
           # 生成モード」節を一次ソースとする。yaml 側は skill 起動パラメータのみを渡す。

--- a/.github/workflows/report-monthly.yml
+++ b/.github/workflows/report-monthly.yml
@@ -44,11 +44,12 @@ jobs:
           ANTHROPIC_DEFAULT_HAIKU_MODEL: "claude-haiku-4-5-20251001"
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # action は v?.? で input が破壊的変更され `model` / `allowed_tools` /
+          # `timeout_minutes` が廃止され `claude_args` (CLI 引数直渡し) に統一された。
           # 廃止モデル (claude-3-5-haiku-20241022) への自動 fallback で 404 が出るため
-          # 現行 sonnet を明示する。
-          model: "claude-sonnet-4-5-20250929"
-          allowed_tools: "Bash,Read,Write,WebFetch,Skill"
-          timeout_minutes: 45
+          # 現行 sonnet を `--model` で明示する。`timeout_minutes` 相当は job-level
+          # `timeout-minutes: 60` でカバーされるため省略。
+          claude_args: "--model claude-sonnet-4-5-20250929 --allowedTools Bash,Read,Write,WebFetch,Skill"
           # monthly digest 生成プロンプト。tech-news-weekly skill を since=month で起動する。
           prompt: |
             あなたは tech-news-bot の自動レポート生成エージェントです。

--- a/.github/workflows/report-weekly.yml
+++ b/.github/workflows/report-weekly.yml
@@ -43,11 +43,12 @@ jobs:
           ANTHROPIC_DEFAULT_HAIKU_MODEL: "claude-haiku-4-5-20251001"
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # action は v?.? で input が破壊的変更され `model` / `allowed_tools` /
+          # `timeout_minutes` が廃止され `claude_args` (CLI 引数直渡し) に統一された。
           # 廃止モデル (claude-3-5-haiku-20241022) への自動 fallback で 404 が出るため
-          # 現行 sonnet を明示する。
-          model: "claude-sonnet-4-5-20250929"
-          allowed_tools: "Bash,Read,Write,WebFetch,Skill"
-          timeout_minutes: 30
+          # 現行 sonnet を `--model` で明示する。`timeout_minutes` 相当は job-level
+          # `timeout-minutes: 60` でカバーされるため省略。
+          claude_args: "--model claude-sonnet-4-5-20250929 --allowedTools Bash,Read,Write,WebFetch,Skill"
           # weekly digest 生成プロンプト。skill 起動と最終ファイル書き出しを明示する。
           prompt: |
             あなたは tech-news-bot の自動レポート生成エージェントです。


### PR DESCRIPTION
## Summary

- `anthropics/claude-code-base-action@main` の input が破壊的変更され `model` / `allowed_tools` / `timeout_minutes` が廃止され `claude_args` (CLI 引数直渡し) に統一された
- `allowed_tools` が silently 無視されて Bash/Write/WebFetch などの tool 呼び出しが 10 回 deny され、`/tmp/report.md` が生成されず `report-daily` が失敗していた ([run 25263750717](https://github.com/rikeda71/tech-news-bot/actions/runs/25263750717))
- `report-daily` / `report-weekly` / `report-monthly` の 3 つを `claude_args: "--model ... --allowedTools ..."` に移行。`timeout_minutes` 相当は job-level `timeout-minutes: 60` でカバーされるため省略

Closes #479

## Test plan

- [ ] CI (lint / typecheck / test) green
- [ ] マージ後 `report-daily` を `workflow_dispatch` で手動実行し、`Save report to D1 via admin API` ステップまで通ることを確認
- [ ] (定期実行待ち) JST 翌朝 07:00 の自動 daily run が成功することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configurations to use unified argument passing format for the Claude action across daily, weekly, and monthly reporting workflows.
  * Improved environment configuration for default model handling in automated tasks.
  * Simplified timeout management by consolidating job-level settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->