### PR TITLE
chore(ci): bump report-*.yml model to claude-sonnet-4-6

### DIFF
--- a/.github/workflows/report-daily.yml
+++ b/.github/workflows/report-daily.yml
@@ -51,7 +51,7 @@ jobs:
           # 廃止モデル (claude-3-5-haiku-20241022) への自動 fallback で 404 が出るため
           # 現行 sonnet を `--model` で明示する。`timeout_minutes` 相当は job-level
           # `timeout-minutes: 60` でカバーされるため省略。
-          claude_args: "--model claude-sonnet-4-5-20250929 --allowedTools Bash,Read,Write,WebFetch,Skill"
+          claude_args: "--model claude-sonnet-4-6 --allowedTools Bash,Read,Write,WebFetch,Skill"
           # daily digest 生成プロンプト。詳細な手順 (出力ファイル / フォーマット / no-articles 挙動 /
           # URL grounding) は .claude/skills/tech-news-digest/SKILL.md の「自動 daily report
           # 生成モード」節を一次ソースとする。yaml 側は skill 起動パラメータのみを渡す。

--- a/.github/workflows/report-monthly.yml
+++ b/.github/workflows/report-monthly.yml
@@ -49,7 +49,7 @@ jobs:
           # 廃止モデル (claude-3-5-haiku-20241022) への自動 fallback で 404 が出るため
           # 現行 sonnet を `--model` で明示する。`timeout_minutes` 相当は job-level
           # `timeout-minutes: 60` でカバーされるため省略。
-          claude_args: "--model claude-sonnet-4-5-20250929 --allowedTools Bash,Read,Write,WebFetch,Skill"
+          claude_args: "--model claude-sonnet-4-6 --allowedTools Bash,Read,Write,WebFetch,Skill"
           # monthly digest 生成プロンプト。tech-news-weekly skill を since=month で起動する。
           prompt: |
             あなたは tech-news-bot の自動レポート生成エージェントです。

--- a/.github/workflows/report-weekly.yml
+++ b/.github/workflows/report-weekly.yml
@@ -48,7 +48,7 @@ jobs:
           # 廃止モデル (claude-3-5-haiku-20241022) への自動 fallback で 404 が出るため
           # 現行 sonnet を `--model` で明示する。`timeout_minutes` 相当は job-level
           # `timeout-minutes: 60` でカバーされるため省略。
-          claude_args: "--model claude-sonnet-4-5-20250929 --allowedTools Bash,Read,Write,WebFetch,Skill"
+          claude_args: "--model claude-sonnet-4-6 --allowedTools Bash,Read,Write,WebFetch,Skill"
           # weekly digest 生成プロンプト。skill 起動と最終ファイル書き出しを明示する。
           prompt: |
             あなたは tech-news-bot の自動レポート生成エージェントです。


### PR DESCRIPTION
## Summary

- `report-daily.yml` / `report-weekly.yml` / `report-monthly.yml` で使う Claude モデルを Sonnet 4.5 (`claude-sonnet-4-5-20250929`) から最新の Sonnet 4.6 (`claude-sonnet-4-6`) に更新
- Sonnet 4.6 は現時点で日付サフィックス付き snapshot ID が公開されておらず、Anthropic 公式ドキュメント上の API ID も alias 形式 (`claude-sonnet-4-6`) のため、そのまま指定する

## Test plan

- [ ] CI green
- [ ] マージ後 `report-daily` を `workflow_dispatch` で手動実行し、Sonnet 4.6 で `/tmp/report.md` 生成 → D1 保存まで通ることを確認