### PR TITLE
test(feed-stats): drop vi.setSystemTime from 7d test

### DIFF
--- a/apps/web/tests/worker/db/feed-stats.test.ts
+++ b/apps/web/tests/worker/db/feed-stats.test.ts
@@ -400,7 +400,9 @@ describe("getFeedHealth", () => {
   });
 
   it("counts only articles published within 7 days in articles_last_7d", async () => {
-    vi.setSystemTime(new Date("2026-04-29T00:00:00Z"));
+    // SQL の datetime('now', '-7 days') は Workers ランタイム (SQLite) の実時間を見るため
+    // vi.setSystemTime で JS 側だけ固定すると境界がズレて flaky になる。
+    // ここでは固定せず recentAt() の実時間相対オフセットで境界を担保する。
     await syncFeeds(env.DB, [FEED_BIGTECH]);
     await insertArticles(env.DB, [
       {


### PR DESCRIPTION
## Summary
- `feed-stats.test.ts` の `counts only articles published within 7 days in articles_last_7d` が 2026-05-04 以降の CI で `expected +0 to be 1` で落ちる flaky を修正
- 原因: `vi.setSystemTime("2026-04-29")` で JS 時刻だけ固定する一方、`getFeedHealth` の SQL は `datetime('now', '-7 days')` で Workers ランタイム (SQLite) の **実時間** を参照するため、実時間がカットオフ境界を跨ぐと `recentAt(3)=4/26` も 7 日窓から外れて 0 件になっていた
- 同等の `tests/worker/api/health.test.ts:223` のテストは `vi.setSystemTime` を使わず実時間ベースで書かれており pass しているため、こちらも同方針に揃える

## Test plan
- [x] `pnpm exec vp test run tests/worker/db/feed-stats.test.ts` で当該 it 含め 20 件 pass
- [x] `pnpm test` (worker 全体) で 1006 件全 pass
- [x] `pnpm exec vp check` で 0 errors (warnings は既存)

Closes #485

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved stability of feed health statistics test by using real timers and relative time offsets instead of frozen time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->