### PR TITLE
fix(ci): CI を通せない dependabot bump (vite-plus 0.3.0 / jose 6.2.12) を ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,26 @@ updates:
       # Node.js LTS 24 を当面利用するため、@types/node の major bump は対象外にする
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
+      # pnpm-workspace.yaml の catalog は vite-plus / @voidzero-dev/vite-plus-core (= vite) /
+      # @voidzero-dev/vite-plus-test (= vitest) の 3 つを同一バージョンで揃える必要がある。
+      # dependabot は vite-plus 単体しか上げられないうえ、vite-plus-test は 0.1.24 が最新で
+      # 0.2.x / 0.3.x が存在しない。vite-plus 0.3.0 は `./binding` の subpath export を廃止
+      # したため、0.1.x のままの vite-plus-core が rolldown の native binding を解決できず
+      # ERR_PACKAGE_PATH_NOT_EXPORTED で vp check / test / build が全滅する。
+      # vite-plus-test が追随したら 3 エントリを手動で揃えて上げ、この ignore を外すこと。
+      - dependency-name: "vite-plus"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+      # jose 6.2.12 は verifyCompact が protected header の parse を async verifySignature へ
+      # 移し、その promise を await せず return するようになった。promise adoption の余分な
+      # tick で rejection が一瞬 unhandled になり、workerd がそれを報告するため
+      # tests/worker/middleware/access-jwt.test.ts が全 pass でも exit 1 になる
+      # (Serialized Error: { code: 'ERR_JWS_INVALID' })。6.2.11 までは発生しない。
+      # jose は JWT 検証に使う security-critical な依存なので範囲では止めず、
+      # 壊れている 6.2.12 だけを外す。上流修正版が出たらこの ignore を削除すること。
+      - dependency-name: "jose"
+        versions: ["6.2.12"]
     groups:
       production-deps:
         # production 依存の minor / patch をすべて 1 PR にまとめる


### PR DESCRIPTION
Closes #538

## 背景 / 目的

dependabot の production-deps グループが、CI を絶対に通せない bump を繰り返し提案している。放置すると毎週 red な PR が生成され続けるため、`.github/dependabot.yml` で該当バージョンを除外する。

元は PR #532 (6 依存の一括 bump) の CI 全滅を調査していたが、調査中に dependabot が #532 を close し、`vite-plus` 単体に絞った #537 を作り直した。#537 も同じ理由で通らない。

## 原因

### 1. vite-plus 0.1.20 → 0.3.0 (PR #537)

`pnpm-workspace.yaml` の catalog は 3 エントリを同一バージョンで揃える前提。

```yaml
catalog:
  vite: npm:@voidzero-dev/vite-plus-core@^0.1.20
  vite-plus: ^0.1.20
  vitest: npm:@voidzero-dev/vite-plus-test@^0.1.20
```

dependabot は `vite-plus` しか動かせない。そして `@voidzero-dev/vite-plus-test` は **0.1.24 が最新** で 0.2.x / 0.3.x が存在しない (`vite-plus` と `@voidzero-dev/vite-plus-core` だけが 0.3.0 まで出ている)。

`vite-plus@0.3.0` は `./binding` の subpath export を廃止したため、0.1.x のまま残る `@voidzero-dev/vite-plus-core@0.1.20` が rolldown の native binding を解決できなくなる。現行 main の上で再現済み:

```
Error: Cannot find native binding. ...
  [cause]: Error [ERR_PACKAGE_PATH_NOT_EXPORTED]:
    Package subpath './binding' is not defined by "exports"
    in node_modules/vite-plus/package.json
```

`vp check` / `vp test` / `vp build` が起動時点で死ぬので CI 全ジョブが失敗する。

3 エントリを揃えて 0.1.24 に上げること自体は可能だが、同梱 oxlint が 1.67.0 に上がって新ルール (`vitest(expect-expect)` / `vitest(no-conditional-expect)` / `unicorn(consistent-function-scoping)` / `typescript(no-unnecessary-type-conversion)`) が有効化され lint error が 56 件出るため、別タスクとする。

### 2. jose 6.2.12

`jose@6.2.12` は `verifyCompact` から protected header の parse を async な `verifySignature` 側へ移し、その promise を **await せず return** する形に変えた。

```js
// 6.2.12 lib/jws_verify.js
async function verifyCompact(jws, shared, key) {
  ...
  return verifySignature({ payload, protected: protectedHeader, signature }, shared, key, encodeCompactUnencodedPayload);
}
// -> parseProtectedHeader は verifySignature の中で throw する
```

```js
// 6.2.11 は verifyCompact の同期部分で parse していた
const parsedProt = parseProtectedHeader(protectedHeader), ...
```

promise adoption の余分な tick で rejection が一瞬 unhandled になり、workerd がそれを報告する。結果 `apps/web/tests/worker/middleware/access-jwt.test.ts` は 6 件とも pass するのに `Errors 1 error` で **exit 1** になる。

```
⎯⎯ Unhandled Errors ⎯⎯
Serialized Error: { code: 'ERR_JWS_INVALID' }
This error originated in "tests/worker/middleware/access-jwt.test.ts"
The latest test that might've caused the error is "不正な JWT で 401"
```

バージョン別に実測:

| jose              | 結果                        |
| ----------------- | --------------------------- |
| 6.2.3 (現行 main) | clean                       |
| 6.2.10            | clean                       |
| 6.2.11            | clean                       |
| 6.2.12            | **Errors 1 error / exit 1** |

なお素の Node で同じコードを流しても unhandled rejection は出ない。workerd 固有の検出タイミングによるもの。

## 変更内容

`.github/dependabot.yml` の `ignore` に 2 件追加。どちらも「いつ外すか」をコメントで明記した。

| 依存        | 除外内容                                | 解除条件                                                                 |
| ----------- | --------------------------------------- | ------------------------------------------------------------------------ |
| `vite-plus` | minor / major (0.1.x 内の patch は許可) | `@voidzero-dev/vite-plus-test` が追随したら 3 エントリ手動で揃えて上げる |
| `jose`      | `6.2.12` の 1 バージョンのみ            | 上流修正版が出たら削除                                                   |

`jose` は JWT 検証に使う security-critical な依存なので、`>=6.2.12` のような範囲指定ではなく壊れている 1 バージョンだけを外している。次回以降 dependabot は 6.2.11 を提案でき、6.2.13 以降も通常どおり提案される。

## 検証

| チェック             | 結果                               |
| -------------------- | ---------------------------------- |
| `vp check`           | exit 0 (error 0 / 既存 warning 22) |
| `pnpm -r typecheck`  | exit 0                             |
| `pnpm build`         | exit 0                             |
| `pnpm test` (worker) | exit 0 — 67 files / 1006 tests     |
| `pnpm test:client`   | exit 0 — 49 files / 406 tests      |
| `pnpm e2e`           | exit 0 — 30 passed                 |

失敗側も現行 main 上で再現を確認済み (vite-plus 0.3.0 / jose 6.2.12 をそれぞれ適用)。

## 補足 (このPRの対象外)

- **Dependabot Updates workflow の失敗**: 直近の run で `jose` / `react` / `react-dom` が `unknown_error` (詳細 null) で更新に失敗している。dependabot 側のエラーでログから原因を特定できないため、このPRでは触っていない。
- **PR #537**: 上記 1. の理由で close する。

## 完了条件

- [x] vp check pass
- [x] vp test run pass
- [x] pnpm test:client / pnpm e2e pass
- [ ] PR #537 に理由をコメントして close
