### PR TITLE
chore(deps): coarsen Dependabot PR grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,27 +10,31 @@ updates:
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
     groups:
-      types:
-        # @types/* をまとめて 1 PR に
-        patterns:
-          - "@types/*"
-      vite-ecosystem:
-        # vite / vitest / vite-plus 関連をまとめて 1 PR に
-        patterns:
-          - "vite"
-          - "vite-*"
-          - "vitest"
-          - "@vitejs/*"
-          - "vite-plus"
-          - "@voidzero-dev/*"
-      cloudflare:
-        # Cloudflare 系をまとめて 1 PR に
-        patterns:
-          - "@cloudflare/*"
-          - "wrangler"
+      production-deps:
+        # production 依存の minor / patch をすべて 1 PR にまとめる
+        # major は互換性リスクが高いのでグループ外 (個別 PR) に残す
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      development-deps:
+        # devDependencies の minor / patch をすべて 1 PR にまとめる
+        # types / vite / cloudflare 等のサブグループは廃止してここに統合
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
 
   # GitHub Actions のバージョンを週次で自動 PR
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      gha-deps:
+        # GitHub Actions の minor / patch をすべて 1 PR にまとめる
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

- npm の細粒度グループ (types / vite-ecosystem / cloudflare) を廃止し、production-deps / development-deps の 2 グループに統合した
- major バージョンアップは互換性リスクを個別確認できるようにグループ外（個別 PR）に残した
- GitHub Actions に gha-deps グループを追加し、これまでグループなしだった GHA の更新もまとめるようにした

## Test plan

- [ ] .github/dependabot.yml の YAML 構文に問題がないことを確認
- [ ] vp check (lint / typecheck / format) が dependabot.yml の変更に影響を受けないことを確認済み

Closes #494

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Enhanced automated dependency management by consolidating production and development dependency updates: minor and patch versions are now grouped into weekly pull requests for streamlined handling, while major updates are kept separate for thorough review. GitHub Actions updates are also better organized.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rikeda71/tech-news-bot/pull/495)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->